### PR TITLE
Fix GitHub links and styling on website

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,12 +21,12 @@ Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@fino
 
 ## Prerequisites
 
-* [ ] Have you [searched for duplicates](https://github.com/FDC3/FDC3/issues?utf8=%E2%9C%93&q=)?  A simple search for exception error messages or a summary of the unexpected behaviour should suffice.
+* [ ] Have you [searched for duplicates](https://github.com/finos/FDC3/issues?utf8=%E2%9C%93&q=)?  A simple search for exception error messages or a summary of the unexpected behaviour should suffice.
 * [ ] Are you running the latest version?
 * [ ] Are you sure this is a bug or missing capability?
 
 ## Raising an Issue
-* Create your issue [here](https://github.com/FDC3/FDC3/issues/new).
+* Create your issue [here](https://github.com/finos/FDC3/issues/new).
 * New issues contain two templates in the description: bug report and enhancement request. Please pick the most appropriate for your issue, **then delete the other**.
   * Please also tag the new issue with either "Bug" or "Enhancement".
 * Please use [Markdown formatting](https://help.github.com/categories/writing-on-github/)
@@ -38,12 +38,12 @@ To make review of PRs easier, please:
 
  * Please make sure your PRs will merge cleanly - PRs that don't are unlikely to be accepted.
  * For code contributions, follow the existing code layout.
- * For documentation contributions, follow the general structure, language, and tone of the [existing docs](https://github.com/FDC3/FDC3/wiki).
+ * For documentation contributions, follow the general structure, language, and tone of the [existing docs](https://github.com/finos/FDC3/wiki).
  * Keep commits small and cohesive - if you have multiple contributions, please submit them as independent commits (and ideally as independent PRs too).
  * Reference issue #s if your PR has anything to do with an issue (even if it doesn't address it).
  * Minimise non-functional changes (e.g. whitespace shenanigans).
  * Ensure all new files include a header comment block containing the [Apache License v2.0 and your copyright information](http://www.apache.org/licenses/LICENSE-2.0#apply).
- * If necessary (e.g. due to 3rd party dependency licensing requirements), update the [NOTICE file](https://github.com/FDC3/FDC3/blob/master/NOTICE) with any new attribution or other notices
+ * If necessary (e.g. due to 3rd party dependency licensing requirements), update the [NOTICE file](https://github.com/finos/FDC3/blob/master/NOTICE) with any new attribution or other notices
 
 
 ## Commit and PR Messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,23 +30,23 @@ Thank you to the following contributors who helped with this release:
 * @saori-tr
 
 ### Added
-* Use Case 15 ([#49](https://github.com/FDC3/FDC3/pull/49))
-* FDC3 Roadmap ([#55](https://github.com/FDC3/FDC3/pull/55))
-* User showcase on website ([#67](https://github.com/FDC3/FDC3/pull/67))
+* Use Case 15 ([#49](https://github.com/finos/FDC3/pull/49))
+* FDC3 Roadmap ([#55](https://github.com/finos/FDC3/pull/55))
+* User showcase on website ([#67](https://github.com/finos/FDC3/pull/67))
 
 ### Changed
-* Use case text on front page of website ([#54](https://github.com/FDC3/FDC3/pull/54))
-* Feature icons on website ([#57](https://github.com/FDC3/FDC3/pull/57))
+* Use case text on front page of website ([#54](https://github.com/finos/FDC3/pull/54))
+* Feature icons on website ([#57](https://github.com/finos/FDC3/pull/57))
 
 ### Fixed
-* General cleanup of spelling, grammar and punctuation ([#34](https://github.com/FDC3/FDC3/pull/34))
-* Remove unnecessary dates from use case file names ([#41](https://github.com/FDC3/FDC3/pull/41))
-* Fix header colouring on responsive website ([#56](https://github.com/FDC3/FDC3/pull/56))
-* Fix workflow numbers in Use Case 1 ([#60](https://github.com/FDC3/FDC3/pull/60))
-* More proofreading changes to existing docs ([62](https://github.com/FDC3/FDC3/pull/62))
-* Fix examples in Intent Overview doc ([#65](https://github.com/FDC3/FDC3/pull/65))
-* Fix errors in DesktopAgent API doc ([#66](https://github.com/FDC3/FDC3/pull/66))
-* Add hyperlink to FDC3 Intro doc ([#69](https://github.com/FDC3/FDC3/pull/69))
+* General cleanup of spelling, grammar and punctuation ([#34](https://github.com/finos/FDC3/pull/34))
+* Remove unnecessary dates from use case file names ([#41](https://github.com/finos/FDC3/pull/41))
+* Fix header colouring on responsive website ([#56](https://github.com/finos/FDC3/pull/56))
+* Fix workflow numbers in Use Case 1 ([#60](https://github.com/finos/FDC3/pull/60))
+* More proofreading changes to existing docs ([62](https://github.com/finos/FDC3/pull/62))
+* Fix examples in Intent Overview doc ([#65](https://github.com/finos/FDC3/pull/65))
+* Fix errors in DesktopAgent API doc ([#66](https://github.com/finos/FDC3/pull/66))
+* Add hyperlink to FDC3 Intro doc ([#69](https://github.com/finos/FDC3/pull/69))
 
 ## [1.0.0-beta] - 2019-03-05
 
@@ -69,6 +69,6 @@ Thank you to the following contributors who helped with this release:
 * Documentation website generated with [Docusaurus](https://docusaurus.io).
 
 
-[Unreleased]: https://github.com/FDC3/FDC3/compare/v1.0.0..HEAD
-[1.0.0]: https://github.com/FDC3/FDC3/compare/v1.0.0..v1.0.0-beta
-[1.0.0-beta]: https://github.com/FDC3/FDC3/releases/tag/v1.0.0-beta
+[Unreleased]: https://github.com/finos/FDC3/compare/v1.0.0..HEAD
+[1.0.0]: https://github.com/finos/FDC3/compare/v1.0.0..v1.0.0-beta
+[1.0.0-beta]: https://github.com/finos/FDC3/releases/tag/v1.0.0-beta

--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -3,5 +3,5 @@ DataLicense: CC0-1.0
 Creator: FDC3
 PackageName: FDC3
 PackageOriginator: FDC3
-PackageHomePage: https://github.com/FDC3/FDC3
+PackageHomePage: https://github.com/finos/FDC3
 PackageLicenseDeclared: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/FDC3/FDC3.svg?branch=master)](https://travis-ci.org/FDC3/FDC3)
+[![Build Status](https://travis-ci.org/finos/FDC3.svg?branch=master)](https://travis-ci.org/finos/FDC3)
 [![FINOS - Released](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-released.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Released)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-fdc3-orange.svg)](https://stackoverflow.com/questions/tagged/fdc3)
@@ -18,7 +18,7 @@ Latest version of the standard is [1.0](https://fdc3.finos.org/docs/1.0/fdc3-int
 ## Contributing
 To join Working Groups meetings and Mailing lists where the standard is built, please check the [FDC3 space in the FINOS Wiki](http://wiki.finos.org/fdc3). If you'd like to contribute code to this repository:
 
-1. Fork it (<https://github.com/FDC3/FDC3/fork>)
+1. Fork it (<https://github.com/finos/FDC3/fork>)
 2. Create your feature branch (`git checkout -b feature/fooBar`)
 3. Commit your changes (`git commit -am 'Add some fooBar'`)
 4. Push to the branch (`git push origin feature/fooBar`)

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -163,5 +163,5 @@ App channels are created and obtained as thus:
 ## APIs
 The APIs are defined in TypeScript in [src], with documentation generated in the [docs] folder.
 
-[src]: https://github.com/FDC3/FDC3/tree/master/src/api
-[docs]: https://github.com/FDC3/FDC3/tree/master/docs/api
+[src]: https://github.com/finos/FDC3/tree/master/src/api
+[docs]: https://github.com/finos/FDC3/tree/master/docs/api

--- a/docs/use-cases/004-client-side-fx-trader.md
+++ b/docs/use-cases/004-client-side-fx-trader.md
@@ -21,6 +21,6 @@ layout: use_case
 
 - Point-to-point RPC invocation.  Current FDC3 API proposal doesn't define response message for "open" and "send" methods as they both returns `Promise<void>`:
 
-https://github.com/FDC3/FDC3/blob/master/src/api/interface.ts#L66
+https://github.com/finos/FDC3/blob/master/src/api/interface.ts#L66
 
-https://github.com/FDC3/FDC3/blob/master/src/api/interface.ts#L34
+https://github.com/finos/FDC3/blob/master/src/api/interface.ts#L34

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -138,34 +138,29 @@ class Index extends React.Component {
       </Block>
     );
 
-    const FeatureCallout = () => (
-      <div  className="featureShowcaseSection  paddingBottom">
-      <div class="CTA-image" style={{paddingLeft:'9px',paddingRight:'9px'}}>
-        <a href="https://www.surveymonkey.com/r/finosfdc3" target="_blank"><img style={{width:'150px',height:'150px'}} id="fdc3survey" src={`${baseUrl}docs/assets/fdc3-survey-1080.jpeg`} height='300px' alt="FDC3 Survey" title="FDC3 Survey"/></a>
-        
-      </div>
-      <div class="CTA-text">
-        
-        <p>As we approach the end of the first year of the FDC3 1.0 standards, FINOS would like to get your feedback on how well FDC3
-         - both the community and the standard - 
-        is addressing the needs of financial organizations. With your feedback, we can better help and support companies adopting FDC3,
-        as well as contributors to the specification.</p>
-        <h3><a href="https://www.surveymonkey.com/r/finosfdc3" target="_blank">Fill Out The Survey Here!</a></h3>
-       </div>
-       
+    const SurveyBanner = () => (
+      <div className="surveyBanner">
+        <div className="CTA-image">
+          <a href="https://www.surveymonkey.com/r/finosfdc3" target="_blank"><img style={{width:'150px',height:'150px'}} id="fdc3survey" src={`${baseUrl}docs/assets/fdc3-survey-1080.jpeg`} height='300px' alt="FDC3 Survey" title="FDC3 Survey"/></a>
+          
+        </div>
+        <div class="CTA-text">
+          
+          <p>As we approach the end of the first year of the FDC3 1.0 standards, FINOS would like to get your feedback on how well FDC3
+          - both the community and the standard - 
+          is addressing the needs of financial organizations. With your feedback, we can better help and support companies adopting FDC3,
+          as well as contributors to the specification.</p>
+          <h3><a href="https://www.surveymonkey.com/r/finosfdc3" target="_blank">Fill Out The Survey Here!</a></h3>
+        </div>
       </div>
     );
 
-      //<MarkdownBlock>{`Document business [use cases](${docUrl('use-cases/overview')}) that drive FDC3 interoperability standards.`}</MarkdownBlock>
-
-    //const FinosBanner = () => (
-      //<div className="finos finosBanner">
-        //<a href="https://www.finos.org">
-          //<img id="finosicon" src={`${baseUrl}img/finos_wordmark.svg`} height='150px' alt="FINOS" title="FINOS"/>
-        //</a>
-        //<h2 id="proud">Proud member of the Fintech Open Source Foundation</h2>
-      //</div>
-    //);
+    const FeatureCallout = () => (
+      <div  className="featureShowcaseSection  paddingBottom" style={{textAlign: 'center'}}>
+        <h2>Use Cases</h2>
+        <MarkdownBlock>{`Document business [use cases](${docUrl('use-cases/overview')}) that drive FDC3 interoperability standards.`}</MarkdownBlock>
+      </div>
+    );
 
     const UserShowcase = () => {
       if ((siteConfig.users || []).length === 0) {
@@ -194,13 +189,11 @@ class Index extends React.Component {
     return (
       <div>
         <HomeSplash siteConfig={siteConfig} language={language} />
-        <FeatureCallout />
+        <SurveyBanner />
         <div className="mainContainer">
           <Features />
-          
-          
+          <FeatureCallout />
           <UserShowcase />
-         
         </div>
       </div>
     );

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -95,7 +95,7 @@ const siteConfig = {
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
-  repoUrl: 'https://github.com/FDC3/FDC3'
+  repoUrl: 'https://github.com/finos/FDC3'
 };
 
 module.exports = siteConfig;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -142,8 +142,16 @@ body {
   background-color: #F7F7F7; /* CHANGE THIS TO PRIMARY PROJECT COLOR */
   padding-top: 10px;
   padding-bottom: 40px;
+}
+
+.surveyBanner {
+  background-color: #F7F7F7; /* CHANGE THIS TO PRIMARY PROJECT COLOR */
+  padding-top: 10px;
+  padding-bottom: 40px;
   display: inline-flex;
   flex-wrap: nowrap;
+  width: 100%;
+  padding: 20px;
 }
 
 .CTA-image {

--- a/website/versioned_docs/version-1.0/api/api-spec.md
+++ b/website/versioned_docs/version-1.0/api/api-spec.md
@@ -136,5 +136,5 @@ Intents functionality is dependent on resolver functionality to map the intent t
 ## APIs
 The APIs are defined in TypeScript in [src], with the documentation generated in the [docs] folder.
 
-[src]: https://github.com/FDC3/FDC3/tree/master/src/api
-[docs]: https://github.com/FDC3/FDC3/tree/master/docs/api
+[src]: https://github.com/finos/FDC3/tree/master/src/api
+[docs]: https://github.com/finos/FDC3/tree/master/docs/api

--- a/website/versioned_docs/version-1.0/use-cases/004-client-side-fx-trader.md
+++ b/website/versioned_docs/version-1.0/use-cases/004-client-side-fx-trader.md
@@ -22,6 +22,6 @@ original_id: uc-4
 
 - Point-to-point RPC invocation.  Current FDC3 API proposal doesn't define response message for "open" and "send" methods as they both returns `Promise<void>`:
 
-https://github.com/FDC3/FDC3/blob/master/src/api/interface.ts#L66
+https://github.com/finos/FDC3/blob/master/src/api/interface.ts#L66
 
-https://github.com/FDC3/FDC3/blob/master/src/api/interface.ts#L34
+https://github.com/finos/FDC3/blob/master/src/api/interface.ts#L34


### PR DESCRIPTION
- Fix Travis build link in README.
- Fix GitHub links in repo
- Restore use cases section to front page of website
- Use separate block for survey banner, and fix styling

![image](https://user-images.githubusercontent.com/3295115/70646898-c6ad8780-1c3f-11ea-96d9-f49b16e5db9e.png)
