### PR TITLE
compare join to being on the Channel object vs the global

### DIFF
--- a/docs/api/DesktopAgent.md
+++ b/docs/api/DesktopAgent.md
@@ -175,29 +175,6 @@ Retrieves a list of the System channels available for the app to join
 #### See also
 *[`Channel`](#channel)
 
-### `joinChannel`
-```typescript
-joinChannel(channelId: string) : Promise<void>;
-```
-Joins the app to the specified channel.
-If an app is joined to a channel, all _fdc3.broadcast_ calls will go to the channel, and all listeners assigned via _fdc3.addContextListener_ will listen on the channel.
-An app can only be joined to one channel at a time.
-Rejects with error if the channel is unavailable or the join request is denied.
- `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
-
-#### Examples
-```javascript
-  //get all system channels
-  const channels = await fdc3.getSystemChannels();
-
-  //create UI to pick from the system channels
-
-  //join the channel on selection
-  fdc3.joinChannel(selectedChannel.id);
-
-```
-#### See also
-*[`getSystemChannels`](#getSystemChannels)
 
 
 ### `addIntentListener`
@@ -305,6 +282,7 @@ The `unsubscribe` method on the listener object allows the application to cancel
   id: string;
   type: string;
   displayMetadata?: DisplayMetadata;
+  join() : Promise<void>;
   broadcast(context: Context): Promise<void>;
   getCurrentContext(): Promise<Context|null>;
   addBroadcastListener(listener: (event: {channel: Channel; context: Context}) => void): DesktopAgent.Listener;
@@ -313,7 +291,12 @@ The `unsubscribe` method on the listener object allows the application to cancel
 Object representing a context channel.
 * __id__ uniquely identifies the channel. It is either assigned by the desktop agent (system channel) or defined by an application (app channel)
 * __type__ may be _system_ or _app_
-* __dispalyMetadata__   DisplayMetaData can be used to provide display hints for channels intended to be visualized and selectable by end users.
+* __displayMetadata__   DisplayMetaData can be used to provide display hints for channels intended to be visualized and selectable by end users.
+* __join__ Joins the app to the channel.
+If an app is joined to a channel, all _fdc3.broadcast_ calls will go to the channel, and all listeners assigned via _fdc3.addContextListener_ will listen on the channel.
+An app can only be joined to one channel at a time.
+Rejects with error if the channel is unavailable or the join request is denied.
+ `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
 * __broadcast__  Broadcasts a context on the channel. This function can be used without first joining the channel, allowing applications to broadcast on channels that they aren't a member of.  `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
 * __getCurrentContext__ Returns the last context that was broadcast on the channel. If no context has been set on the channel, this will return `null`.  `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
 * __addBroadcastListener__  Event that is fired whenever a window broadcasts on this channel. The `channel` property within the event will always be this channel instance.  `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -170,10 +170,14 @@ To find a system channel, one calls
 To join a channel. one calls
 
 ```javascript
-    fdc3.joinChannel(redChannel.id);
+    redChannel.join();
+
+    //join the 'default' channel to effectively reset channel membership
+    const defaultChannel = await fdc3.getOrCreateChannel('default');
+    defaultChannel.join();
 ```
 
-Calling _fdc3.broadcast_ will now route context to the joined channel.
+Calling _fdc3.broadcast_ will now route context to the `red` channel.
 
 #### App Channels
 

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -96,6 +96,14 @@ declare class Channel {
   displayMetadata?: DisplayMetadata;
 
    /**
+   * Joins the app to the channel
+   * An app can only be joined to one channel at a time
+   * rejects with error if the channel is unavailable or the join request is denied
+   * `Error` with a string from the `ChannelError` enumeration.
+   */
+  public join() : Promise<void>;
+
+   /**
    * Broadcasts the given context on this channel. This is equivalent to joining the channel and then calling the 
    * top-level FDC3 `broadcast` function.
    * 
@@ -130,6 +138,8 @@ declare class Channel {
    * `Error` with a string from the `ChannelError` enumeration.
    */
   public addBroadcastListener(listener: (event: {channel: Channel; context: Context}) => void): Listener;
+
+  
 }
 
 /**
@@ -276,13 +286,6 @@ interface DesktopAgent {
    */
   getSystemChannels(): Promise<Array<Channel>>;
 
-  /**
-   * Joins the app to the specified channel
-   * An app can only be joined to one channel at a time
-   * rejects with error if the channel is unavailable or the join request is denied
-   * `Error` with a string from the `ChannelError` enumeration.
-   */
-  joinChannel(channelId: string) : Promise<void>;
 
   /**
    * Returns a channel with the given identity. Either stands up a new channel or returns an existing channel.


### PR DESCRIPTION
As discussed, this shows moving the 'joinChannel' method from the global fdc3 object to a 'join' method on the Channel class. @pjbroadbent