### PR TITLE
Add context filtering to API and improve docs

### DIFF
--- a/docs/api/Channel.md
+++ b/docs/api/Channel.md
@@ -1,0 +1,193 @@
+---
+id: Channel
+sidebar_label: Channel
+title: Channel
+hide_title: true
+---
+# `Channel`
+
+```ts
+class Channel {
+
+  // properties
+  id: string;
+  type: string;
+  displayMetadata?: DisplayMetadata;
+
+  // methods
+  broadcast(context: Context): Promise<void>;
+  getCurrentContext(contextType?: string): Promise<Context|null>;
+  addContextListener(handler: ContextHandler): Listener;
+  addContextListener(contextType: string, handler: ContextHandler): Listener;
+}
+```
+
+Represents a context channel that applications can join to share context data. 
+
+A channel can be either a well-known "system" channel (retrieved with [`getSystemChannels`](DesktopAgent#getsystemchannels)) or a custom "app" channel (obtained through [`getOrCreateChannel`](DesktopAgent#getorcreatechannel)).
+
+Channels each have a unique identifier, some display metadata and operations for broadcasting context to other applications, or receiving context from other applications.
+
+#### See also
+
+* [`Context`](Context)
+* [`DesktopAgent.getSystemChannels`](DesktopAgent#getsystemchannels)
+* [`DesktopAgent.getOrCreateChannel`](DesktopAgent#getorcreatechannel)
+* [`DesktopAgent.joinChannel`](DesktopAgent#joinchannel)
+
+## Properties
+
+### `id`
+
+```ts
+public readonly id: string;
+```
+
+Uniquely identifies the channel. It is either assigned by the desktop agent (system channel) or defined by an application (app channel).
+
+### `type`
+
+```ts
+public readonly type: string;
+```
+
+Can be _system_ or _app_.
+
+### `displayMetadata`
+
+```ts
+public readonly displayMetadata?: DisplayMetadata;
+```
+
+DisplayMetadata can be used to provide display hints for channels intended to be visualized and selectable by end users.
+
+#### See also
+* [`DisplayMetadata`](DisplayMetadata)
+
+## Methods
+
+### `broadcast`
+
+```typescript
+public broadcast(context: Context): Promise<void>;
+```
+
+Broadcasts a context on the channel. This function can be used without first joining the channel, allowing applications to broadcast on channels that they aren't a member of.
+
+If broadcasting fails, the promise will return an `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
+
+#### Example
+
+```javascript
+const instrument = {
+    type: 'fdc3.instrument',
+    id: {
+        ticker: 'AAPL'
+    }
+};
+
+try {
+    await channel.broadcast(instrument);
+} catch (err: ChannelError) {
+    // handler errror
+}
+```
+
+#### See also
+* [`ChannelError`](Errors#channelerror)
+* [`getCurrentContext`](#getcurrentcontext)
+* [`addContextListener`](#addcontextlistener)
+
+### `getCurrentContext`
+
+```ts
+public getCurrentContext(contextType?: string): Promise<Context|null>;
+```
+
+Returns the most recent context that was broadcast on the channel. If no context has been set on the channel, this will return `null`.  
+
+Optionally a _context type_ can be provided, in which case the current context of the matching type will be returned (if any). 
+
+Desktop agent implementations may decide to record most recent contexts by type, in which case it will be possible to get the most recent context of each type, but this is not necessarily guaranteed.
+
+If getting the current context fails, the promise will return an `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
+
+#### Examples
+
+Without specifying a context type:
+
+```ts
+try {
+    const context = await channel.getCurrentContext();
+} catch (err: ChannelError) {
+    // handler errror
+}
+```
+
+Specifying a context type:
+
+```ts
+try {
+    const contact = await channel.getCurrentContext('fdc3.contact');
+} catch (err: ChannelError) {
+    // handler errror
+}
+```
+
+#### See also
+* [`ChannelError`](Errors#channelerror)
+* [`broadcast`](#broadcast)
+* [`addContextListener`](#addcontextlistener)
+
+### `addContextListener`
+
+```ts
+public addContextListener(handler: ContextHandler): Listener;
+```
+
+Adds a listener for incoming contexts whenever a broadcast happens on the channel.
+
+```ts
+public addContextListener(contextType: string, handler: ContextHandler): Listener;
+```
+
+Adds a listener for incoming contexts of the specified _context type_ whenever a broadcast happens on this channel.
+
+#### Examples
+
+Add a listener for any context that is broadcast on the channel:
+
+```ts
+const listener = channel.addContextListener(context => {
+    if (context.type === 'fdc3.contact') {
+        // handle the contact
+    } else if (context.type === 'fdc3.instrument') => {
+        // handle the instrument
+    }
+});
+
+// later
+listener.unsubscribe();
+```
+
+Adding listeners for specific types of context that is broadcast on the channel:
+
+```ts
+const contactListener = channel.addContextListener('fdc3.contact', contact => {
+    // handle the contact
+});
+
+const instrumentListener = channel.addContextListener('fdc3.instrument', instrument => {
+    // handle the instrument
+});
+
+// later
+contactListener.unsubscribe();
+instrumentListener.unsubscribe();
+```
+
+#### See also
+* [`Listener`](Listener)
+* [`ContextHandler`](ContextHandler)
+* [`broadcast`](#broadcast)
+* [`getCurrentContext`](#addcontextlistener)

--- a/docs/api/Context.md
+++ b/docs/api/Context.md
@@ -11,3 +11,22 @@ type Context = object;
 ```
 
 The base object that all contexts should extend.
+
+The API specification allows this to be any object, but typically this is supposed to be a context data object adhering to the [Context Data Specification](../context-spec).
+
+This means that it must at least have a `type` property that indicates what type of data it represents, e.g. `'fdc3.contact'`.
+
+The `type` property of context objects is important for certain FDC3 operations, like [`Channel.getCurrentContext`](Channel#getCurrentContext) and [`DesktopAgent.addContextListener`](DesktopAgent#addContextListener), which allows you to filter contexts by their type.
+
+#### See also
+* [`ContextHandler`](ContextHandler)
+* [`DesktopAgent.open`](DesktopAgent#open)
+* [`DesktopAgent.broadcast`](DesktopAgent#broadcast)
+* [`DesktopAgent.addIntentListener`](DesktopAgent#addintentlistener)
+* [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
+* [`DesktopAgent.findIntent`](DesktopAgent#findintent)
+* [`DesktopAgent.findIntentsByContext`](DesktopAgent#findintentsbycontext)
+* [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
+* [`Channel.broadcast`](Channel#broadcast)
+* [`Channel.getCurrentContext`](Cahnnel#getCurrentContext)
+* [`Channel.addContextListener`](Cahnnel#addContextListener)

--- a/docs/api/ContextHandler.md
+++ b/docs/api/ContextHandler.md
@@ -1,0 +1,21 @@
+---
+id: ContextHandler
+sidebar_label: ContextHandler
+title: ContextHandler
+hide_title: true
+---
+# `ContextHandler`
+
+```typescript
+type ContextHandler = (context: Context) => void;
+```
+
+Describes a callback that handles a context event.
+
+Used when attaching listeners for context broadcasts and raised intents.
+
+#### See also
+* [`Context`](Context)
+* [`DesktopAgent.addIntentListener`](DesktopAgent#addintentlistener)
+* [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
+* [`Channel.addContextListener`](Channel#addcontextlistener)

--- a/docs/api/DisplayMetadata.md
+++ b/docs/api/DisplayMetadata.md
@@ -1,0 +1,48 @@
+---
+id: DisplayMetadata
+sidebar_label: DisplayMetadata
+title: DisplayMetadata
+hide_title: true
+---
+# `DisplayMetadata`
+
+```ts
+ public interface DisplayMetadata {
+  name?: string;
+  color?: string;
+  glyph?: string;
+}
+```
+
+A desktop agent (typically for _system_ channels) may want to provide additional information about how a channel can be represented in a UI. A common use case is for color linking.
+
+#### See also
+
+* [`Channel`](Channel)
+* [`DesktopAgent.getSystemChannels`](DesktopAgent#getsystemchannels)
+
+## Properties
+
+### `name`
+
+```ts
+name?: string;
+```
+
+The display name for the channel.
+
+### `color`
+
+```ts
+color?: string;
+```
+
+A name, hex, rgba, etc. that should be associated within the channel when displaying it in a UI.
+
+### `glyph`
+
+```ts
+glyph: string;
+```
+
+A URL of an image that can be used to display this channel.

--- a/docs/api/Listener.md
+++ b/docs/api/Listener.md
@@ -1,0 +1,31 @@
+---
+id: Listener
+sidebar_label: Listener
+title: Listener
+hide_title: true
+---
+# `Listener`
+
+```typescript
+interface Listener {
+  unsubscribe(): void;
+}
+```
+
+A Listener object is returned when an application subscribes to intents or context broadcasts via the [`addIntentListener`](#addintentlistener) or [`addContextListener`](#addcontextlistener) methods on the [DesktopAgent](DesktopAgent) object.
+
+## Methods
+
+### `unsubscribe`
+
+```ts
+unsubscribe(): void;
+```
+
+Allows an application to unsubscribe from listening to intents or context broadcasts. 
+
+#### See also
+* [`DesktopAgent.addIntentListener`](DestkopAgent#addintentlistener)
+* [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
+* [`Channel.addContextListener`](Channel#addcontextlistener)
+* [`ContextHandler`](ContextHandler)

--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -83,7 +83,7 @@ Raising an Intent will return a Promise-type object that will resolve/reject bas
 ##### Resolution Object
 If the raising of the intent resolves (or rejects), a standard object will be passed into the resolver function with the following format:
 
-```javascript
+```js
 {
     source: String;
     data?: Object; 
@@ -96,11 +96,11 @@ If the raising of the intent resolves (or rejects), a standard object will be pa
 
 For example
 
-```javascript
+```js
 try {
-    let result = await agent.raiseIntent('StageOrder');
-    if (result.data){
-        let orderId = result.data.id;
+    const result = await fdc3.raiseIntent('StageOrder');
+    if (result.data) {
+        const orderId = result.data.id;
     }
 }
 catch (er){
@@ -112,11 +112,11 @@ catch (er){
 ##### Upgrading to a Remote API Connection
 There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
 
-```javascript
-    let chart = await agent.raiseIntent('ViewChart');
-     //construct an OpenFin wrapper for the App
-    let chartApp = fin.Application.wrap(chart.source);
-    //do some OpenFin specific stuff
+```js
+const chart = await fdc3.raiseIntent('ViewChart');
+// construct an OpenFin wrapper for the App
+const chartApp = fin.Application.wrap(chart.source);
+// do some OpenFin-specific stuff
 ```
 ![Upgrading Connection to Remote API](assets/api-3.png)
 
@@ -160,17 +160,17 @@ While joining channels automates a lot of the channel behavior for an app, it ha
 ### Examples
 To find a system channel, one calls
 
-```javascript
-    //returns an array of channels
-    let allChannels = await fdc3.getSystemChannels(); 
-    let redChannel = allChannels.find(c => c.id === 'red');
+```js
+// returns an array of channels
+const allChannels = await fdc3.getSystemChannels(); 
+const redChannel = allChannels.find(c => c.id === 'red');
 ```
 #### Joining channels
 
 To join a channel. one calls
 
-```javascript
-    fdc3.joinChannel(redChannel.id);
+```js
+fdc3.joinChannel(redChannel.id);
 ```
 
 Calling _fdc3.broadcast_ will now route context to the joined channel.
@@ -181,19 +181,17 @@ App channels are topics dynamically created by applications connected via FDC3. 
 
 To get (or create) a channel reference, then interact with it
 
-```javascript
-    const appChannel = await fdc3.getOrCreateChannel('my_custom_channel');
-    //get the current context of the channel
-    let current = await appChannel.getCurrentContext();
-    //add a listener
-    appChannel.addBroadcastListener(event => {...});
-    //broadcast to the channel
-    appChannel.broadcast(context);
+```js
+const appChannel = await fdc3.getOrCreateChannel('my_custom_channel');
+// get the current context of the channel
+const current = await appChannel.getCurrentContext();
+// add a listener
+appChannel.addContextListener(context => {...});
+// broadcast to the channel
+appChannel.broadcast(context);
 
 ```
 
-
-    
 ## APIs
 The APIs are defined in TypeScript in [src], with documentation generated in the [docs] folder.
 

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -4,6 +4,7 @@
  */
 
 type Context = object;
+type ContextHandler = (context: Context) => void;
 
 enum OpenError {
   AppNotFound = "AppNotFound",
@@ -90,10 +91,10 @@ declare class Channel {
   public readonly type: string;
 
   /**
-   * Channels may be visualized and selectable by users. DisplayMetaData may be used to provide hints on how to see them.
+   * Channels may be visualized and selectable by users. DisplayMetadata may be used to provide hints on how to see them.
    * For app channels, displayMetadata would typically not be present
    */
-  displayMetadata?: DisplayMetadata;
+  public readonly displayMetadata?: DisplayMetadata;
 
    /**
    * Broadcasts the given context on this channel. This is equivalent to joining the channel and then calling the 
@@ -102,34 +103,36 @@ declare class Channel {
    * Note that this function can be used without first joining the channel, allowing applications to broadcast on
    * channels that they aren't a member of.
    * 
-   * This broadcast will be received by all windows that are members of this channel, *except* for the window that
-   * makes the broadcast. This matches the behaviour of the top-level FDC3 `broadcast` function.
    * `Error` with a string from the `ChannelError` enumeration.
    */
   public broadcast(context: Context): Promise<void>;
 
   /**
    * Returns the last context that was broadcast on this channel. All channels initially have no context, until a 
-   * window is added to the channel and then broadcasts. If there is not yet any context on the channel, this method
-   * will return `null`. The context is also reset back into it's initial context-less state whenever a channel is
-   * cleared of all windows.
+   * context is broadcast on the channel. If there is not yet any context on the channel, this method
+   * will return `null`.
    * 
    * The context of a channel will be captured regardless of how the context is broadcasted on this channel - whether
    * using the top-level FDC3 `broadcast` function, or using the channel-level {@link broadcast} function on this 
    * object.
    * 
-   * NOTE: Only non-default channels are stateful, for the default channel this method will always return `null`.
+   * Optionally a {@link contextType} can be provided, in which case the current context of the matching type will
+   * be returned (if any). Desktop agent implementations may decide to record contexts by type, in which case it will
+   * be possible to get the most recent context of the type specified, but this is not guaranteed.
+   * 
    * `Error` with a string from the `ChannelError` enumeration.
    */
-  public getCurrentContext(): Promise<Context|null>;
+  public getCurrentContext(contextType?: string): Promise<Context|null>;
 
   /**
-   * Event that is fired whenever a window broadcasts on this channel.
-   * 
-   * The `channel` property within the event will always be this channel instance.
-   * `Error` with a string from the `ChannelError` enumeration.
+   * Adds a listener for incoming contexts whenever a broadcast happens on this channel.
    */
-  public addBroadcastListener(listener: (event: {channel: Channel; context: Context}) => void): Listener;
+  public addContextListener(handler: ContextHandler): Listener;
+
+  /**
+   * Adds a listener for incoming contexts of the specified context type whenever a broadcast happens on this channel.
+   */
+  public addContextListener(contextType: string, handler: ContextHandler): Listener;
 }
 
 /**
@@ -264,12 +267,17 @@ interface DesktopAgent {
   /**
    * Adds a listener for incoming Intents from the Agent.
    */
-  addIntentListener(intent: string, handler: (context: Context) => void): Listener;
+  addIntentListener(intent: string, handler: ContextHandler): Listener;
 
   /**
    * Adds a listener for incoming context broadcast from the Desktop Agent.
    */
-  addContextListener(handler: (context: Context) => void): Listener;
+  addContextListener(handler: ContextHandler): Listener;
+
+  /**
+   * Adds a listener for the broadcast of a specific type of context object.
+   */
+  addContextListener(contextType: string, handler: ContextHandler): Listener;
 
   /**
    * Retrieves a list of the System channels available for the app to join
@@ -277,9 +285,9 @@ interface DesktopAgent {
   getSystemChannels(): Promise<Array<Channel>>;
 
   /**
-   * Joins the app to the specified channel
-   * An app can only be joined to one channel at a time
-   * rejects with error if the channel is unavailable or the join request is denied
+   * Joins the app to the specified channel.
+   * An app can only be joined to one channel at a time.
+   * Rejects with error if the channel is unavailable or the join request is denied.
    * `Error` with a string from the `ChannelError` enumeration.
    */
   joinChannel(channelId: string) : Promise<void>;
@@ -293,6 +301,4 @@ interface DesktopAgent {
    * `Error` with a string from the `ChannelError` enumeration.
    */
   getOrCreateChannel(channelId: string): Promise<Channel>;
-
-
-
+}

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -14,7 +14,11 @@
         "label": "API Reference",
         "ids": [
           "api/DesktopAgent",
+          "api/Channel",
+          "api/Listener",
+          "api/DisplayMetadata",
           "api/Context",
+          "api/ContextHandler",
           "api/Errors"
         ]
       }


### PR DESCRIPTION
Addresses #121.

A summary of the type changes I introduced:

* I introduced a new type for consistent context handling:
```ts
type ContextHandler = (context: Context) => void;
```

* Changed the channel broadcast listener to be consistent with the rest of the API:
 ```ts
addBroadcastListener(listener: (event: {channel: Channel; context: Context}) => void): Listener;
```
becomes:
```ts
addContextListener(handler: ContextHandler): Listener;
```
The channel parameter is completely redundant here, as we already now what the channel is from the owning object - if a reference is needed, it can be captured with a closure. This brings the handler in line with the one on the desktop agent, which makes for much easier consumption.

* Added a new overload for the top-level context listener and channel context listener:
```ts
addContextListener(contextType: string, handler: ContextHandler): Listener;
```

* Added an optional parameter when getting the current context:
```ts
getCurrentContext(contextType?: string): Promise<Context|null>;
```

Apart from that I have factored out and improved the relevant documentation sections on the website.
