### PR TITLE
make return on Channel.broadcast void to be consistent with broadcast…

### DIFF
--- a/docs/api/Channel.md
+++ b/docs/api/Channel.md
@@ -15,7 +15,7 @@ class Channel {
   displayMetadata?: DisplayMetadata;
 
   // methods
-  broadcast(context: Context): Promise<void>;
+  broadcast(context: Context): void;
   getCurrentContext(contextType?: string): Promise<Context|null>;
   addContextListener(handler: ContextHandler): Listener;
   addContextListener(contextType: string, handler: ContextHandler): Listener;
@@ -69,12 +69,12 @@ DisplayMetadata can be used to provide display hints for channels intended to be
 ### `broadcast`
 
 ```typescript
-public broadcast(context: Context): Promise<void>;
+public broadcast(context: Context): void;
 ```
 
 Broadcasts a context on the channel. This function can be used without first joining the channel, allowing applications to broadcast on channels that they aren't a member of.
 
-If broadcasting fails, the promise will return an `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
+If the broadcast is denied by the channel or the channel is not available, the method will return an `Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration.
 
 #### Example
 
@@ -87,7 +87,7 @@ const instrument = {
 };
 
 try {
-    await channel.broadcast(instrument);
+    channel.broadcast(instrument);
 } catch (err: ChannelError) {
     // handler errror
 }

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -125,7 +125,7 @@ declare class Channel {
    * 
    * `Error` with a string from the `ChannelError` enumeration.
    */
-  public broadcast(context: Context): Promise<void>;
+  public broadcast(context: Context): void;
 
   /**
    * Returns the last context that was broadcast on this channel. All channels initially have no context, until a 


### PR DESCRIPTION
As per https://github.com/finos/FDC3/issues/160

Make return on Channel.broadcast void to be consistent with fdc3.broadcast

@nicholasdgoodman