### PR TITLE
Add Google Analytics code to FDC3 microsite

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -95,7 +95,10 @@ const siteConfig = {
 
   // You may provide arbitrary config keys to be used as needed by your
   // template. For example, if you need your repo's URL...
-  repoUrl: 'https://github.com/finos/FDC3'
+  repoUrl: 'https://github.com/finos/FDC3',
+
+  //Google Analytics tracking ID to track page views.
+  gaTrackingId: 'UA-89349362-8'
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
## Description
This pull request adds the Google Analytics code UA-89349362-8 to the FDC3 Docusaurus microsite as requested in issue #138
 
![Screenshot 2020-02-07 at 17 46 07](https://user-images.githubusercontent.com/6029572/74052676-4b174f00-49d2-11ea-96ce-68ca06c72eff.png)
