### PR TITLE
v1.1.0-alpha.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: npm-package-release
 on:
   release:
     types: 
-      - created
+      - published
 
 jobs:
   test:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-alpha.1",
   "author": "Fintech Open Source Foundation (FINOS)",
   "repository": "git@github.com:finos/FDC3.git",
   "license": "Apache-2.0",


### PR DESCRIPTION
Change release publishing trigger to "published" instead of "created", as it doesn't trigger for draft releases that were previously created.

See https://developer.github.com/webhooks/event-payloads/#release