### PR TITLE
Add (manually created) enums for intents and context types.

### DIFF
--- a/src/context/ContextType.ts
+++ b/src/context/ContextType.ts
@@ -1,0 +1,11 @@
+export enum ContextTypes {
+  Contact = 'fdc3.contact',
+  ContactList = 'fdc3.contactList',
+  Country = 'fdc3.country',
+  Instrument = 'fdc3.instrument',
+  Organization = 'fdc3.organization',
+  Portfolio = 'fdc3.portfolio',
+  Position = 'fdc3.position',
+}
+
+export type ContextType = ContextTypes | string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export * from './api/IntentMetadata';
 export * from './api/IntentResolution';
 export * from './api/Listener';
 export * from './context/ContextTypes';
+export * from './context/ContextType';
+export * from './intents/Intents';
 
 declare global {
   interface Window {

--- a/src/intents/Intents.ts
+++ b/src/intents/Intents.ts
@@ -1,0 +1,10 @@
+export enum Intents {
+  StartCall = 'StartCall',
+  StartChart = 'StartChart',
+  ViewChart = 'ViewChart',
+  ViewContact = 'ViewContact',
+  ViewQuote = 'ViewQuote',
+  ViewNews = 'ViewNews',
+  ViewInstrument = 'ViewInstrument',
+  ViewAnalysis = 'ViewAnalysis',
+}


### PR DESCRIPTION
Per #261, adding manually created enums for intents and context types:

```typescript
let instrumentContext: Instrument = {
  type: ContextTypes.Instrument,
  id: {
    ticker: "GBPUSD"
  }
};

fdc3.raiseIntent(Intents.ViewChart, instrumentContext);
```

Additional PR to follow to improve typegen to use enum types etc. Will be for 1.2 as it necessitates changes to the schema files.