### PR TITLE
Add appId & version to AppMetadata

### DIFF
--- a/docs/api/ref/AppMetadata.md
+++ b/docs/api/ref/AppMetadata.md
@@ -9,6 +9,8 @@ hide_title: true
 ```ts
 interface AppMetadata {
   name: string;
+  appId?: string;
+  version?: string;
   title?: string;
   tooltip?: string;
   description?: string;
@@ -23,6 +25,8 @@ It always includes at least a `name` property, which can be used with [`open`](D
 
 Optionally, extra information from the app directory can be returned, to aid in rendering UI elements, e.g. a context menu.
 This includes a title, description, tooltip and icon and image URLs.
+
+In situations where a desktop agent connects to multiple app directories or multiple versions of the same app exists in a single app directory, it may be neccessary to specify appId and version to target applications that share the same name. 
 
 #### See also
 * [`AppIntent.apps`](AppIntent)

--- a/src/api/AppMetadata.ts
+++ b/src/api/AppMetadata.ts
@@ -10,6 +10,12 @@ export interface AppMetadata {
   /** The unique app name that can be used with the open and raiseIntent calls. */
   readonly name: string;
 
+  /** The unique application identifier located within a specific application directory instance.  */
+  readonly appId?: string;
+
+  /** The Version of the application. */
+  readonly version?: string;
+
   /** A more user-friendly application title that can be used to render UI elements  */
   readonly title?: string;
 

--- a/src/api/AppMetadata.ts
+++ b/src/api/AppMetadata.ts
@@ -10,7 +10,7 @@ export interface AppMetadata {
   /** The unique app name that can be used with the open and raiseIntent calls. */
   readonly name: string;
 
-  /** The unique application identifier located within a specific application directory instance.  */
+  /** The unique application identifier located within a specific application directory instance. An example of an appId might be 'app@sub.root' */
   readonly appId?: string;
 
   /** The Version of the application. */


### PR DESCRIPTION
This PR contributes appId & version to the definition of an AppMetadata object as described in #240 

Specifically this PR changes
- The AppMetadata type definition and interface
- Updates documentation
