### PR TITLE
chore: fix app directory readme

### DIFF
--- a/src/app-directory/README.md
+++ b/src/app-directory/README.md
@@ -1,51 +1,52 @@
-# Application Directory API -- THIS IS NOT A RATIFIED FDC3 API or SPECIFICATION
-
-**This is NOT a ratified API or specification but rather a tool to evaluate both the use cases and technology implementations.**
-[View FULL FDC3 SPECIFICATION HERE](https://fdc3.finos.org/)
+# FDC3 Application Directory API
 
 ## Overview
-This project is a POC focused on creation of an Application Directory API as defined through initial proposals and
-ongoing discussions in the Application Directory FDC3 working group.  The purpose of this POC is to:
-* Define an initial interface through an OpenAPI specification
-* Start to ratify schema/models
-* Generate example server stubs for java and nodejs
-* Generate example client binding for java
+This folder contains the FDC3 Application Directory specification as defined through initial proposals and
+ongoing discussions in the FDC3 Standards Working Group.  
 
-[View it in a nice swagger editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/FDC3/appd-api/master/specification/appd.yaml)
+The purpose of the Application Directory specification within FDC3 is to:
+* Define a REST application directory interface through an OpenAPI specification
+* Ratify related schemas and models
+* Generate example server stubs for Java and NodeJS
+* Generate example client bindings for Java
 
-## Build
+## Specification
 
-Compilation requires **jdk 8+** and **maven**
-
-Build:
-
-    #git clone..*:
-    #cd cloned_directory
-    #mvn clean install package
+* [View the OpenAPI Specification in Swagger](https://editor.swagger.io/?url=https://fdc3.finos.org/schemas/1.1/app-directory.yaml)
+* [More about the Specification on the FDC3 Website](https://fdc3.finos.org/docs/1.1/app-directory/overview)
 
 
 ## Directory structure
 
-*  **appd-api/specification**:
+*  **`app-directory/specification`**:
     Contains the OpenAPI specification for interfaces and models.
-    [View it here](https://editor.swagger.io/?url=https://raw.githubusercontent.com/FDC3/appd-api/master/specification/appd.yaml)
-*  **appd-api/appd-java-server-stubs**:
+    [View it here](./specification/appd.yaml)
+
+*  **`app-directory/appd-java-server-stubs`**:
     Contains the generated java server stubs (jaxrs/Jersey2) which the application server implements.  After build, you can reference the stubs using the following dependency.
-     ```
+     ```xml
      <dependency>
         <groupId>org.fdc3.appd</groupId>
         <artifactId>appd-server-stubs</artifactId>
         <version>0.0.1-SNAPSHOT</version>
      </dependency>
      ```
-* **appd-api/appd-nodejs-server-stubs**:
+* **`app-directory/appd-nodejs-server-stubs`**:
     Contains the generated nodejs server stubs.
-* **appd-api/appd-jersey-client**:
+* **`app-directory/appd-jersey-client`**:
     Contains a java (jersey2) client binding to the application directory
 
+## Build
+
+Compilation requires **jdk 8+** and **maven**.
+
+Build:
+
+```
+cd src/app-directory
+mvn clean install package
+```
 
 ## Example implementation
 
-Please see the [Application Directory POC](https://github.com/FDC3/appd-poc) for an implementation of the specification.
-
-*END*
+ Please see the [Application Directory POC](https://github.com/FDC3/appd-poc) for an example implementation of the specification.


### PR DESCRIPTION
Remove info that predates merge of separate FDC3 repositories. Closes #106