### PR TITLE
Support nullable return type for getCurrentChannel

### DIFF
--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -164,5 +164,5 @@ export interface DesktopAgent {
    *
    * Returns `null` if the app is not joined to a channel.
    */
-  getCurrentChannel(): Promise<Channel>;
+  getCurrentChannel(): Promise<Channel | null>;
 }

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -71,6 +71,6 @@ export const getOrCreateChannel: (
   return window.fdc3.getOrCreateChannel(channelId);
 };
 
-export const getCurrentChannel: () => Promise<Channel> = () => {
+export const getCurrentChannel: () => Promise<Channel | null> = () => {
   return window.fdc3.getCurrentChannel();
 };


### PR DESCRIPTION
According to the specification (https://fdc3.finos.org/docs/1.1/api/ref/DesktopAgent#getcurrentchannel), `getCurrentChannel` should allow for a nullable return type, but the current type signature does not support this.

Included changes:
1. In references to `getCurrentChannel`, change the return type to `Promise<Channel | null>`