### PR TITLE
Implement missing 'leaveCurrentChannel' method

### DIFF
--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -170,4 +170,12 @@ export interface DesktopAgent {
    * Returns `null` if the app is not joined to a channel.
    */
   getCurrentChannel(): Promise<Channel>;
+
+  /**
+   * Removes the app from any channel membership.
+   *
+   * Context broadcast and listening through the top-level `fdc3.broadcast` and `fdc3.addContextListener` will be
+   * in a no-op when the app is not on a channel.
+   */
+  leaveCurrentChannel(): Promise<void>;
 }

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -74,3 +74,7 @@ export const getOrCreateChannel: (
 export const getCurrentChannel: () => Promise<Channel> = () => {
   return window.fdc3.getCurrentChannel();
 };
+
+export const leaveCurrentChannel: () => Promise<void> = () => {
+  return window.fdc3.leaveCurrentChannel();
+};

--- a/test/methods.test.ts
+++ b/test/methods.test.ts
@@ -11,6 +11,7 @@ import {
   getOrCreateChannel,
   getSystemChannels,
   joinChannel,
+  leaveCurrentChannel,
   open,
   raiseIntent,
 } from '../src';
@@ -164,6 +165,14 @@ describe('test ES6 module', () => {
     getCurrentChannel();
 
     const mock = getMock('getCurrentChannel');
+    expect(mock.mock.calls.length).toBe(1);
+    expect(mock.mock.calls[0]).toEqual([]);
+  });
+
+  it('leaveCurrentChannel should delegate to window.fdc3.leaveCurrentChannel', () => {
+    leaveCurrentChannel();
+
+    const mock = getMock('leaveCurrentChannel');
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0]).toEqual([]);
   });


### PR DESCRIPTION
This adds `leaveCurrentChannel` to the DesktopAgent interface and exported methods.