### PR TITLE
Clarify docs for broadcast functions

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# ignore markdown files
+*.md

--- a/docs/api/ref/Channel.md
+++ b/docs/api/ref/Channel.md
@@ -129,6 +129,8 @@ Broadcasts a context on the channel. This function can be used without first joi
 
 If the broadcast is denied by the channel or the channel is not available, the method will return an `Error` with a string from the [`ChannelError`](ChannelError) enumeration.
 
+Channel implementations should ensure that context messages broadcast by an application on a channel should not be delivered back to that same application if they are joined to the channel.
+
 #### Example
 
 ```javascript

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -91,6 +91,8 @@ broadcast(context: Context): void;
 
 Publishes context to other apps on the desktop.  Calling `broadcast` at the `DesktopAgent` scope will push the context to whatever `Channel` the app is joined to.  If the app is not currently joined to a channel, calling `fdc3.broadcast` will have no effect.  Apps can still directly broadcast and listen to context on any channel via the methods on the `Channel` class.
 
+DesktopAgent implementations should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
+
 #### Example
 ```js
 const instrument = {
@@ -118,7 +120,7 @@ _findIntent_ is effectively granting programmatic access to the Desktop Agent's 
 It returns a promise resolving to the intent, its metadata and metadata about the apps that are registered to handle it.
 This can be used to raise the intent against a specific app.
  
- If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](ResolveError) enumeration.
+If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](ResolveError) enumeration.
 
 #### Examples
 ```js

--- a/src/api/Channel.ts
+++ b/src/api/Channel.ts
@@ -35,7 +35,7 @@ export interface Channel {
    * Note that this function can be used without first joining the channel, allowing applications to broadcast on
    * channels that they aren't a member of.
    *
-   * Channel implementations should ensure that context messages broadcast by an application on a channel should 
+   * Channel implementations should ensure that context messages broadcast by an application on a channel should
    * not be delivered back to that same application if they are joined to the channel.
    *
    * `Error` with a string from the `ChannelError` enumeration.

--- a/src/api/Channel.ts
+++ b/src/api/Channel.ts
@@ -33,8 +33,8 @@ export interface Channel {
    * top-level FDC3 `broadcast` function.
    *
    * Note that this function can be used without first joining the channel, allowing applications to broadcast on
-   * channels that they aren't a member of. 
-   * 
+   * channels that they aren't a member of.
+   *
    * Channel implementations should ensure that context messages broadcast by an application on a channel should 
    * not be delivered back to that same application if they are joined to the channel.
    *

--- a/src/api/Channel.ts
+++ b/src/api/Channel.ts
@@ -33,7 +33,10 @@ export interface Channel {
    * top-level FDC3 `broadcast` function.
    *
    * Note that this function can be used without first joining the channel, allowing applications to broadcast on
-   * channels that they aren't a member of.
+   * channels that they aren't a member of. 
+   * 
+   * Channel implementations should ensure that context messages broadcast by an application on a channel should 
+   * not be delivered back to that same application if they are joined to the channel.
    *
    * `Error` with a string from the `ChannelError` enumeration.
    */

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -104,7 +104,9 @@ export interface DesktopAgent {
   /**
    * Publishes context to other apps on the desktop.
    * 
-   * DesktopAgent implementations should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
+   * DesktopAgent implementations should ensure that context messages broadcast to a channel 
+   * by an application joined to it should not be delivered back to that same application.
+   * 
    * ```javascript
    *  agent.broadcast(context);
    * ```

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -103,6 +103,8 @@ export interface DesktopAgent {
 
   /**
    * Publishes context to other apps on the desktop.
+   * 
+   * DesktopAgent implementations should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
    * ```javascript
    *  agent.broadcast(context);
    * ```

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -103,10 +103,10 @@ export interface DesktopAgent {
 
   /**
    * Publishes context to other apps on the desktop.
-   * 
-   * DesktopAgent implementations should ensure that context messages broadcast to a channel 
+   *
+   * DesktopAgent implementations should ensure that context messages broadcast to a channel
    * by an application joined to it should not be delivered back to that same application.
-   * 
+   *
    * ```javascript
    *  agent.broadcast(context);
    * ```


### PR DESCRIPTION
While working with a vendor app, we noted that they were worried about message loops. The documentation should clarify that its the job of the desktop agent implemention to prevent an application from receiving its own broadcasts