### PR TITLE
App instance proposal + connect to app instance for intent results

### DIFF
--- a/docs/api/ref/AppInstance.md
+++ b/docs/api/ref/AppInstance.md
@@ -1,0 +1,177 @@
+---
+id: AppInstance
+sidebar_label: AppInstance
+title: AppInstance
+hide_title: true
+---
+# `AppInstance`
+
+```ts
+interface AppInstance {
+  //properties
+  readonly instanceId : string;
+  readonly status : 'ready' | 'loading' | 'unregistered';
+  
+  //methods
+  addContextListener(handler: ContextHandler): Listener;
+  addContextListener(contextType: string, handler: ContextHandler): Listener;
+  broadcast(context: Context): void;
+  onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
+
+}
+```
+
+Represents a specific instance of an app.  
+
+AppInstances can be used to directly listen for and broadcast context between two apps connected to a desktop agent.
+
+An AppInstance is obtained by calling the `getAppInstence` method on the `DesktopAgent` using a source token provided by either an IntentResolution or as an argument to a ContextHandler. 
+
+#### See also
+
+* [`IntentResolution`](IntentResolution)
+* [`ContextHandler`](ContextHandler)
+* [`DesktopAgent.getAppInstance`](DesktopAgent#getappinstannce)
+
+
+## Properties
+
+### `instanceId`
+
+```ts
+public readonly instanceId: string;
+```
+
+Uniquely identifies the instance. This identifier is internal to the desktop agent.  It should correspond to the source prop returned for IntentResolution and ContextHandlers.
+
+### `status`
+
+```ts
+public readonly status: 'ready' | 'loading' | 'unregistered';
+```
+
+Represents the lifecycle status of the AppInstance.  
+
+- *ready* indicates that the instance is loaded and connected to the DesktopAgent.
+- *loading* indicates that the instance is in the process of loading and not yet connected and ready to recieve context or intents.
+- *unregistered* indicates that the instance has disconnected from the DesktopAgent and is no longer available. 
+
+
+## Methods
+
+
+### `addContextListener`
+
+```ts
+public addContextListener(handler: ContextHandler): Listener;
+```
+
+Adds a listener for incoming contexts from the app instance.
+
+```ts
+public addContextListener(contextType: string, handler: ContextHandler): Listener;
+```
+
+Adds a listener for incoming contexts from the app instance using the specified _context type_.
+
+#### Examples
+Raise an intent then add a context listener on the resolved instance.
+```ts
+const listener = instance.addContextListener(context => {
+    if (context.type === 'fdc3.contact') {
+        // handle the contact
+    } else if (context.type === 'fdc3.instrument') => {
+        // handle the instrument
+    }
+});
+
+
+```
+
+Adding listeners for specific types of context that is broadcast from the instance:
+
+```ts
+const contactListener = instance.addContextListener('fdc3.contact', contact => {
+    // handle the contact
+});
+
+const instrumentListener = instance.addContextListener('fdc3.instrument', instrument => {
+    // handle the instrument
+});
+
+// later
+contactListener.unsubscribe();
+instrumentListener.unsubscribe();
+```
+
+#### See also
+* [`Listener`](Listener)
+* [`ContextHandler`](ContextHandler)
+* [`IntentResolution`](IntentResolution)
+
+
+### `broadcast`
+
+```typescript
+public broadcast(context: Context): void;
+```
+
+Broadcasts a context directly to the app instance. 
+
+If the instance is not available, the method will return an `Error` with a string from the [`InstanceError`](InstanceError) enumeration.
+
+#### Example
+
+```javascript
+const instrument = {
+    type: 'fdc3.instrument',
+    id: {
+        ticker: 'AAPL'
+    }
+};
+
+try {
+    instance.broadcast(instrument);
+} catch (err: InstanceError) {
+    // handler errror
+}
+```
+
+#### See also
+* [`InstanceError`](ChannelError)
+* [`addContextListener`](#addcontextlistener)
+
+### `onStatusChannged`
+
+``` typescript
+public onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
+```
+
+Sets a listener for status change events on an app instance.
+
+Possible status values are:
+
+- ready
+- loading
+- unregistered
+
+### Example
+
+```javascript
+
+// get an app instance
+const instance = await fdc3.getAppInstance(source);
+
+// if status is ready, add a context listener
+if (instance.status === 'ready'){
+    const listener = instance.addContextListener(someContext, myListener);
+}
+
+// listen for status change, if status is unregistered, then unsubscribe the context listener
+instance.onStatusChanged((status) => {
+    if (status === 'unregistered'){
+        listener.unsubscribe();
+    }
+});
+
+```

--- a/docs/api/ref/AppInstance.md
+++ b/docs/api/ref/AppInstance.md
@@ -10,7 +10,7 @@ hide_title: true
 interface AppInstance {
   //properties
   readonly instanceId : string;
-  readonly status : 'ready' | 'loading' | 'unregistered';
+  readonly status : AppInstanceStatus;
   
   //methods
   addContextListener(handler: ContextHandler): Listener;
@@ -18,6 +18,12 @@ interface AppInstance {
   broadcast(context: Context): void;
   onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
 
+}
+
+enum AppInstanceStatus {
+  Ready = 'ready',
+  Loading = 'loading',
+  Unregistered = 'unregistered',
 }
 ```
 
@@ -47,7 +53,7 @@ Uniquely identifies the instance. This identifier is internal to the desktop age
 ### `status`
 
 ```ts
-public readonly status: 'ready' | 'loading' | 'unregistered';
+public readonly status: AppInstanceStatus;
 ```
 
 Represents the lifecycle status of the AppInstance.  
@@ -144,7 +150,7 @@ try {
 ### `onStatusChannged`
 
 ``` typescript
-public onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
+public onStatusChanged(handler : (newVal : AppInstanceStatus, oldVal : AppInstanceStatus) => {}) : void;
 ```
 
 Sets a listener for status change events on an app instance.
@@ -163,13 +169,13 @@ Possible status values are:
 const instance = await fdc3.getAppInstance(source);
 
 // if status is ready, add a context listener
-if (instance.status === 'ready'){
+if (instance.status === AppInstanceStatus.Ready){
     const listener = instance.addContextListener(someContext, myListener);
 }
 
 // listen for status change, if status is unregistered, then unsubscribe the context listener
 instance.onStatusChanged((status) => {
-    if (status === 'unregistered'){
+    if (status === AppInstanceStatus.unregistered){
         listener.unsubscribe();
     }
 });

--- a/docs/api/ref/ContextHandler.md
+++ b/docs/api/ref/ContextHandler.md
@@ -7,7 +7,7 @@ hide_title: true
 # `ContextHandler`
 
 ```typescript
-type ContextHandler = (context: Context) => void;
+type ContextHandler = (context: Context, source? : string) => void;
 ```
 
 Describes a callback that handles a context event.
@@ -19,3 +19,5 @@ Used when attaching listeners for context broadcasts and raised intents.
 * [`DesktopAgent.addIntentListener`](DesktopAgent#addintentlistener)
 * [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
 * [`Channel.addContextListener`](Channel#addcontextlistener)
+* [`DesktopAgent.getAppInstance`](DesktopAgent#getAppInstance)
+* [`AppInstance`](AppInstance)

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -9,7 +9,7 @@ hide_title: true
 ```ts
 interface DesktopAgent {
   // apps
-  open(name: string, context?: Context): Promise<void>;
+  open(name: string, context?: Context): Promise<AppInstance | null>;
   getAppInstance(instanceId : string ) : Promise<AppInstance>;
   
   // context
@@ -337,10 +337,10 @@ redChannel.addContextListener(channelListener);
 ### `open`
 
 ```ts
-open(name: string, context?: Context): Promise<void>;
+open(name: string, context?: Context): Promise<AppInstance | null>;
 ```
 
-Launches/links to an app by name.  
+Launches/links to an app by name, resolves with an `AppInstance` reference to the launched app.
 
 The `open` method differs in use from [`raiseIntent`](#raiseIntent).  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying the App Directory, `open` would be used to an app returned in the search results.  **Note**, if both the intent and target app name are known, it is recommended to instead use `raiseIntent` with a `target` argument. 
 
@@ -355,10 +355,18 @@ await fdc3.open('myApp');
 
 // with context
 await fdc3.open('myApp', context);
+
+// opening, attaching an instance context handler, and broadcating on the instance
+const instance = await fdc3.open('myApp');
+if (instance !== null){
+  instance.addContextListener('myContextType',handler);
+  instance.broadcast('myContetextType',context);
+}
 ```
 
 #### See also
 * [`Context`](Context)
+* [`AppInstance`](AppInstance)
 * [`OpenError`](OpenError)
 
 

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -10,6 +10,7 @@ hide_title: true
 interface DesktopAgent {
   // apps
   open(name: string, context?: Context): Promise<void>;
+  getAppInstance(instanceId : string ) : Promise<AppInstance>;
   
   // context
   broadcast(context: Context): void;
@@ -294,7 +295,44 @@ redChannel.addContextListener(channelListener);
 
 ```
 
+### `getAppInstance`
 
+  ```ts
+  getAppInstance(instanceId : string ) : Promise<AppInstance>;
+  ```
+
+ Returns the instance of an app for a given identifier.
+  
+  An instanceId can be obtained from
+- the *source* propery of an [`IntentResolution`](IntentResolution)
+- the *source* arg of a [`ContextHandler`](ContextHandler) 
+  
+#### Examples
+```js
+  //get an app instance discovered through intent resolutionn
+  const intentRes = await fdc3.raiseIntent("ViewChart", someContext);
+   
+  const chartApp = await fdc3.getAppInstance(intentRes.source);
+ 
+  //send a new context to the same chart
+  chartApp.broadcast(newContext);
+
+  //raise a data intent and create a subscription to updates from the data provider
+  const intentRes = await fdc3.raiseIntent("GetPrices", someContext);
+
+  //get the provider from the resolution object and set handler for future updates
+  const priceProvider = await fdc3.getAppInstance(intentRes.source);
+  priceProvider.addContextListener("GetPrices", updatePrice);
+ 
+  //handle immediate context data payload (if any)
+   if (intentRes.data){
+      updatePrice(intentRes.data);
+  } 
+  ```
+  
+  #### See also
+* [`AppInstance`](AppInstance)
+  
 
 ### `open`
 

--- a/docs/api/ref/InstanceError.md
+++ b/docs/api/ref/InstanceError.md
@@ -1,0 +1,21 @@
+---
+id: InstanceError
+sidebar_label: InstanceError
+title: InstanceError
+hide_title: true
+---
+# `InstanceError`
+
+```typescript
+enum InstanceError {
+  NoInstanceFound = "NoInstanceFound",
+  AccessDenied = "AccessDenied"
+}
+```
+
+Contains constants representing the errors that can be encountered when calling app instance using the [`getAppInstance`](DesktopAgent#getAppInstance) method, or the  [`broadcast`](AppInstance#broadcast) or [`addContextListener`](AppInstance#addcontextlistener) methods on the `AppInstance` object.
+
+#### See also
+* [`DesktopAgent.getAppInstance`](DesktopAgent#getAppInstance)
+* [`AppInstance.broadcast`](AppInstance#broadcast)
+* [`AppInstance.addContextListener`](AppInstance#addcontextlistener)

--- a/docs/api/ref/IntentResolution.md
+++ b/docs/api/ref/IntentResolution.md
@@ -24,3 +24,4 @@ const intentResolution = await fdc3.raiseIntent("intentName", context);
 
 #### See also
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
+* [`AppInstance`](AppInstance)

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -76,7 +76,7 @@ Examples of End Points include:
 
 ## Functional Use Cases
 ### Open an Application by Name
-Linking from one application to another is a critical basic workflow that the web revolutionized via the hyperlink.  Supporting semantic addressing of applications across different technologies and platform domains greatly reduces friction in linking different applications into a single workflow.
+Linking from one application to another is a critical basic workflow that the web revolutionized via the hyperlink.  Supporting semantic addressing of applications across different technologies and platform domains greatly reduces friction in linking different applications into a single workflow. 
 
 ### Raising Intents
 Often, we want to link from one app to another to dynamically create a workflow.  Enabling this without requiring prior knowledge between apps is a key goal of FDC3.

--- a/src/api/AppInstance.ts
+++ b/src/api/AppInstance.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2020 FINOS FDC3 contributors - see NOTICE file
+ */
+
+import { Context } from '../context/ContextTypes';
+import { ContextHandler } from './ContextHandler';
+import { Listener } from './Listener';
+
+/**
+ * An interface that relates an instance of an app to other apps
+ */
+export interface AppInstance {
+  readonly instanceId : string;
+  readonly status : 'ready' | 'loading' | 'unregistered';
+  
+   /**
+   * Adds a listener for incoming contexts whenever a broadcast happens from this instance.
+   */
+  addContextListener(handler: ContextHandler): Listener;
+
+    /**
+   * Adds a listener for incoming contexts of the specified context type whenever a broadcast happens from this instance.
+   */
+  addContextListener(contextType: string, handler: ContextHandler): Listener;
+
+   /**
+   * Sends the given context to this app instance. 
+   * The context will be recieved on the applicable contextListener for the instance.
+   */
+  broadcast(context: Context): void;
+
+  /**
+   * 
+   */
+  onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
+
+}

--- a/src/api/AppInstance.ts
+++ b/src/api/AppInstance.ts
@@ -33,7 +33,9 @@ export interface AppInstance {
   /**
    *
    */
-  onStatusChanged(handler: (newVal: AppInstanceStatus, oldVal: AppInstanceStatus) => {}): void;
+  onStatusChanged(
+    handler: (newVal: AppInstanceStatus, oldVal: AppInstanceStatus) => {}
+  ): void;
 }
 
 export enum AppInstanceStatus {

--- a/src/api/AppInstance.ts
+++ b/src/api/AppInstance.ts
@@ -11,28 +11,33 @@ import { Listener } from './Listener';
  * An interface that relates an instance of an app to other apps
  */
 export interface AppInstance {
-  readonly instanceId : string;
-  readonly status : 'ready' | 'loading' | 'unregistered';
-  
-   /**
+  readonly instanceId: string;
+  readonly status: AppInstanceStatus;
+
+  /**
    * Adds a listener for incoming contexts whenever a broadcast happens from this instance.
    */
   addContextListener(handler: ContextHandler): Listener;
 
-    /**
+  /**
    * Adds a listener for incoming contexts of the specified context type whenever a broadcast happens from this instance.
    */
   addContextListener(contextType: string, handler: ContextHandler): Listener;
 
-   /**
-   * Sends the given context to this app instance. 
+  /**
+   * Sends the given context to this app instance.
    * The context will be recieved on the applicable contextListener for the instance.
    */
   broadcast(context: Context): void;
 
   /**
-   * 
+   *
    */
-  onStatusChanged(handler : (newVal : string, oldVal :string) => {}) : void;
+  onStatusChanged(handler: (newVal: AppInstanceStatus, oldVal: AppInstanceStatus) => {}): void;
+}
 
+export enum AppInstanceStatus {
+  Ready = 'ready',
+  Loading = 'loading',
+  Unregistered = 'unregistered',
 }

--- a/src/api/ContextHandler.ts
+++ b/src/api/ContextHandler.ts
@@ -5,4 +5,4 @@
 
 import { Context } from '../context/ContextTypes';
 
-export type ContextHandler = (context: Context, source? : string) => void;
+export type ContextHandler = (context: Context, source?: string) => void;

--- a/src/api/ContextHandler.ts
+++ b/src/api/ContextHandler.ts
@@ -5,4 +5,4 @@
 
 import { Context } from '../context/ContextTypes';
 
-export type ContextHandler = (context: Context) => void;
+export type ContextHandler = (context: Context, source? : string) => void;

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -9,6 +9,7 @@ import { ContextHandler } from './ContextHandler';
 import { IntentResolution } from './IntentResolution';
 import { Listener } from './Listener';
 import { Context } from '../context/ContextTypes';
+import {AppInstance} from './AppInstance';
 
 /**
  * A Desktop Agent is a desktop component (or aggregate of components) that serves as a
@@ -165,4 +166,38 @@ export interface DesktopAgent {
    * Returns `null` if the app is not joined to a channel.
    */
   getCurrentChannel(): Promise<Channel>;
+
+  /**
+   * Returns the instance of an app for a given identifier
+   * 
+   * An instanceId can be obtained from
+   *  - *source* propery in an IntentResolution
+   * 
+   * For example:
+   * ```javascript
+   *  //get an app instance discovered through intent resolutionn
+   *  const intentRes = await fdc3.raiseIntent("ViewChart", someContext);
+   *  
+   *  const chartApp = await fdc3.getAppInstance(intentRes.source);
+   *  
+   *  //send a new context to the same chart
+   *   chartApp.broadcast(newContext);
+   * 
+   *  //raise a data intent and create a subscription to updates from the data provider
+   *  const intentRes = await fdc3.raiseIntent("GetPrices", someContext);
+   * 
+   *  //get the provider from the resolution object and set handler for future updates
+   *  const priceProvider = await fdc3.getAppInstance(intentRes.source);
+   *  priceProvider.addContextListener("GetPrices", updatePrice);
+   *  
+   *  //handle immediate context data payload (if any)
+   *  if (intentRes.data){
+   *    updatePrice(intentRes.data);
+   *  }
+   * 
+   * 
+   * ```
+   * 
+   */
+  getAppInstance(instanceId : string ) : Promise<AppInstance>;
 }

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -9,7 +9,7 @@ import { ContextHandler } from './ContextHandler';
 import { IntentResolution } from './IntentResolution';
 import { Listener } from './Listener';
 import { Context } from '../context/ContextTypes';
-import {AppInstance} from './AppInstance';
+import { AppInstance } from './AppInstance';
 
 /**
  * A Desktop Agent is a desktop component (or aggregate of components) that serves as a
@@ -23,7 +23,7 @@ import {AppInstance} from './AppInstance';
 
 export interface DesktopAgent {
   /**
-   * Launches an app by name.
+   * Launches an app by name.  Resolves with an `AppInstance` reference for the opened app, or `null` if the app name could not be resolved.
    *
    * If a Context object is passed in, this object will be provided to the opened application via a contextListener.
    * The Context argument is functionally equivalent to opening the target app with no context and broadcasting the context directly to it.
@@ -37,7 +37,7 @@ export interface DesktopAgent {
    *     agent.open('myApp', context);
    * ```
    */
-  open(name: string, context?: Context): Promise<void>;
+  open(name: string, context?: Context): Promise<AppInstance | null>;
 
   /**
    * Find out more information about a particular intent by passing its name, and optionally its context.
@@ -169,35 +169,35 @@ export interface DesktopAgent {
 
   /**
    * Returns the instance of an app for a given identifier
-   * 
+   *
    * An instanceId can be obtained from
    *  - *source* propery in an IntentResolution
-   * 
+   *
    * For example:
    * ```javascript
    *  //get an app instance discovered through intent resolutionn
    *  const intentRes = await fdc3.raiseIntent("ViewChart", someContext);
-   *  
+   *
    *  const chartApp = await fdc3.getAppInstance(intentRes.source);
-   *  
+   *
    *  //send a new context to the same chart
    *   chartApp.broadcast(newContext);
-   * 
+   *
    *  //raise a data intent and create a subscription to updates from the data provider
    *  const intentRes = await fdc3.raiseIntent("GetPrices", someContext);
-   * 
+   *
    *  //get the provider from the resolution object and set handler for future updates
    *  const priceProvider = await fdc3.getAppInstance(intentRes.source);
    *  priceProvider.addContextListener("GetPrices", updatePrice);
-   *  
+   *
    *  //handle immediate context data payload (if any)
    *  if (intentRes.data){
    *    updatePrice(intentRes.data);
    *  }
-   * 
-   * 
+   *
+   *
    * ```
-   * 
+   *
    */
-  getAppInstance(instanceId : string ) : Promise<AppInstance>;
+  getAppInstance(instanceId: string): Promise<AppInstance>;
 }

--- a/src/api/methods.ts
+++ b/src/api/methods.ts
@@ -6,11 +6,12 @@ import {
   IntentResolution,
   Listener,
 } from '..';
+import { AppInstance } from './AppInstance';
 
-export const open: (name: string, context?: Context) => Promise<void> = (
-  name,
-  context
-) => {
+export const open: (
+  name: string,
+  context?: Context
+) => Promise<AppInstance | null> = (name, context) => {
   return window.fdc3.open(name, context);
 };
 

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -15,8 +15,9 @@
         "ids": [
           "api/ref/DesktopAgent",
           "api/ref/Channel",
+          "api/ref/AppInstance",
           "api/ref/Listener",
-          "api/ref/AppIntent",
+          "api/ref/AppIntent",   
           "api/ref/IntentResolution",
           "api/ref/AppMetadata",
           "api/ref/IntentMetadata",


### PR DESCRIPTION
This is an initial PR to introduce the concept of AppInstances to address data returning intents - as outlined in issue #201 as well as questions around app instances (e.g. issue #231).  

Key points of this PR are:

-   introduction of an *AppInstance* class that provides a reference to a specific instance of an app and allows direct broadcasting / listening of context with that instance
- `IntentResolution` *source* properties can be used to obtain an AppInstance
- `ContextHandler` functions now get an additional *source* arg that provides a reference to the instance sending the context or intent
- Instances provide lifecycle information