### PR TITLE
core(docs, build): add version numbers to specs, simplify build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ['10.x', '12.x', '14.x']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        node: [14.x]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * [API] New raiseIntentForContext method (#268)
-* [API] Add fdc3Ready event to API specification (#269)
+* [API] Add fdc3Ready event to API specification (#269, #327)
 * [API] Add optional appId and version properties to AppMetadata (#273)
-* [API] Define new Target type for use with open and raiseIntent (#279)
+* [API] Define new TargetApp type for use with open and raiseIntent (#279, #315)
+* [API] New getInfo method with method data about implementation (#324)
 * [Package] Build and publish an npm package for FDC3 (#252)
 * [Package] Add enums for intents and context types (#264)
 * [Package] Add ES6 module support to FDC3 API package (#266)
@@ -18,9 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 * [API] Allow AppMetadata to be passed in as a target argument (#272)
 * [API] Reject/throw as appropriate in ES6 exported methods if window.fdc3 is not available (#277)
-* [API] Clarify docs for broadcast functions to prevent message loops (#285)
-* [Website] Add Genesis logo (#209)
-* [Website] Change ChartIQ logo to Cosaic after rebrand (#225)
+* [API] API specification clarifications around intents/context and loops when broadcasting (#285, #307, 310)
+* [Website] Add/update participant logos (#209, #225, #320)
 * [Website] Update "Get Involved" with standards governance info (#228, #249, #300, #286)
 
 ### Fixed
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Technical
 * [Readme] Fix AppDirectory Readme (#274)
-* [Readme] Update main Readme (#275)
+* [Readme] Update main Readme (#275, #318)
 * [GitHub] Remove FINOS SVG from project root (#204)
 * [GitHub] Switch builds from Travis to GitHub workflows (#239, #252, #253, #254)
 * [GitHub] Meeting workflows and templates (#292, #293)

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -1,15 +1,12 @@
 ---
 id: spec
 sidebar_label: API Specification
-title: API Specification
-hide_title: true
+title: API Specification (next)
 ---
-
-# API Specification
 
 ## Components
 ### Desktop Agent
-A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.  
+A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.
 
 Examples of Desktop Agents include:
 
@@ -18,10 +15,10 @@ Examples of Desktop Agents include:
 - OpenFin
 - Refinitiv Eikon
 
-Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*. 
+Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*.
 
 #### Desktop Agent Implementation
-The FDC3 API specification consists of interfaces.  It is expected that each Desktop Agent will implement these interfaces.  A typical implemention would provide instantiable classes for the following interfaces: 
+The FDC3 API specification consists of interfaces.  It is expected that each Desktop Agent will implement these interfaces.  A typical implemention would provide instantiable classes for the following interfaces:
 
 - `DesktopAgent`
 - `Channel`
@@ -38,7 +35,7 @@ Other interfaces defined in the spec are not critical to define as concrete type
 
 
 #### API Access
-The FDC3 API can be made available to an application through a number of different methods.  In the case of web applications, a Desktop Agent SHOULD provide the FDC3 API via a global accessible as _window.fdc3_. Implementors MAY additionally make the API available through modules, imports, or other means. 
+The FDC3 API can be made available to an application through a number of different methods.  In the case of web applications, a Desktop Agent SHOULD provide the FDC3 API via a global accessible as _window.fdc3_. Implementors MAY additionally make the API available through modules, imports, or other means.
 
 The global `window.fdc3` must only be available after the API is ready to use. To prevent the API from being used before it is ready, implementors SHOULD provide a global `fdc3Ready` event. Here is code demonstrating the use of the FDC3 API and the ready event:
 
@@ -57,9 +54,9 @@ if (window.fdc3) {
 #### Standards vs. Implementation
 ![Desktop Agent - Standards Schematic](assets/api-1.png)
 
-The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).  
+The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).
 
-For example: 
+For example:
 - workspace management
 - user identity and SSO
 - entitlements
@@ -68,13 +65,13 @@ For example:
 Are all areas of functionality that any feature complete desktop agent would implement, but are not currently areas considered for standardization under FDC3.
 
 #### Inter-Agent Communication
-A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.  
+A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.
 
 ![Desktop Agent - Interop](assets/api-2.png)
 
-Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.  
+Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.
 
-The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequetly handled for the time being on a case-by-case basis.  
+The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequetly handled for the time being on a case-by-case basis.
 
 ### Application
 An application is any endpoint on the desktop that is:
@@ -101,7 +98,7 @@ Intents provide a way for an app to request functionality from another app and d
 - **Remote API**: An app wants to remote an entire API that it owns to another App.  In this case, the API for the App cannot be standardized.  However, the FDC3 API can address how an App connects to another App in order to get access to a proprietary API.
 
 #### Intents and Context
-When raising an Intent a specific context may be provided. The type of the provided context may determine which applications can resolve the Intent. 
+When raising an Intent a specific context may be provided. The type of the provided context may determine which applications can resolve the Intent.
 
 A Context type may also be associated with multiple Intents. For example, an `fdc3.instrument` could be associated with `ViewChart`, `ViewNews`, `ViewAnalysis` or other Intents. In addition to raising a specific intent, you can raise an Intent for a specific Context allowing the Desktop Agent or the user (if the Intent is ambiguous) to select the appropriate Intent for the selected Context and then to raise that Intent for resolution.
 
@@ -123,7 +120,7 @@ If the raising of the intent resolves (or rejects), a standard object will be pa
 ```js
 {
     source: String;
-    data?: Object; 
+    data?: Object;
     version: String;
 }
 ```
@@ -159,7 +156,7 @@ catch (er){
 ```
 
 ##### Upgrading to a Remote API Connection
-There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
+There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example:
 
 ```js
 const chart = await fdc3.raiseIntent('ViewChart');
@@ -173,13 +170,13 @@ const chartApp = fin.Application.wrap(chart.source);
 Applications need to let the system know the Intents they can support.  Typically, this is done via registration with the App Directory.  It is also possible for Intents to be registered at the application level as well to support ad-hoc registration which may be helpful at development time.  While, dynamic registration is not part of this specification, a Desktop Agent agent may choose to support any number of registration paths.
 
 #### Compliance with Intent Standards
-Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.  
+Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.
 
 It is expected that App Directories will also curate listed apps and ensure that they are complying with declared intents.
 
 Like FDC3 Context Data, the Intent schemas need to be versioned.  Desktop Agents will be responsible to declare which version of the Intent schema they are using.   Applications may also assert a specific version requirement when raising an Intent.  Version negotation may be supported by a given Desktop Agent.
 
-### Send/broadcast Context  
+### Send/broadcast Context
 On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features. However, a Desktop Agent should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
 
 ### Retrieve Metadata about the Desktop Agent implementation
@@ -202,23 +199,23 @@ Intents functionality is dependent on resolver functionality to map the intent t
 
 Context channels allows a set of apps to share a stateful piece of data between them, and be alerted when it changes.  Use cases for channels include color linking between applications to automate the sharing of context and topic based pub/sub such as theme.
 
-There are two types of channels, which are functionally identical, but have different visibility and discoverability semantics.  
+There are two types of channels, which are functionally identical, but have different visibility and discoverability semantics.
 
 1. The 'system' ones, which have a well understood identity. One is called 'global'.
 2. The 'app' ones, which have a transient identity and need to be revealed
- 
+
 
 ### Joining Channels
 Apps can join channels.  An app can only be joined to one channel at a time.  When an app joins a channel it will automatically recieve the current context for that channel.
 
 When an app is joined to a channel, calls to fdc3.broadcast and listeners added through fdc3.addContextListener will be routed to that channel.  If an app is not joined to a channel these methods will be no-ops, but apps can still choose to listen and broadcast to specific channels via the methods on the `Channel` class.
 
-It is possible that a call to join a channel could be rejected.  If for example, the desktop agent wanted to implement controls around what data apps can access.  
+It is possible that a call to join a channel could be rejected.  If for example, the desktop agent wanted to implement controls around what data apps can access.
 
-Joining channels in FDC3 is intended to be a behavior initiated by the end user. For example: by color linking or apps being grouped in the same workspace.  Most of the time, it is expected that apps will be joined to a channel by mechanisms outside of the app.  Always, there SHOULD be a clear UX indicator of what channel an app is joined to. 
+Joining channels in FDC3 is intended to be a behavior initiated by the end user. For example: by color linking or apps being grouped in the same workspace.  Most of the time, it is expected that apps will be joined to a channel by mechanisms outside of the app.  Always, there SHOULD be a clear UX indicator of what channel an app is joined to.
 
 ### The 'global' Channel
-The 'system' channels include a 'global' channel which serves as the backwards compatible layer with the 'send/broadcast context' behavior in FDC3 1.0.  A desktop agent MAY choose to make membership in the 'global' channel the default state for apps on start up.  
+The 'system' channels include a 'global' channel which serves as the backwards compatible layer with the 'send/broadcast context' behavior in FDC3 1.0.  A desktop agent MAY choose to make membership in the 'global' channel the default state for apps on start up.
 
 The 'global' channel should be returned as part of the response from the `fdc3.getSystemChannels` call.  Desktop Agents may want to filter out the 'global' option in their UI for system channel pickers.
 
@@ -257,7 +254,7 @@ To find a system channel, one calls
 
 ```js
 // returns an array of channels
-const allChannels = await fdc3.getSystemChannels(); 
+const allChannels = await fdc3.getSystemChannels();
 const redChannel = allChannels.find(c => c.id === 'red');
 ```
 #### Joining channels

--- a/docs/app-directory/spec.md
+++ b/docs/app-directory/spec.md
@@ -1,7 +1,7 @@
 ---
 id: spec
 sidebar_label: App Directory Specification
-title: App Directory Specification
+title: App Directory Specification (next)
 ---
 ## API
 
@@ -12,5 +12,5 @@ View the [full specification](/schemas/next/app-directory) in [OpenAPI v3.0](htt
  Endpoint           | Method | Description
  ------------------ | ------ | -----------
  `/v1/apps`         | POST   | Create a new application definition
- `/v1/apps/{appId}` | GET    | Retrieve an application defintion        
- `/v1/apps/search`  | GET    | Retrieve a list of applications   
+ `/v1/apps/{appId}` | GET    | Retrieve an application defintion
+ `/v1/apps/search`  | GET    | Retrieve a list of applications

--- a/docs/context/spec.md
+++ b/docs/context/spec.md
@@ -1,11 +1,9 @@
 ---
 id: spec
 sidebar_label: Context Data Specification
-title: Context Data Specification
+title: Context Data Specification (next)
 hide_title: true
 ---
-
-# Context Data Specification
 
 ## Introduction
 
@@ -80,7 +78,7 @@ The identifier "foo" is proprietary, an application that can use it is free to d
 
 ## Standard Context Types
 
-The following are standard FDC3 context types. 
+The following are standard FDC3 context types.
  __Note:__ The specification for these types are shared with the [FINOS Financial Objects](https://fo.finos.org) definitions, JSON schemas are hosted with FDC3.
 
 - __fdc3.contact__
@@ -171,8 +169,8 @@ __Note:__ The below examples show how the base context data interface can be use
 {
     "type" : "fdc3.instrument",
     "name" : "Apple",
-    "id" : 
-    {  
+    "id" :
+    {
         "ticker" : "aapl",
         "ISIN" : "US0378331005",
         "CUSIP" : "037833100",
@@ -187,14 +185,14 @@ __Note:__ The below examples show how the base context data interface can be use
     "type" : "fdc3.instrumentList",
     "name" : "my portfolio",
     "instruments" : [
-        {  
+        {
             "type" : "fdc3.instrument",
             "name" : "Apple",
             "id": {
                "ticker" : "aapl"
             }
         },
-        {  
+        {
             "type" : "fdc3.instrument",
             "name" : "International Business Machines",
             "id": {
@@ -228,7 +226,7 @@ __Note:__ The below examples show how the base context data interface can be use
             "instrument": {
                 "type" : "fdc3.instrument",
                 "name" : "Apple",
-                "id" : 
+                "id" :
                 {
                     "ISIN" : "US0378331005"
                 }
@@ -240,7 +238,7 @@ __Note:__ The below examples show how the base context data interface can be use
             "instrument": {
                 "type" : "fdc3.instrument",
                 "name" : "IBM",
-                "id" : 
+                "id" :
                 {
                     "ISIN" : "US4592001014"
                 }
@@ -259,7 +257,7 @@ __Note:__ The below examples show how the base context data interface can be use
     "instrument": {
         "type" : "fdc3.instrument",
         "name" : "Apple",
-        "id" : 
+        "id" :
         {
             "ISIN" : "US0378331005"
         }

--- a/docs/intents/spec.md
+++ b/docs/intents/spec.md
@@ -1,19 +1,16 @@
 ---
 id: spec
 sidebar_label: Intents Specification
-title: Intents Specification
-hide_title: true
+title: Intents Specification (next)
 ---
-
-# Intents Specification
 
 ## Introduction
 
-FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.  
+FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.
 
 ### Naming Syntax
-* Intent names should be free of non-alphanumeric characters.   
-* ‘.’ will be used to namespace the intent (see below).  
+* Intent names should be free of non-alphanumeric characters.
+* ‘.’ will be used to namespace the intent (see below).
 * Intent names should be in UpperCamelCase.
 
 ### Characteristics
@@ -24,14 +21,14 @@ Intents shoulde be:
 * Repeatable
     * Many instances across the industry
 * Stateless
-    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow. 
+    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow.
 * Specific
     * Terms should not be so open-ended that one endpoint could fulfill the Intent in a completely different way than another
 * Distinct
-    * Granular enough that Intent handlers can communicate key functional differences 
+    * Granular enough that Intent handlers can communicate key functional differences
 
 ### Namespaces ###
-All standard Intent names are reserved. Applications may use their own Intents ad hoc. 
+All standard Intent names are reserved. Applications may use their own Intents ad hoc.
 However, there is a need for applications to ensure that their Intents avoid collision. The recommended approach here is to use the app name as the noun. For example, the ‘myChart’ App may expose the ‘ViewChart’ intent and the ‘myChart.Foo’ proprietary Intent.
 
 ## Initial Set of Standard Intents ##

--- a/website/versioned_docs/version-1.0/api/api-spec.md
+++ b/website/versioned_docs/version-1.0/api/api-spec.md
@@ -1,16 +1,13 @@
 ---
 id: version-1.0-api-spec
 sidebar_label: API Specification
-title: API Specification
-hide_title: true
+title: API Specification 1.0
 original_id: api-spec
 ---
 
-# API Specification 
-
 ## Components
 ### Desktop Agent
-A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.  
+A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.
 
 Examples of Desktop Agents include:
 
@@ -18,13 +15,13 @@ Examples of Desktop Agents include:
 - Autobahn
 - ThomsonReuters Eikon
 
-Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*. 
+Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*.
 
 ![Desktop Agent - Standards Schematic](assets/api-1.png)
 
-The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).  
+The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).
 
-For example: 
+For example:
 - workspace management
 - user identity and SSO
 - entitlements
@@ -33,13 +30,13 @@ For example:
 Are all areas of functionality that any feature-complete desktop agent would implement, but are not currently areas considered for standardization under FDC3.
 
 #### Inter-Agent Communication
-A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.  
+A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.
 
 ![Desktop Agent - Interop](assets/api-2.png)
 
-Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.  
+Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.
 
-The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequately handled for the time being on a case-by-case basis.  
+The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequately handled for the time being on a case-by-case basis.
 
 ### Application
 An application is any endpoint on the desktop that is:
@@ -83,7 +80,7 @@ If the raising of the intent resolves (or rejects), a standard object will be pa
 ```javascript
 {
     source: String;
-    data?: Object; 
+    data?: Object;
     version: String;
 }
 ```
@@ -107,7 +104,7 @@ catch (er){
 ```
 
 ##### Upgrading to a Remote API Connection
-There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
+There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example:
 
 ```javascript
     let chart = await agent.raiseIntent('ViewChart');
@@ -121,14 +118,14 @@ There are a wide range of workflows where decoupled intents and/or context passi
 Applications need to let the system know the Intents they can support.  Typically, this is done via registration with the App Directory.  It is also possible for Intents to be registered at the application level as well to support ad-hoc registration which may be helpful at development time.  While dynamic registration is not part of this specification, a Desktop Agent agent may choose to support any number of registration paths.
 
 #### Compliance with Intent Standards
-Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.  
+Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.
 
 It is expected that App Directories will also curate listed apps and ensure that they are complying with declared intents.
 
 Like FDC3 Context Data, the Intent schemas need to be versioned.  Desktop Agents will be responsible to declare which version of the Intent schema they are using.   Applications may also assert a specific version requirement when raising an Intent.  Version negotiation may be supported by a given Desktop Agent.
 
-### Send/broadcast context  
-On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.  
+### Send/broadcast context
+On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.
 
 ## Resolvers
 Intents functionality is dependent on resolver functionality to map the intent to a specific App.  This will often require end-user input.  Resolution can either be performed by the Desktop Agent (raising UI to pick the desired App for the intent) or by the app launching the intent - in which case the calling App will handle the resolution itself (using the findIntents API below) and then invoke an explicit Intent object.

--- a/website/versioned_docs/version-1.0/appd-spec.md
+++ b/website/versioned_docs/version-1.0/appd-spec.md
@@ -1,7 +1,7 @@
 ---
 id: version-1.0-appd-spec
 sidebar_label: App Directory Specification
-title: App Directory Specification
+title: App Directory Specification 1.0
 original_id: appd-spec
 ---
 ## API
@@ -13,5 +13,5 @@ View the [full specification](/1.0/appd-spec) in [OpenAPI v3.0](https://www.open
  Endpoint           | Method | Description
  ------------------ | ------ | -----------
  `/v1/apps`         | POST   | Create a new application definition
- `/v1/apps/{appId}` | GET    | Retrieve an application defintion        
- `/v1/apps/search`  | GET    | Retrieve a list of applications   
+ `/v1/apps/{appId}` | GET    | Retrieve an application defintion
+ `/v1/apps/search`  | GET    | Retrieve a list of applications

--- a/website/versioned_docs/version-1.0/context-spec.md
+++ b/website/versioned_docs/version-1.0/context-spec.md
@@ -1,12 +1,9 @@
 ---
 id: version-1.0-context-spec
 sidebar_label: Context Data Specification
-title: Context Data Specification
-hide_title: true
+title: Context Data Specification 1.0
 original_id: context-spec
 ---
-
-# Context Data Specification
 
 ## Introduction
 
@@ -60,8 +57,8 @@ __Note:__ The below examples show how the base context data interface can be use
 {
     "type" : "fdc3.instrument",
     "name" : "Apple",
-    "id" : 
-    {  
+    "id" :
+    {
         "ticker" : "aapl",
         "ISIN" : "US0378331005",
         "CUSIP" : "037833100",
@@ -121,7 +118,7 @@ __Note:__ The below examples show how the base context data interface can be use
     "instrument": {
         "type" : "fdc3.instrument",
         "name" : "Apple",
-        "id" : 
+        "id" :
         {
             "ISIN" : "US0378331005"
         }

--- a/website/versioned_docs/version-1.0/intents-spec.md
+++ b/website/versioned_docs/version-1.0/intents-spec.md
@@ -1,20 +1,17 @@
 ---
 id: version-1.0-intents-spec
 sidebar_label: Intents Specification
-title: Intents Specification
-hide_title: true
+title: Intents Specification 1.0
 original_id: intents-spec
 ---
 
-# Intents Specification
-
 ## Introduction
 
-FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.  
+FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.
 
 ### Naming Syntax
-* Intent names should be free of non-alphanumeric characters.   
-* ‘.’ will be used to namespace the intent (see below).  
+* Intent names should be free of non-alphanumeric characters.
+* ‘.’ will be used to namespace the intent (see below).
 * Intent names should be in UpperCamelCase.
 
 ### Characteristics
@@ -25,14 +22,14 @@ Intents shoulde be:
 * Repeatable
     * Many instances across the industry
 * Stateless
-    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow. 
+    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow.
 * Specific
     * Terms should not be so open-ended that one endpoint could fulfill the Intent in a completely different way than another
 * Distinct
-    * Granular enough that Intent handlers can communicate key functional differences 
+    * Granular enough that Intent handlers can communicate key functional differences
 
 ### Namespaces ###
-All standard Intent names are reserved. Applications may use their own Intents ad hoc. 
+All standard Intent names are reserved. Applications may use their own Intents ad hoc.
 However, there is a need for applications to ensure that their Intents avoid collision. The recommended approach here is to use the app name as the noun. For example, the ‘myChart’ App may expose the ‘ViewChart’ intent and the ‘myChart.Foo’ proprietary Intent.
 
 ## Initial Set of Standard Intents ##

--- a/website/versioned_docs/version-1.1/api/spec.md
+++ b/website/versioned_docs/version-1.1/api/spec.md
@@ -1,16 +1,12 @@
 ---
 id: version-1.1-spec
 sidebar_label: API Specification
-title: API Specification
-hide_title: true
+title: API Specification 1.1
 original_id: spec
 ---
-
-# API Specification
-
 ## Components
 ### Desktop Agent
-A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.  
+A Desktop Agent is a desktop component (or aggregate of components) that serves as a launcher and message router (broker) for applications in its domain.  A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.
 
 Examples of Desktop Agents include:
 
@@ -19,10 +15,10 @@ Examples of Desktop Agents include:
 - OpenFin
 - Refinitiv Eikon
 
-Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*. 
+Desktop Agents expose an FDC3 standard API to applications they have launched.  When an App is launched by a Desktop Agent and is given access to the Agent's API to interoperate, it is running in that Desktop Agent's *context*.
 
 #### Desktop Agent Implementation
-The FDC3 API specification consists of interfaces.  It is expected that each Desktop Agent will implement these interfaces.  A typical implemention would provide instantiable classes for the following interfaces: 
+The FDC3 API specification consists of interfaces.  It is expected that each Desktop Agent will implement these interfaces.  A typical implemention would provide instantiable classes for the following interfaces:
 
 - `DesktopAgent`
 - `Channel`
@@ -40,14 +36,14 @@ Other interfaces defined in the spec are not critical to define as concrete type
 
 
 #### API Access
-The FDC3 API can be made available to an application through a number of different methods.  In the case of web applications, a Desktop Agent SHOULD provide the FDC3 API via a global accessible as _window.fdc3_. Implementors MAY additionally make the API available through modules, imports, or other means. 
+The FDC3 API can be made available to an application through a number of different methods.  In the case of web applications, a Desktop Agent SHOULD provide the FDC3 API via a global accessible as _window.fdc3_. Implementors MAY additionally make the API available through modules, imports, or other means.
 
 #### Standards vs. Implementation
 ![Desktop Agent - Standards Schematic](assets/api-1.png)
 
-The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).  
+The surface area of FDC3 standardization (shown in *white* above) itself is quite small in comparison to the extent of a typical desktop agent implementation (in *grey*).
 
-For example: 
+For example:
 - workspace management
 - user identity and SSO
 - entitlements
@@ -56,13 +52,13 @@ For example:
 Are all areas of functionality that any feature complete desktop agent would implement, but are not currently areas considered for standardization under FDC3.
 
 #### Inter-Agent Communication
-A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.  
+A goal of FDC3 standards is that applications running in different Desktop Agent contexts on the same desktop would be able to interoperate.  And that one Desktop Agent context would be able to discover and launch an application in another Desktop Application context.
 
 ![Desktop Agent - Interop](assets/api-2.png)
 
-Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.  
+Desktop Agent interop is supported by common standards for APIs for App discovery and launching.  So, an App in one Desktop Agent context would not need to know a different syntax to call an App in another Desktop Agent context.
 
-The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequetly handled for the time being on a case-by-case basis.  
+The actual connection protocol between Desktop Agents is not currently in scope for FDC3 standards.  Given that there are a relatively small number of Desktop Agents, and that any given desktop will have a finite and relatively static number of Desktop Agents installed at any given time, the connectivity between different Agents can be adequetly handled for the time being on a case-by-case basis.
 
 ### Application
 An application is any endpoint on the desktop that is:
@@ -106,7 +102,7 @@ If the raising of the intent resolves (or rejects), a standard object will be pa
 ```js
 {
     source: String;
-    data?: Object; 
+    data?: Object;
     version: String;
 }
 ```
@@ -130,7 +126,7 @@ catch (er){
 ```
 
 ##### Upgrading to a Remote API Connection
-There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
+There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example:
 
 ```js
 const chart = await fdc3.raiseIntent('ViewChart');
@@ -144,14 +140,14 @@ const chartApp = fin.Application.wrap(chart.source);
 Applications need to let the system know the Intents they can support.  Typically, this is done via registration with the App Directory.  It is also possible for Intents to be registered at the application level as well to support ad-hoc registration which may be helpful at development time.  While, dynamic registration is not part of this specification, a Desktop Agent agent may choose to support any number of registration paths.
 
 #### Compliance with Intent Standards
-Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.  
+Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.
 
 It is expected that App Directories will also curate listed apps and ensure that they are complying with declared intents.
 
 Like FDC3 Context Data, the Intent schemas need to be versioned.  Desktop Agents will be responsible to declare which version of the Intent schema they are using.   Applications may also assert a specific version requirement when raising an Intent.  Version negotation may be supported by a given Desktop Agent.
 
-### Send/broadcast context  
-On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.  
+### Send/broadcast context
+On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features.
 
 ## Resolvers
 Intents functionality is dependent on resolver functionality to map the intent to a specific App.  This will often require end-user input.  Resolution can either be performed by the Desktop Agent (raising UI to pick the desired App for the intent) or by the app launching the intent - in which case the calling App will handle the resolution itself (using the findIntents API below) and then invoke an explicit Intent object.
@@ -160,23 +156,23 @@ Intents functionality is dependent on resolver functionality to map the intent t
 
 Context channels allows a set of apps to share a stateful piece of data between them, and be alerted when it changes.  Use cases for channels include color linking between applications to automate the sharing of context and topic based pub/sub such as theme.
 
-There are two types of channels, which are functionally identical, but have different visibility and discoverability semantics.  
+There are two types of channels, which are functionally identical, but have different visibility and discoverability semantics.
 
 1. The 'system' ones, which have a well understood identity. One is called 'global'.
 2. The 'app' ones, which have a transient identity and need to be revealed
- 
+
 
 ### Joining Channels
 Apps can join channels.  An app can only be joined to one channel at a time.  When an app joins a channel it will automatically recieve the current context for that channel.
 
-When an app is joined to a channel, calls to fdc3.broadcast and listeners added through fdc3.addContextListener will be routed to that channel.  If an app is not joined to a channel these methods will be no-ops, but apps can still choose to listen and broadcast to specific channels via the methods on the `Channel` class.  
+When an app is joined to a channel, calls to fdc3.broadcast and listeners added through fdc3.addContextListener will be routed to that channel.  If an app is not joined to a channel these methods will be no-ops, but apps can still choose to listen and broadcast to specific channels via the methods on the `Channel` class.
 
-It is possible that a call to join a channel could be rejected.  If for example, the desktop agent wanted to implement controls around what data apps can access.  
+It is possible that a call to join a channel could be rejected.  If for example, the desktop agent wanted to implement controls around what data apps can access.
 
-Joining channels in FDC3 is intended to be a behavior initiated by the end user. For example: by color linking or apps being grouped in the same workspace.  Most of the time, it is expected that apps will be joined to a channel by mechanisms outside of the app.  Always, there SHOULD be a clear UX indicator of what channel an app is joined to. 
+Joining channels in FDC3 is intended to be a behavior initiated by the end user. For example: by color linking or apps being grouped in the same workspace.  Most of the time, it is expected that apps will be joined to a channel by mechanisms outside of the app.  Always, there SHOULD be a clear UX indicator of what channel an app is joined to.
 
 ### The 'global' Channel
-The 'system' channels include a 'global' channel which serves as the backwards compatible layer with the 'send/broadcast context' behavior in FDC3 1.0.  A desktop agent MAY choose to make membership in the 'global' channel the default state for apps on start up.  
+The 'system' channels include a 'global' channel which serves as the backwards compatible layer with the 'send/broadcast context' behavior in FDC3 1.0.  A desktop agent MAY choose to make membership in the 'global' channel the default state for apps on start up.
 
 The 'global' channel should be returned as part of the response from the `fdc3.getSystemChannels` call.  Desktop Agents may want to filter out the 'global' option in their UI for system channel pickers.
 
@@ -214,7 +210,7 @@ To find a system channel, one calls
 
 ```js
 // returns an array of channels
-const allChannels = await fdc3.getSystemChannels(); 
+const allChannels = await fdc3.getSystemChannels();
 const redChannel = allChannels.find(c => c.id === 'red');
 ```
 #### Joining channels

--- a/website/versioned_docs/version-1.1/app-directory/spec.md
+++ b/website/versioned_docs/version-1.1/app-directory/spec.md
@@ -1,7 +1,7 @@
 ---
 id: version-1.1-spec
 sidebar_label: App Directory Specification
-title: App Directory Specification
+title: App Directory Specification 1.1
 original_id: spec
 ---
 ## API
@@ -13,5 +13,5 @@ View the [full specification](/schemas/1.1/app-directory) in [OpenAPI v3.0](http
  Endpoint           | Method | Description
  ------------------ | ------ | -----------
  `/v1/apps`         | POST   | Create a new application definition
- `/v1/apps/{appId}` | GET    | Retrieve an application defintion        
- `/v1/apps/search`  | GET    | Retrieve a list of applications   
+ `/v1/apps/{appId}` | GET    | Retrieve an application defintion
+ `/v1/apps/search`  | GET    | Retrieve a list of applications

--- a/website/versioned_docs/version-1.1/context/spec.md
+++ b/website/versioned_docs/version-1.1/context/spec.md
@@ -1,12 +1,9 @@
 ---
 id: version-1.1-spec
 sidebar_label: Context Data Specification
-title: Context Data Specification
-hide_title: true
+title: Context Data Specification 1.1
 original_id: spec
 ---
-
-# Context Data Specification
 
 ## Introduction
 
@@ -81,7 +78,7 @@ The identifier "foo" is proprietary, an application that can use it is free to d
 
 ## Standard Context Types
 
-The following are standard FDC3 context types. 
+The following are standard FDC3 context types.
  __Note:__ The specification for these types are shared with the [FINOS Financial Objects](https://fo.finos.org) definitions, JSON schemas are hosted with FDC3.
 
 - __fdc3.contact__
@@ -172,8 +169,8 @@ __Note:__ The below examples show how the base context data interface can be use
 {
     "type" : "fdc3.instrument",
     "name" : "Apple",
-    "id" : 
-    {  
+    "id" :
+    {
         "ticker" : "aapl",
         "ISIN" : "US0378331005",
         "CUSIP" : "037833100",
@@ -188,14 +185,14 @@ __Note:__ The below examples show how the base context data interface can be use
     "type" : "fdc3.instrumentList",
     "name" : "my portfolio",
     "instruments" : [
-        {  
+        {
             "type" : "fdc3.instrument",
             "name" : "Apple",
             "id": {
                "ticker" : "aapl"
             }
         },
-        {  
+        {
             "type" : "fdc3.instrument",
             "name" : "International Business Machines",
             "id": {
@@ -229,7 +226,7 @@ __Note:__ The below examples show how the base context data interface can be use
             "instrument": {
                 "type" : "fdc3.instrument",
                 "name" : "Apple",
-                "id" : 
+                "id" :
                 {
                     "ISIN" : "US0378331005"
                 }
@@ -241,7 +238,7 @@ __Note:__ The below examples show how the base context data interface can be use
             "instrument": {
                 "type" : "fdc3.instrument",
                 "name" : "IBM",
-                "id" : 
+                "id" :
                 {
                     "ISIN" : "US4592001014"
                 }
@@ -260,7 +257,7 @@ __Note:__ The below examples show how the base context data interface can be use
     "instrument": {
         "type" : "fdc3.instrument",
         "name" : "Apple",
-        "id" : 
+        "id" :
         {
             "ISIN" : "US0378331005"
         }

--- a/website/versioned_docs/version-1.1/intents/spec.md
+++ b/website/versioned_docs/version-1.1/intents/spec.md
@@ -1,20 +1,17 @@
 ---
 id: version-1.1-spec
 sidebar_label: Intents Specification
-title: Intents Specification
-hide_title: true
+title: Intents Specification 1.1
 original_id: spec
 ---
 
-# Intents Specification
-
 ## Introduction
 
-FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.  
+FDC3 [Intents](intents-intro) define a standard set of nouns and verbs that can be used to put together common cross-application workflows on the financial desktop.
 
 ### Naming Syntax
-* Intent names should be free of non-alphanumeric characters.   
-* ‘.’ will be used to namespace the intent (see below).  
+* Intent names should be free of non-alphanumeric characters.
+* ‘.’ will be used to namespace the intent (see below).
 * Intent names should be in UpperCamelCase.
 
 ### Characteristics
@@ -25,14 +22,14 @@ Intents shoulde be:
 * Repeatable
     * Many instances across the industry
 * Stateless
-    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow. 
+    * Workflows should not require callbacks or endpoints to maintain references to each other.  Once an Intent is passed to an endpoint - it controls the rest of that workflow.
 * Specific
     * Terms should not be so open-ended that one endpoint could fulfill the Intent in a completely different way than another
 * Distinct
-    * Granular enough that Intent handlers can communicate key functional differences 
+    * Granular enough that Intent handlers can communicate key functional differences
 
 ### Namespaces ###
-All standard Intent names are reserved. Applications may use their own Intents ad hoc. 
+All standard Intent names are reserved. Applications may use their own Intents ad hoc.
 However, there is a need for applications to ensure that their Intents avoid collision. The recommended approach here is to use the app name as the noun. For example, the ‘myChart’ App may expose the ‘ViewChart’ intent and the ‘myChart.Foo’ proprietary Intent.
 
 ## Initial Set of Standard Intents ##


### PR DESCRIPTION
- ensure all previous spec documents have version number included
- update changelog
- reduce amount of builds (Node 14 only, no Mac)