### PR TITLE
chore: upgrade to at least y18n 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,9 @@
   },
   "resolutions": {
     "node-fetch": "^2.6.1",
+    "node-notifier": "^8.0.1",
     "yargs-parser": "^13.1.2",
-    "node-notifier": "^8.0.1"
+    "y18n": "^4.0.1"
   },
   "devDependencies": {
     "husky": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6706,10 +6706,10 @@ xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+"y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0, y18n@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yaml@^1.10.0, yaml@^1.5.0, yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
- fix high security vulnerability