### PR TITLE
feat: add fdc3Ready helper function and getInfo to npm package exports

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 # ignore folders
 website
 dist
+src/app-directory/*/target

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -53,24 +53,33 @@ The [`@finos/fdc3` npm package](https://www.npmjs.com/package/@finos/fdc3) provi
 ```ts
 import * as fdc3 from '@finos/fdc3'
 
-const listener = fdc3.addIntentListener('ViewAnalysis', context => {
-  // do something
-})
+async function fdc3Action() {
+  // all asynchronous function will implicitly check if window.fdc3 is defined,
+  // and wait for the fdc3Ready event if it isn't (with a default timeout of 5 seconds)
+  await fdc3.raiseIntent('ViewAnalysis', {
+      type: 'fdc3.instrument',
+      id: { ticker: 'AAPL' }
+  })
+}
 ```
 
 Alternatively you can also import individual operations directly:
 
 ```ts
-import { raiseIntent } from '@finos/fdc3'
+import { fdc3Ready, addIntentListener } from '@finos/fdc3'
 
-await raiseIntent('ViewAnalysis', {
-    type: 'fdc3.instrument',
-    id: { ticker: 'AAPL' }
-})
+async function fdc3Action() {
+  // for synchronous functions, like broadcast or adding a listener, it is recommend to wait for fdc3 to be ready yourself,
+  // as the synchronous function can only check if window.fdc3 is defined, and throw if it isn't
+  await fdc3Ready();
+  const listener = addIntentListener('ViewAnalysis', instrument => {
+    console.log('View analysis for ' + instrument.id.ticker);
+  })
+}
 ```
 
-The npm package will take care of checking for the existence of the global `fdc3` object, and wait for the `fdc3Ready` event, or throw an error if FDC3 is not supported.
-
+#### See also
+* [`fdc3Ready() Function`](ref/Globals#fdc3ready-function)
 
 
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -53,29 +53,22 @@ The [`@finos/fdc3` npm package](https://www.npmjs.com/package/@finos/fdc3) provi
 ```ts
 import * as fdc3 from '@finos/fdc3'
 
-async function fdc3Action() {
-  // all asynchronous function will implicitly check if window.fdc3 is defined,
-  // and wait for the fdc3Ready event if it isn't (with a default timeout of 5 seconds)
-  await fdc3.raiseIntent('ViewAnalysis', {
-      type: 'fdc3.instrument',
-      id: { ticker: 'AAPL' }
-  })
-}
+await fdc3.raiseIntent('ViewAnalysis', {
+    type: 'fdc3.instrument',
+    id: { ticker: 'AAPL' }
+})
 ```
 
-Alternatively you can also import individual operations directly:
+It also includes a helper function you can use to wait for FDC3 to become available:
 
 ```ts
 import { fdc3Ready, addIntentListener } from '@finos/fdc3'
 
-async function fdc3Action() {
-  // for synchronous functions, like broadcast or adding a listener, it is recommend to wait for fdc3 to be ready yourself,
-  // as the synchronous function can only check if window.fdc3 is defined, and throw if it isn't
-  await fdc3Ready();
-  const listener = addIntentListener('ViewAnalysis', instrument => {
-    console.log('View analysis for ' + instrument.id.ticker);
-  })
-}
+await fdc3Ready();
+
+const listener = addIntentListener('ViewAnalysis', instrument => {
+  // handle intent
+})
 ```
 
 #### See also

--- a/docs/api/ref/Globals.md
+++ b/docs/api/ref/Globals.md
@@ -52,7 +52,7 @@ import { fdc3Ready, broadcast } from '@finos/fdc3'
 
 async function fdc3Action() {
   try {
-    await fdc3Ready(1000); // wait for 1 second
+    await fdc3Ready(1000); // wait for (at most) 1 second
     broadcast({
       type: 'fdc3.instrument',
       id: { ticker: 'AAPL' }

--- a/docs/api/ref/Globals.md
+++ b/docs/api/ref/Globals.md
@@ -35,18 +35,15 @@ function fdc3Action() {
 if (window.fdc3) {
   fdc3Action();
 } else {
-  window.addEventListener("fdc3Ready", fdc3Action);
+  window.addEventListener('fdc3Ready', fdc3Action);
 }
 ```
 
 ## `fdc3Ready()` Function
 
-If you are using the `@finos/fdc3` NPM package, it includes a wrapper function that automatically waits on the `fdc3Ready` event for you.
+If you are using the `@finos/fdc3` NPM package, it includes a handy wrapper function that will check for the existence of `window.fdc3` and wait on the `fdc3Ready` event for you.
 
-It will resolve immediately if the `window.fdc3` global is already defined, or reject with an error if the `fdc3Ready` event doesn't fire after a
-default timeout of 5 seconds.
-
-All asynchronous functions in the package include this call automatically. You can override the amount of milliseconds to wait if you like.
+It returns a promise that will resolve immediately if the `window.fdc3` global is already defined, or reject with an error if the `fdc3Ready` event doesn't fire after a specified timeout period (default: 5 seconds).
 
 ### Example
 
@@ -56,7 +53,7 @@ import { fdc3Ready, broadcast } from '@finos/fdc3'
 async function fdc3Action() {
   try {
     await fdc3Ready(1000); // wait for 1 second
-    fdc3.broadcast({
+    broadcast({
       type: 'fdc3.instrument',
       id: { ticker: 'AAPL' }
     })

--- a/docs/api/ref/Globals.md
+++ b/docs/api/ref/Globals.md
@@ -38,3 +38,33 @@ if (window.fdc3) {
   window.addEventListener("fdc3Ready", fdc3Action);
 }
 ```
+
+## `fdc3Ready()` Function
+
+If you are using the `@finos/fdc3` NPM package, it includes a wrapper function that automatically waits on the `fdc3Ready` event for you.
+
+It will resolve immediately if the `window.fdc3` global is already defined, or reject with an error if the `fdc3Ready` event doesn't fire after a
+default timeout of 5 seconds.
+
+All asynchronous functions in the package include this call automatically. You can override the amount of milliseconds to wait if you like.
+
+### Example
+
+```ts
+import { fdc3Ready, broadcast } from '@finos/fdc3'
+
+async function fdc3Action() {
+  try {
+    await fdc3Ready(1000); // wait for 1 second
+    fdc3.broadcast({
+      type: 'fdc3.instrument',
+      id: { ticker: 'AAPL' }
+    })
+  } catch (error) {
+    // handle error
+  }
+}
+```
+
+
+

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "singleQuote": true,
     "arrowParens": "avoid",
     "trailingComma": "es5",
-    "endOfLine": "auto"
+    "endOfLine": "auto",
+    "printWidth": 120
   },
   "resolutions": {
     "node-fetch": "^2.6.1",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "husky": "^4.3.0",
+    "jest-mock-extended": "^1.0.13",
     "quicktype": "^15.0.258",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.1",

--- a/src/api/Channel.ts
+++ b/src/api/Channel.ts
@@ -68,8 +68,5 @@ export interface Channel {
   /**
    * Adds a listener for incoming contexts of the specified context type whenever a broadcast happens on this channel.
    */
-  addContextListener(
-    contextType: string | null,
-    handler: ContextHandler
-  ): Listener;
+  addContextListener(contextType: string | null, handler: ContextHandler): Listener;
 }

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -124,11 +124,7 @@ export interface DesktopAgent {
    * await fdc3.raiseIntent("StartChat", context, appMetadata);
    * ```
    */
-  raiseIntent(
-    intent: string,
-    context: Context,
-    app?: TargetApp
-  ): Promise<IntentResolution>;
+  raiseIntent(intent: string, context: Context, app?: TargetApp): Promise<IntentResolution>;
 
   /**
    * Raises a context to the desktop agent to resolve with one of the possible Intents for that context.
@@ -136,10 +132,7 @@ export interface DesktopAgent {
    * await fdc3.raiseIntentForContext(context);
    * ```
    */
-  raiseIntentForContext(
-    context: Context,
-    app?: TargetApp
-  ): Promise<IntentResolution>;
+  raiseIntentForContext(context: Context, app?: TargetApp): Promise<IntentResolution>;
 
   /**
    * Adds a listener for incoming Intents from the Agent.
@@ -155,10 +148,7 @@ export interface DesktopAgent {
   /**
    * Adds a listener for the broadcast of a specific type of context object.
    */
-  addContextListener(
-    contextType: string | null,
-    handler: ContextHandler
-  ): Listener;
+  addContextListener(contextType: string | null, handler: ContextHandler): Listener;
 
   /**
    * Retrieves a list of the System channels available for the app to join

--- a/src/api/Methods.ts
+++ b/src/api/Methods.ts
@@ -1,113 +1,112 @@
-import {
-  AppIntent,
-  Channel,
-  Context,
-  ContextHandler,
-  IntentResolution,
-  Listener,
-  ImplementationMetadata,
-} from '..';
+import { AppIntent, Channel, Context, ContextHandler, IntentResolution, Listener, ImplementationMetadata } from '..';
 import { TargetApp } from './Types';
 
-const unavailableError = new Error(
-  'FDC3 DesktopAgent not available at `window.fdc3`.'
+const DEFAULT_TIMEOUT = 5000;
+
+const unavailableError = new Error('FDC3 DesktopAgent not available at `window.fdc3`.');
+
+const unavailableAfterReadyError = new Error(
+  'FDC3 DesktopAgent not available at `window.fdc3`, despite `fdc3Ready` event firing.'
 );
 
-const rejectIfNoGlobal = (f: () => Promise<any>) => {
-  return window.fdc3 ? f() : Promise.reject(unavailableError);
-};
-
-const throwIfNoGlobal = (f: () => any) => {
+function throwIfNoGlobal() {
   if (!window.fdc3) {
     throw unavailableError;
   }
-  return f();
+}
+
+export const fdc3Ready = async (waitForMs = DEFAULT_TIMEOUT): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    // if the global is already available resolve immediately
+    if (window.fdc3) {
+      resolve();
+    } else {
+      // if its not available setup a timeout to return a rejected promise
+      const timeout = setTimeout(() => (window.fdc3 ? resolve() : reject(unavailableError)), waitForMs);
+      // listen for the fdc3Ready event
+      window.addEventListener(
+        'fdc3Ready',
+        () => {
+          clearTimeout(timeout);
+          window.fdc3 ? resolve() : reject(unavailableAfterReadyError);
+        },
+        { once: true }
+      );
+    }
+  });
 };
 
-export const open: (app: TargetApp, context?: Context) => Promise<void> = (
-  app,
-  context
-) => {
-  return rejectIfNoGlobal(() => window.fdc3.open(app, context));
-};
+export async function open(app: TargetApp, context?: Context): Promise<void> {
+  await fdc3Ready();
+  return window.fdc3.open(app, context);
+}
 
-export const findIntent: (
-  intent: string,
-  context?: Context
-) => Promise<AppIntent> = (intent, context) => {
-  return rejectIfNoGlobal(() => window.fdc3.findIntent(intent, context));
-};
+export async function findIntent(intent: string, context?: Context): Promise<AppIntent> {
+  await fdc3Ready();
+  return window.fdc3.findIntent(intent, context);
+}
 
-export const findIntentsByContext: (
-  context: Context
-) => Promise<Array<AppIntent>> = context => {
-  return rejectIfNoGlobal(() => window.fdc3.findIntentsByContext(context));
-};
+export async function findIntentsByContext(context: Context): Promise<AppIntent[]> {
+  await fdc3Ready();
+  return window.fdc3.findIntentsByContext(context);
+}
 
-export const broadcast: (context: Context) => void = context => {
-  throwIfNoGlobal(() => window.fdc3.broadcast(context));
-};
+export function broadcast(context: Context): void {
+  // cannot use await fdc3Ready(), will only check window.fdc3 is defined, and throw if it isn't
+  throwIfNoGlobal();
+  window.fdc3.broadcast(context);
+}
 
-export const raiseIntent: (
-  intent: string,
-  context: Context,
-  app?: TargetApp
-) => Promise<IntentResolution> = (intent, context, app) => {
-  return rejectIfNoGlobal(() => window.fdc3.raiseIntent(intent, context, app));
-};
+export async function raiseIntent(intent: string, context: Context, app?: TargetApp): Promise<IntentResolution> {
+  await fdc3Ready();
+  return window.fdc3.raiseIntent(intent, context, app);
+}
 
-export const raiseIntentForContext: (
-  context: Context,
-  app?: TargetApp
-) => Promise<IntentResolution> = (context, app) => {
-  return rejectIfNoGlobal(() =>
-    window.fdc3.raiseIntentForContext(context, app)
-  );
-};
+export async function raiseIntentForContext(context: Context, app?: TargetApp): Promise<IntentResolution> {
+  await fdc3Ready();
+  return window.fdc3.raiseIntentForContext(context, app);
+}
 
-export const addIntentListener: (
-  intent: string,
-  handler: ContextHandler
-) => Listener = (intent, handler) => {
-  return throwIfNoGlobal(() => window.fdc3.addIntentListener(intent, handler));
-};
+export function addIntentListener(intent: string, handler: ContextHandler): Listener {
+  // cannot use await fdc3Ready(), will only check window.fdc3 is defined, and throw if it isn't
+  throwIfNoGlobal();
+  return window.fdc3.addIntentListener(intent, handler);
+}
 
-export const addContextListener: (
-  contextTypeOrHandler: string | ContextHandler,
-  handler?: ContextHandler
-) => Listener = (a, b) => {
-  if (typeof a !== 'function') {
-    return throwIfNoGlobal(() =>
-      window.fdc3.addContextListener(a as string, b as ContextHandler)
-    );
+export function addContextListener(contextTypeOrHandler: string | ContextHandler, handler?: ContextHandler): Listener {
+  // cannot use await fdc3Ready(), will only check window.fdc3 is defined, and throw if it isn't
+  throwIfNoGlobal();
+  if (typeof contextTypeOrHandler !== 'function') {
+    return window.fdc3.addContextListener(contextTypeOrHandler as string, handler as ContextHandler);
   } else {
-    return throwIfNoGlobal(() =>
-      window.fdc3.addContextListener(a as ContextHandler)
-    );
+    return window.fdc3.addContextListener(contextTypeOrHandler as ContextHandler);
   }
-};
+}
 
-export const getSystemChannels: () => Promise<Array<Channel>> = () => {
-  return rejectIfNoGlobal(() => window.fdc3.getSystemChannels());
-};
+export async function getSystemChannels(): Promise<Channel[]> {
+  await fdc3Ready();
+  return window.fdc3.getSystemChannels();
+}
 
-export const joinChannel: (channelId: string) => Promise<void> = channelId => {
-  return rejectIfNoGlobal(() => window.fdc3.joinChannel(channelId));
-};
+export async function joinChannel(channelId: string): Promise<void> {
+  await fdc3Ready();
+  return await window.fdc3.joinChannel(channelId);
+}
 
-export const getOrCreateChannel: (
-  channelId: string
-) => Promise<Channel> = channelId => {
-  return rejectIfNoGlobal(() => window.fdc3.getOrCreateChannel(channelId));
-};
+export async function getOrCreateChannel(channelId: string): Promise<Channel> {
+  await fdc3Ready();
+  return window.fdc3.getOrCreateChannel(channelId);
+}
 
-export const getCurrentChannel: () => Promise<Channel | null> = () => {
-  return rejectIfNoGlobal(() => window.fdc3.getCurrentChannel());
-};
+export async function getCurrentChannel(): Promise<Channel | null> {
+  await fdc3Ready();
+  return await window.fdc3.getCurrentChannel();
+}
 
-export const leaveCurrentChannel: () => Promise<void> = () => {
-  return rejectIfNoGlobal(() => window.fdc3.leaveCurrentChannel());
-};
+export async function leaveCurrentChannel(): Promise<void> {
+  await fdc3Ready();
+  return window.fdc3.leaveCurrentChannel();
+}
 
 /**
  * Compare numeric semver version number strings (in the form `1.2.3`).
@@ -119,19 +118,12 @@ export const leaveCurrentChannel: () => Promise<void> = () => {
  * @param a
  * @param b
  */
-export const compareVersionNumbers: (a: string, b: string) => number | null = (
-  a,
-  b
-) => {
+export const compareVersionNumbers: (a: string, b: string) => number | null = (a, b) => {
   try {
     let aVerArr = a.split('.').map(Number);
     let bVerArr = b.split('.').map(Number);
-    for (
-      let index = 0;
-      index < Math.max(aVerArr.length, bVerArr.length);
-      index++
-    ) {
-      /* If one version number has more digits and the other does not, and they are otherwise equal, 
+    for (let index = 0; index < Math.max(aVerArr.length, bVerArr.length); index++) {
+      /* If one version number has more digits and the other does not, and they are otherwise equal,
          assume the longer is greater. E.g. 1.1.1 > 1.1 */
       if (index === aVerArr.length || aVerArr[index] < bVerArr[index]) {
         return -1;
@@ -155,10 +147,10 @@ export const compareVersionNumbers: (a: string, b: string) => number | null = (
  * @param metadata
  * @param version
  */
-export const versionIsAtLeast: (
-  metadata: ImplementationMetadata,
-  version: string
-) => boolean | null = (metadata, version) => {
+export const versionIsAtLeast: (metadata: ImplementationMetadata, version: string) => boolean | null = (
+  metadata,
+  version
+) => {
   let comparison = compareVersionNumbers(metadata.fdc3Version, version);
   return comparison === null ? null : comparison >= 0 ? true : false;
 };

--- a/src/api/Methods.ts
+++ b/src/api/Methods.ts
@@ -4,7 +4,7 @@ import { TargetApp } from './Types';
 const DEFAULT_TIMEOUT = 5000;
 
 const UnavailableError = new Error('FDC3 DesktopAgent not available at `window.fdc3`.');
-const TimeoutError = new Error('Timed out waiting for fdc3Ready event.');
+const TimeoutError = new Error('Timed out waiting for `fdc3Ready` event.');
 const UnexpectedError = new Error('`fdc3Ready` event fired, but `window.fdc3` not set to DesktopAgent.');
 
 function rejectIfNoGlobal(f: () => Promise<any>) {

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -180,15 +180,9 @@ export class Convert {
 
 function invalidValue(typ: any, val: any, key: any = ''): never {
   if (key) {
-    throw Error(
-      `Invalid value for key "${key}". Expected type ${JSON.stringify(
-        typ
-      )} but got ${JSON.stringify(val)}`
-    );
+    throw Error(`Invalid value for key "${key}". Expected type ${JSON.stringify(typ)} but got ${JSON.stringify(val)}`);
   }
-  throw Error(
-    `Invalid value ${JSON.stringify(val)} for type ${JSON.stringify(typ)}`
-  );
+  throw Error(`Invalid value ${JSON.stringify(val)} for type ${JSON.stringify(typ)}`);
 }
 
 function jsonToJSProps(typ: any): any {
@@ -249,20 +243,14 @@ function transform(val: any, typ: any, getProps: any, key: any = ''): any {
     return d;
   }
 
-  function transformObject(
-    props: { [k: string]: any },
-    additional: any,
-    val: any
-  ): any {
+  function transformObject(props: { [k: string]: any }, additional: any, val: any): any {
     if (val === null || typeof val !== 'object' || Array.isArray(val)) {
       return invalidValue('object', val);
     }
     const result: any = {};
     Object.getOwnPropertyNames(props).forEach(key => {
       const prop = props[key];
-      const v = Object.prototype.hasOwnProperty.call(val, key)
-        ? val[key]
-        : undefined;
+      const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
       result[prop.key] = transform(v, prop.typ, getProps, prop.key);
     });
     Object.getOwnPropertyNames(val).forEach(key => {

--- a/test/ContextTypes.test.ts
+++ b/test/ContextTypes.test.ts
@@ -15,8 +15,6 @@ describe('Context types', () => {
   });
 
   it('Convert contact to json', () => {
-    expect(JSON.parse(Convert.contactToJson(contact))).toEqual(
-      JSON.parse(json)
-    );
+    expect(JSON.parse(Convert.contactToJson(contact))).toEqual(JSON.parse(json));
   });
 });

--- a/test/Methods.test.ts
+++ b/test/Methods.test.ts
@@ -3,37 +3,28 @@ import {
   addContextListener,
   addIntentListener,
   broadcast,
+  compareVersionNumbers,
   ContextHandler,
   ContextTypes,
   DesktopAgent,
+  fdc3Ready,
   findIntent,
   findIntentsByContext,
   getCurrentChannel,
+  getInfo,
   getOrCreateChannel,
   getSystemChannels,
+  ImplementationMetadata,
   joinChannel,
   leaveCurrentChannel,
   open,
-  fdc3Ready,
   raiseIntent,
   raiseIntentForContext,
-  getInfo,
-  ImplementationMetadata,
-  compareVersionNumbers,
   versionIsAtLeast,
 } from '../src';
 
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toRejectWithUnavailableError: () => CustomMatcherResult;
-      toThrowUnavailableError: () => CustomMatcherResult;
-    }
-  }
-}
-
 const UnavailableError = new Error('FDC3 DesktopAgent not available at `window.fdc3`.');
-const TimeoutError = new Error('Timed out waiting for fdc3Ready event.');
+const TimeoutError = new Error('Timed out waiting for `fdc3Ready` event.');
 const UnexpectedError = new Error('`fdc3Ready` event fired, but `window.fdc3` not set to DesktopAgent.');
 
 const ContactContext = {
@@ -54,62 +45,62 @@ expect.extend({
 
 describe('test ES6 module', () => {
   describe('without `window.fdc3` global', () => {
-    test('open should reject', () => {
-      expect(open(expect.any(String))).toRejectWithUnavailableError();
+    test('open should reject', async () => {
+      await expect(open(expect.any(String))).rejects.toEqual(UnavailableError);
     });
 
-    test('findIntent should reject', () => {
-      expect(findIntent(expect.any(String))).toRejectWithUnavailableError();
+    test('findIntent should reject', async () => {
+      await expect(findIntent(expect.any(String))).rejects.toEqual(UnavailableError);
     });
 
-    test('findIntentsByContext should reject', () => {
-      expect(findIntentsByContext(expect.any(Object))).toRejectWithUnavailableError();
+    test('findIntentsByContext should reject', async () => {
+      await expect(findIntentsByContext(expect.any(Object))).rejects.toEqual(UnavailableError);
     });
 
-    test('broadcast should throw', () => {
-      expect(() => broadcast(expect.any(Object))).toThrowUnavailableError();
+    test('broadcast should throw', async () => {
+      expect(() => broadcast(expect.any(Object))).toThrowError(UnavailableError);
     });
 
-    test('raiseIntent should reject', () => {
-      expect(raiseIntent(expect.any(String), expect.any(Object))).toRejectWithUnavailableError();
+    test('raiseIntent should reject', async () => {
+      await expect(raiseIntent(expect.any(String), expect.any(Object))).rejects.toEqual(UnavailableError);
     });
 
-    test('raiseIntentForContext should reject', () => {
-      expect(raiseIntentForContext(expect.any(Object))).toRejectWithUnavailableError();
+    test('raiseIntentForContext should reject', async () => {
+      await expect(raiseIntentForContext(expect.any(Object))).rejects.toEqual(UnavailableError);
     });
 
     test('addIntentListener should throw', () => {
-      expect(() => addIntentListener(expect.any(String), expect.any(Function))).toThrowUnavailableError();
+      expect(() => addIntentListener(expect.any(String), expect.any(Function))).toThrowError(UnavailableError);
     });
 
     test('addContextListener should throw', () => {
-      expect(() => addContextListener(expect.any(Object))).toThrowUnavailableError();
+      expect(() => addContextListener(expect.any(Object))).toThrowError(UnavailableError);
 
-      expect(() => addContextListener(expect.any(String), expect.any(Object))).toThrowUnavailableError();
+      expect(() => addContextListener(expect.any(String), expect.any(Object))).toThrowError(UnavailableError);
     });
 
-    test('getSystemChannels should reject', () => {
-      expect(getSystemChannels()).toRejectWithUnavailableError();
+    test('getSystemChannels should reject', async () => {
+      await expect(getSystemChannels()).rejects.toEqual(UnavailableError);
     });
 
-    test('joinChannel should reject', () => {
-      expect(joinChannel(expect.any(String))).toRejectWithUnavailableError();
+    test('joinChannel should reject', async () => {
+      await expect(joinChannel(expect.any(String))).rejects.toEqual(UnavailableError);
     });
 
-    test('getOrCreateChannel should reject', () => {
-      expect(getOrCreateChannel(expect.any(String))).toRejectWithUnavailableError();
+    test('getOrCreateChannel should reject', async () => {
+      await expect(getOrCreateChannel(expect.any(String))).rejects.toEqual(UnavailableError);
     });
 
-    test('getCurrentChannel should reject', () => {
-      expect(getCurrentChannel()).toRejectWithUnavailableError();
+    test('getCurrentChannel should reject', async () => {
+      await expect(getCurrentChannel()).rejects.toEqual(UnavailableError);
     });
 
-    test('leaveCurrentChannel should reject', () => {
-      expect(leaveCurrentChannel()).toRejectWithUnavailableError();
+    test('leaveCurrentChannel should reject', async () => {
+      await expect(leaveCurrentChannel()).rejects.toEqual(UnavailableError);
     });
 
     test('getInfo should throw', () => {
-      expect(() => getInfo()).toThrowUnavailableError();
+      expect(() => getInfo()).toThrowError(UnavailableError);
     });
   });
 
@@ -122,26 +113,26 @@ describe('test ES6 module', () => {
       window.fdc3 = (undefined as unknown) as DesktopAgent;
     });
 
-    test('open should delegate to window.fdc3.open', () => {
+    test('open should delegate to window.fdc3.open', async () => {
       const target = 'MyApp';
 
-      open(target, ContactContext);
+      await open(target, ContactContext);
 
       expect(window.fdc3.open).toHaveBeenCalledTimes(1);
       expect(window.fdc3.open).toHaveBeenCalledWith(target, ContactContext);
     });
 
-    test('findIntent should delegate to window.fdc3.findIntent', () => {
+    test('findIntent should delegate to window.fdc3.findIntent', async () => {
       const intent = 'ViewChart';
 
-      findIntent(intent, ContactContext);
+      await findIntent(intent, ContactContext);
 
       expect(window.fdc3.findIntent).toHaveBeenCalledTimes(1);
       expect(window.fdc3.findIntent).toHaveBeenCalledWith(intent, ContactContext);
     });
 
-    test('findIntentsByContext should delegate to window.fdc3.findIntentsByContext', () => {
-      findIntentsByContext(ContactContext);
+    test('findIntentsByContext should delegate to window.fdc3.findIntentsByContext', async () => {
+      await findIntentsByContext(ContactContext);
 
       expect(window.fdc3.findIntentsByContext).toHaveBeenCalledTimes(1);
       expect(window.fdc3.findIntentsByContext).toHaveBeenCalledWith(ContactContext);
@@ -154,20 +145,20 @@ describe('test ES6 module', () => {
       expect(window.fdc3.broadcast).toHaveBeenCalledWith(ContactContext);
     });
 
-    test('raiseIntent should delegate to window.fdc3.raiseIntent', () => {
+    test('raiseIntent should delegate to window.fdc3.raiseIntent', async () => {
       const intent = 'ViewChart';
       const target = 'MyApp';
 
-      raiseIntent(intent, ContactContext, target);
+      await raiseIntent(intent, ContactContext, target);
 
       expect(window.fdc3.raiseIntent).toHaveBeenCalledTimes(1);
       expect(window.fdc3.raiseIntent).toHaveBeenCalledWith(intent, ContactContext, target);
     });
 
-    test('raiseIntentForContext should delegate to window.fdc3.raiseIntentForContext', () => {
+    test('raiseIntentForContext should delegate to window.fdc3.raiseIntentForContext', async () => {
       const app = 'MyApp';
 
-      raiseIntentForContext(ContactContext, app);
+      await raiseIntentForContext(ContactContext, app);
 
       expect(window.fdc3.raiseIntentForContext).toHaveBeenCalledTimes(1);
       expect(window.fdc3.raiseIntentForContext).toHaveBeenCalledWith(ContactContext, app);
@@ -196,40 +187,40 @@ describe('test ES6 module', () => {
       expect(window.fdc3.addContextListener).toHaveBeenNthCalledWith(2, handler2);
     });
 
-    test('getSystemChannels should delegate to window.fdc3.getSystemChannels', () => {
-      getSystemChannels();
+    test('getSystemChannels should delegate to window.fdc3.getSystemChannels', async () => {
+      await getSystemChannels();
 
       expect(window.fdc3.getSystemChannels).toHaveBeenCalledTimes(1);
       expect(window.fdc3.getSystemChannels).toHaveBeenCalledWith();
     });
 
-    test('joinChannel should delegate to window.fdc3.joinChannel', () => {
+    test('joinChannel should delegate to window.fdc3.joinChannel', async () => {
       const channelId = 'channel';
 
-      joinChannel(channelId);
+      await joinChannel(channelId);
 
       expect(window.fdc3.joinChannel).toHaveBeenCalledTimes(1);
       expect(window.fdc3.joinChannel).toHaveBeenCalledWith(channelId);
     });
 
-    test('getOrCreateChannel should delegate to window.fdc3.getOrCreateChannel', () => {
+    test('getOrCreateChannel should delegate to window.fdc3.getOrCreateChannel', async () => {
       const channelId = 'channel';
 
-      getOrCreateChannel(channelId);
+      await getOrCreateChannel(channelId);
 
       expect(window.fdc3.getOrCreateChannel).toHaveBeenCalledTimes(1);
       expect(window.fdc3.getOrCreateChannel).toHaveBeenCalledWith(channelId);
     });
 
-    test('getCurrentChannel should delegate to window.fdc3.getCurrentChannel', () => {
-      getCurrentChannel();
+    test('getCurrentChannel should delegate to window.fdc3.getCurrentChannel', async () => {
+      await getCurrentChannel();
 
       expect(window.fdc3.getCurrentChannel).toHaveBeenCalledTimes(1);
       expect(window.fdc3.getCurrentChannel).toHaveBeenCalledWith();
     });
 
-    test('leaveCurrentChannel should delegate to window.fdc3.leaveCurrentChannel', () => {
-      leaveCurrentChannel();
+    test('leaveCurrentChannel should delegate to window.fdc3.leaveCurrentChannel', async () => {
+      await leaveCurrentChannel();
 
       expect(window.fdc3.leaveCurrentChannel).toHaveBeenCalledTimes(1);
       expect(window.fdc3.leaveCurrentChannel).toHaveBeenCalledWith();
@@ -260,9 +251,7 @@ describe('test ES6 module', () => {
       window.fdc3 = (undefined as unknown) as DesktopAgent;
     });
 
-    test('resolves immediately if `window.fdc3` is already defined', () => {
-      expect.assertions(4);
-
+    test('resolves immediately if `window.fdc3` is already defined', async () => {
       // set fdc3 object and call fdc3Ready
       window.fdc3 = mock<DesktopAgent>();
       const promise = fdc3Ready();
@@ -270,38 +259,36 @@ describe('test ES6 module', () => {
       expect(setTimeout).not.toHaveBeenCalled();
       expect(clearTimeout).not.toHaveBeenCalled();
       expect(eventListeners).not.toHaveProperty('fdc3Ready');
-      expect(promise).resolves.toBe(undefined);
+      await expect(promise).resolves.toBe(undefined);
     });
 
-    test('waits for specified milliseconds', () => {
-      expect.assertions(3);
+    test('waits for specified milliseconds', async () => {
+      const waitForMs = 1000;
 
-      const promise = fdc3Ready(1000);
+      const promise = fdc3Ready(waitForMs);
 
       expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), waitForMs);
 
-      jest.advanceTimersToNextTimer();
+      jest.advanceTimersByTime(waitForMs);
 
-      expect(promise).rejects.toThrow(UnavailableError);
+      await expect(promise).rejects.toEqual(TimeoutError);
     });
 
-    test('waits for 5000 milliseconds by default', () => {
-      expect.assertions(3);
+    test('waits for 5000 milliseconds by default', async () => {
+      const defaultWaitForMs = 5000;
 
       const promise = fdc3Ready();
 
       expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 5000);
+      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), defaultWaitForMs);
 
-      jest.advanceTimersToNextTimer();
+      jest.advanceTimersByTime(defaultWaitForMs);
 
-      expect(promise).rejects.toThrow(TimeoutError);
+      await expect(promise).rejects.toEqual(TimeoutError);
     });
 
     test('`fdc3Ready` event cancels timeout and rejects if `window.fdc3` is not defined', () => {
-      expect.assertions(5);
-
       const promise = fdc3Ready();
 
       expect(setTimeout).toHaveBeenCalledTimes(1);
@@ -312,12 +299,10 @@ describe('test ES6 module', () => {
       eventListeners['fdc3Ready']();
 
       expect(clearTimeout).toHaveBeenCalledTimes(1);
-      expect(promise).rejects.toThrow(UnexpectedError);
+      return expect(promise).rejects.toEqual(UnexpectedError);
     });
 
-    test('`fdc3Ready` event cancels timeout and resolves if `window.fdc3` is defined', () => {
-      expect.assertions(5);
-
+    test('`fdc3Ready` event cancels timeout and resolves if `window.fdc3` is defined', async () => {
       const promise = fdc3Ready();
 
       expect(setTimeout).toHaveBeenCalledTimes(1);
@@ -329,7 +314,7 @@ describe('test ES6 module', () => {
       eventListeners['fdc3Ready']();
 
       expect(clearTimeout).toHaveBeenCalledTimes(1);
-      expect(promise).resolves.toBe(undefined);
+      await expect(promise).resolves.toBe(undefined);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,6 +3812,13 @@ jest-message-util@^25.5.0:
     slash "^3.0.0"
     stack-utils "^1.0.1"
 
+jest-mock-extended@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-1.0.13.tgz#07d7b58ea45a4bad8d95ff8ae30ca8f6171c9289"
+  integrity sha512-fs621RgUK9Z6frJWDA75Gb9Vpm1d9HbpuAWjIu12hZTNls+VVdlJl/43xrqz70CYUbJPnfkiTfLwue9mkKC1ww==
+  dependencies:
+    ts-essentials "^4.0.0"
+
 jest-mock@^25.5.0:
   version "25.5.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-25.5.0.tgz#a91a54dabd14e37ecd61665d6b6e06360a55387a"
@@ -6222,6 +6229,11 @@ tr46@^1.0.1:
   integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
   dependencies:
     punycode "^2.1.0"
+
+ts-essentials@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-4.0.0.tgz#506c42b270bbd0465574b90416533175b09205ab"
+  integrity sha512-uQJX+SRY9mtbKU+g9kl5Fi7AEMofPCvHfJkQlaygpPmHPZrtgaBqbWFOYyiA47RhnSwwnXdepUJrgqUYxoUyhQ==
 
 ts-jest@^25.3.1:
   version "25.5.1"


### PR DESCRIPTION
To add support to the FDC3 NPM package for the new `fdc3Ready` event, this adds an asynchronous `fdc3Ready()` function that has the following properties:
- it will resolve immediately if `window.fdc3` is already defined
- it has a default timeout of 5 seconds (as recommend by @kriswest), but can be called with a smaller wait time as well, e.g. `await fdc3Ready(1000)`
- after the timeout expires, or the `fdc3Ready` event is fired, it will again check if `window.fdc3` is defined, and resolve/reject as appropriate

Also adds the `getInfo` method as an exported function, which was missing.

Tests for all of the above are included, as is documentation on the FDC3 website.

Example usage:

```ts
import { fdc3Ready, broadcast } from '@finos/fdc3'

try {
  await fdc3Ready(1000) // wait 1 second before timing out
  fdc3.broadcast({ ... })
} catch (error) {
  // handle
}
```