### PR TITLE
Correct `Generall` spelling mistake in FDC3 General Meeting issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-meeting.md
+++ b/.github/ISSUE_TEMPLATE/general-meeting.md
@@ -1,7 +1,7 @@
 ---
 name: General Meeting
 about: minutes for an FDC3 General Meeting
-title: 'Generall Meeting - mmm dd, yyyy'
+title: 'General Meeting - mmm dd, yyyy'
 labels: General meeting, meeting
 assignees: ''
 


### PR DESCRIPTION
## Description
This PR corrects the `Generall` spelling mistake in the **FDC3 General Meeting** agenda template. The changes made are highlighted below ... 

### From
`title: 'Generall Meeting - mmm dd, yyyy'`

### To
`title: 'General Meeting - mmm dd, yyyy'`