### PR TITLE
Docs: fixing broken link

### DIFF
--- a/website/versioned_docs/version-1.2/fdc3-intro.md
+++ b/website/versioned_docs/version-1.2/fdc3-intro.md
@@ -43,7 +43,7 @@ FDC3 uses the Apache 2.0 open source license for all deliverables.
 
 ## Where should I go next?
 
-- Have a look at the [supported platforms](supported-Platforms) or [common use cases](use-cases/overview).
+- Have a look at the [supported platforms](supported-platforms) or [common use cases](use-cases/overview).
 - Visit FDC3 [on GitHub](https://github.com/finos/FDC3).
 - Download and install our [npm package](https://www.npmjs.com/package/@finos/fdc3).
 - Try out an FDC3-compliant implementation, e.g. this [browser extension](https://github.com/finos/fdc3-desktop-agent).


### PR DESCRIPTION
Add https://github.com/finos/FDC3/pull/392 to the 1.2 version of docs.