### PR TITLE
Fix context definition in API documentation

### DIFF
--- a/docs/api/ref/Types.md
+++ b/docs/api/ref/Types.md
@@ -7,16 +7,17 @@ FDC3 API operations make use of several type declarations.
 ## `Context`
 
 ```typescript
-type Context = object;
+interface Context {
+  id?: { [key: string]: string };
+  name?: string;
+  type: string;
+}
 ```
 
-The base object that all contexts should extend.
+The base interface that all contexts should extend: a context data object adhering to the [Context Data Specification](../../context/spec).
 
-The API specification allows this to be any object, but typically this is supposed to be a context data object adhering to the [Context Data Specification](../../context/spec).
+This means that it must at least have a `type` property that indicates what type of data it represents, e.g. `'fdc3.contact'`. The `type` property of context objects is important for certain FDC3 operations, like [`Channel.getCurrentContext`](Channel#getCurrentContext) and [`DesktopAgent.addContextListener`](DesktopAgent#addContextListener), which allows you to filter contexts by their type.
 
-This means that it must at least have a `type` property that indicates what type of data it represents, e.g. `'fdc3.contact'`.
-
-The `type` property of context objects is important for certain FDC3 operations, like [`Channel.getCurrentContext`](Channel#getCurrentContext) and [`DesktopAgent.addContextListener`](DesktopAgent#addContextListener), which allows you to filter contexts by their type.
 
 #### See also
 * [`ContextHandler`](#contexthandler)

--- a/website/versioned_docs/version-1.2/api/ref/Types.md
+++ b/website/versioned_docs/version-1.2/api/ref/Types.md
@@ -9,16 +9,17 @@ FDC3 API operations make use of several type declarations.
 ## `Context`
 
 ```typescript
-type Context = object;
+interface Context {
+  id?: { [key: string]: string };
+  name?: string;
+  type: string;
+}
 ```
 
-The base object that all contexts should extend.
+The base interface that all contexts should extend: a context data object adhering to the [Context Data Specification](../../context/spec).
 
-The API specification allows this to be any object, but typically this is supposed to be a context data object adhering to the [Context Data Specification](../../context/spec).
+This means that it must at least have a `type` property that indicates what type of data it represents, e.g. `'fdc3.contact'`. The `type` property of context objects is important for certain FDC3 operations, like [`Channel.getCurrentContext`](Channel#getCurrentContext) and [`DesktopAgent.addContextListener`](DesktopAgent#addContextListener), which allows you to filter contexts by their type.
 
-This means that it must at least have a `type` property that indicates what type of data it represents, e.g. `'fdc3.contact'`.
-
-The `type` property of context objects is important for certain FDC3 operations, like [`Channel.getCurrentContext`](Channel#getCurrentContext) and [`DesktopAgent.addContextListener`](DesktopAgent#addContextListener), which allows you to filter contexts by their type.
 
 #### See also
 * [`ContextHandler`](#contexthandler)


### PR DESCRIPTION
Resolves #405 by importing the definition of the context Object from the Context spec and updating documentation.

Once merged should be added to the 1.2 tag