### PR TITLE
Updating reference to point-in-time revision of IP policy and standards governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ please email [fdc3-participants+subscribe@finos.org] making your intent to parti
 Please note that standard participants are bound to the provisions in the [FINOS IP Policy] as described in the [FINOS standards governance].
 
 [fdc3-participants+subscribe@finos.org]: mailto:fdc3-participants+subscribe@finos.org?subject=Please%20enroll%20me%20as%20FDC3%20standard%20participant&amp;cc=fdc3-pmc%40finos.org&amp;body=HI%2C%20my%20name%20is%20%3CFirstName%20LastName%3E%20and%20I%27d%20like%20to%20formally%20participate%20to%20the%20FDC3%20standard%20process.%20I%20plan%20to%20contribute%20as%20%3Cindividual%7Con%20behalf%20of%20organizationName%3E%20and%20I%20have%20reviewed%20the%20policies%20described%20at%20https%3A%2F%2Fgithub.com%2Ffinos%2Fcommunity%2Ftree%2Fmaster%2Fgovernance%2FStandards-Projects%20.%20Thank%20you!
-[FINOS IP Policy]: https://github.com/finos/community/blob/master/governance/IP-Policy.pdf
-[FINOS standards governance]: https://github.com/finos/community/tree/master/governance/Standards-Projects
+[FINOS IP Policy]: https://github.com/finos/community/blob/db11c11b80651b8bc888e7cb1d56d20afdf2a346/governance/IP-Policy.pdf
+[FINOS standards governance]: https://github.com/finos/community/tree/db11c11b80651b8bc888e7cb1d56d20afdf2a346/governance/Standards-Projects
 
 ## The Product Management Committee
 


### PR DESCRIPTION
Referencing proper version of standards governance, if and until new version is adopted by FDC3, now that default FINOS standard governance has changed. 

Once discussions on adopting the new CSL based standard governance are complete, we can revise this to point to the new [default standard governance](https://github.com/finos/community/tree/master/governance/Standards-Projects).