### PR TITLE
Fix broken link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ yarn add @finos/fdc3
 pnpm install @finos/fdc3
 ```
 
-Note that the web application still needs to run in the context of an FDC3 desktop agent to work. For more details, please see the [relevant documentation](https://fdc3.finos.org/docs/installation).
+Note that the web application still needs to run in the context of an FDC3 desktop agent to work. For more details, please see the [relevant documentation](https://fdc3.finos.org/docs/supported-platforms).
 
 ### Usage
 


### PR DESCRIPTION
A broken link in the Readme (which ends up on NPM) was pointed out to me. The link was to https://fdc3.finos.org/docs/installation, I believe it was supposed to point to https://fdc3.finos.org/docs/supported-platforms as the content was talking about running within the context of a Desktop Agent implementation, can you confirm @rikoe ?