### PR TITLE
Correcting an error in ViewQuote intent example

### DIFF
--- a/docs/intents/ref/ViewQuote.md
+++ b/docs/intents/ref/ViewQuote.md
@@ -32,7 +32,7 @@ const instrument = {
     }
 }
 
-fdc3.raiseIntent('fdc3.ViewQuote', instrument)
+fdc3.raiseIntent('ViewQuote', instrument)
 ```
 
 ## See Also

--- a/website/versioned_docs/version-1.1/intents/ref/ViewQuote.md
+++ b/website/versioned_docs/version-1.1/intents/ref/ViewQuote.md
@@ -33,7 +33,7 @@ const instrument = {
     }
 }
 
-fdc3.raiseIntent('fdc3.ViewQuote', instrument)
+fdc3.raiseIntent('ViewQuote', instrument)
 ```
 
 ## See Also


### PR DESCRIPTION
Intent was referred to as `fdc3.ViewQuote`, rather than `ViewQuote`

Didn't see a 1.2 version of the _intents\ref_ folder (as there is for 1.1: _website\versioned_docs\version-1.1\intents\ref_) so I can only assume docusarus isn't creating it because nothing in there changed in 1.2.