### PR TITLE
Ensure system channels are not retrieved until FDC3 API is ready

### DIFF
--- a/toolbox/fdc3-workbench/src/App.tsx
+++ b/toolbox/fdc3-workbench/src/App.tsx
@@ -158,13 +158,6 @@ export const App = observer(() => {
 				setFdc3Available(true);
 			} catch (e) {}
 		})();
-
-		//check window.fdc3 as the FDC3 import will override fdc3
-		// if (typeof window.fdc3.broadcast != "undefined") {
-		// 	setFdc3Available(true);
-		// } else {
-		// 	window.addEventListener("fdc3Ready", () => {setFdc3Available(true);});
-		// }
 	}, []);
 
 	useEffect(() => {

--- a/toolbox/fdc3-workbench/src/fixtures/logMessages.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/logMessages.ts
@@ -8,6 +8,9 @@ type LogMessages = {
 
 export const getLogMessage = (name: logMessagesName, type: logMessagesType, value: string = ""): string => {
 	const logMessages: LogMessages = {
+		getFdc3: {
+			error: `The FDC3 API is not ready${value ? ` (${value})` : ""}`,
+		},
 		getChannels: {
 			success: `Successfully retrieved System channels`,
 			error: `Failed to retrieve System channels`,

--- a/toolbox/fdc3-workbench/src/store/SystemLogStore.ts
+++ b/toolbox/fdc3-workbench/src/store/SystemLogStore.ts
@@ -4,6 +4,7 @@ import { getLogMessage } from "../fixtures/logMessages";
 import snackbarStore from "./SnackbarStore";
 
 export type logMessagesName =
+	| "getFdc3"
 	| "getChannels"
 	| "getCurrentChannel"
 	| "joinChannel"


### PR DESCRIPTION
@donbasuno pointed out that the workbench isn't waiting for the FDC3 ready event before retrieving system channels, meaning it can fail to retrieve them in some Desktop Agent implementations. This occurs, despite the fact that the workbench doesn't render its UI until FDC3 ready has fired, because the channels are retrieved on import of the Channels page, which imports the Channels store, which in turn retrieves the channels in its constructor. 

This PR fixes that issue and appears to ensure that the Channels are more stably retrieved from the FDC3 Desktop Agent Chrome extension, and should also resolve issues in the Finsemble 5 FDC3 add-on.