### PR TITLE
Workbench: Improving FDC3 API not detected message

### DIFF
--- a/toolbox/fdc3-workbench/src/App.tsx
+++ b/toolbox/fdc3-workbench/src/App.tsx
@@ -47,6 +47,16 @@ mainTheme.typography.h5 = {
 	fontSize: "16px",
 };
 
+mainTheme.typography.body1 = {
+	fontSize: "1rem",
+    fontFamily: "Roboto, Helvetica, Arial, sans-serif",
+    fontWeight: 400,
+    lineHeight: 1.5,
+    letterSpacing: "0.00938em",
+	marginBlockStart: "10px",
+	marginBlockEnd: "10px",
+};
+
 const useStyles = makeStyles((theme: Theme) =>
 	createStyles({
 		"@global": {
@@ -127,6 +137,12 @@ const openAPIDocs = (event: React.MouseEvent<HTMLElement>) => {
 const openSpecAccessDocs = (event: React.MouseEvent<HTMLElement>) => {
 	event.preventDefault();
 	window.open("https://fdc3.finos.org/docs/api/spec#api-access", "FDC3ApiDocs");
+	return false;
+};
+
+const openSupportedPlatformsDocs = (event: React.MouseEvent<HTMLElement>) => {
+	event.preventDefault();
+	window.open("https://fdc3.finos.org/docs/supported-platforms", "FDC3ApiDocs");
 	return false;
 };
 
@@ -218,15 +234,28 @@ export const App = observer(() => {
 									<span className={classes.code}>window.fdc3</span>.
 								</Typography>
 								<Typography variant="body1">
-									See the{" "}
+									For web applications to be FDC3-enabled, they need to run in the context of an 
+									agent that makes the FDC3 API available to the application. This desktop agent is 
+									also responsible for lauching and co-ordinating applications. It could be a browser 
+									extension, web app, or full-fledged desktop container framework.
+								</Typography>
+								<Typography variant="body1">
+									See the FDC3 standard documentation for details on{" "}
+									<Link
+										className={classes.link}
+										href="https://fdc3.finos.org/docs/supported-platforms"
+										onClick={openSupportedPlatformsDocs}
+									>
+									supported platforms
+									</Link>
+									{" "}and{" "}
 									<Link
 										className={classes.link}
 										href="https://fdc3.finos.org/docs/api/spec#api-access"
 										onClick={openSpecAccessDocs}
 									>
-										FDC3 standard documentation
-									</Link>{" "}
-									for more details.
+										accessing the FDC3 API
+									</Link>.
 								</Typography>
 							</Paper>
 						</Grid>


### PR DESCRIPTION
The "FDC3 API not detected message" is not sufficiently descriptive for a non-technical user to understand why the workbench doesn't load in Chrome. This PR augments the message with some content from the docs that clarifies + an additional link to the support platforms page. 

Before:
![image](https://user-images.githubusercontent.com/1701764/137476520-0d50fc70-1136-49be-af84-6f2a80750bae.png)

After:
![image](https://user-images.githubusercontent.com/1701764/137476495-16924d4c-15b0-47f8-bcf6-842c1c9e09c6.png)
