### PR TITLE
Workbench: add error handling to getInfo call to prevent errors in OpenFin

### DIFF
--- a/toolbox/fdc3-workbench/src/components/Header.tsx
+++ b/toolbox/fdc3-workbench/src/components/Header.tsx
@@ -50,7 +50,16 @@ export const Header = (props: { fdc3Available: boolean }) => {
 		if (props.fdc3Available) {
 			//getInfo is not available in FDC3 < v1.2, handle any errors thrown when trying to use it
 			try {
-				setAppInfo(fdc3.getInfo());
+				let implInfo = fdc3.getInfo();
+				let displayInfo = {
+					fdc3Version: "not specified", 
+					provider: "not specified", 
+					providerVersion: "not specified"
+				};
+				if (implInfo.fdc3Version) {displayInfo.fdc3Version = implInfo.fdc3Version; } 
+				if (implInfo.provider) {displayInfo.provider = implInfo.provider; } 
+				if (implInfo.providerVersion) {displayInfo.providerVersion = implInfo.providerVersion; } 
+				setAppInfo(displayInfo);
 			} catch (e) {
 				console.error("Failed to retrieve FDC3 implementation info",e);
 			}
@@ -81,7 +90,7 @@ export const Header = (props: { fdc3Available: boolean }) => {
 								</tr>
 								<tr>
 									<th scope="row">Provider version</th>
-									<td>{appInfo?.providerVersion ? appInfo.providerVersion : "-"}</td>
+									<td>{appInfo?.providerVersion ? appInfo.providerVersion : "unknown"}</td>
 								</tr>
 							</tbody>
 						</table>


### PR DESCRIPTION
fdc3.getInfo was introduced in FDC3 1.1 and, despite checking for the existence of the function, calls to it were throwing errors in the current OpenFin FDC3 service. This PR swaps the check for the existence of the function for error handling on calls to it, which should prevent further issues.

If `getInfo` is not implemented or throws an error the workbench will display version info as:
![image](https://user-images.githubusercontent.com/1701764/137478643-55ed4f8b-ce84-4678-a8fc-4157a53b9106.png)
