### PR TITLE
Changelog catchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 * Definition of the `icons` property of AppMetadata, based on PWA icon spec ([#319](https://github.com/finos/FDC3/pull/319))
+* Added support for raiseIntent without a context via the addition of the `fdc3.nothing` context type ([#375](https://github.com/finos/FDC3/pull/375))
+* Added [**FDC3 Workbench**](https://fdc3.finos.org/toolbox/fdc3-workbench/), an FDC3 API developer application ([#457](https://github.com/finos/FDC3/pull/457))
+* Added advice on how to `broadcast` complex context types, composed of other types, so that other apps can listen for both the complex type and simpler constituent types ([#464](https://github.com/finos/FDC3/pull/464))
 
 ### Changed
+* Consolidated `Listener` documentation with other types ([#404](https://github.com/finos/FDC3/pull/404))
+* Updated definition of the `Position` context type to support negative (short) positions ([#419](https://github.com/finos/FDC3/pull/419))
+* Upgraded web access statements from SHOULD to MUST in the API specification ([#440](https://github.com/finos/FDC3/pull/440))
+* Updated copyright notices ([#467](https://github.com/finos/FDC3/pull/467))
+* Adjusted wording in API spec and documentation to acknowledge the possibility of methods of intent resolution other than a resolver UI ([#461](https://github.com/finos/FDC3/pull/461))
+
 ### Deprecated
 ### Fixed
+* Removed trailing slashes from schema references (which break refs for schema parsers) ([#374](https://github.com/finos/FDC3/pull/374))
+* Corrected that definition of the `Context` type in documentation ([#406](https://github.com/finos/FDC3/pull/406)])
+* Corrected syntax errors in context schema examples ([#424](https://github.com/finos/FDC3/pull/424))
+* Corrected a minor error in the ViewQuote Intent example ([#439](https://github.com/finos/FDC3/pull/439))
+* Clarified behavior of `fdc3.addContextListene`r when not joined to a channel ([#449](https://github.com/finos/FDC3/pull/449))
+* Clarified existing behavior of joinChannel and addIntentListener when joining a channel ([#454](https://github.com/finos/FDC3/pull/454))
+* Clarified numerous aspects of the existing raiseIntent behavior in the spec and documentation ([#461](https://github.com/finos/FDC3/pull/461))
+* Updated Methods.ts to support the updated signature for addContextListener introduced in FDC3 1.2 ([#462](https://github.com/finos/FDC3/pull/462))
+
 
 ## [npm v1.2.0] - 2021-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-* Definition of the `icons` property of AppMetadata, based on PWA icon spec ([#319](https://github.com/finos/FDC3/pull/319))
+* Definition of the `icons` property of `AppMetadata`, based on PWA icon spec ([#319](https://github.com/finos/FDC3/pull/319))
 * Added support for raiseIntent without a context via the addition of the `fdc3.nothing` context type ([#375](https://github.com/finos/FDC3/pull/375))
 * Added [**FDC3 Workbench**](https://fdc3.finos.org/toolbox/fdc3-workbench/), an FDC3 API developer application ([#457](https://github.com/finos/FDC3/pull/457))
 * Added advice on how to `broadcast` complex context types, composed of other types, so that other apps can listen for both the complex type and simpler constituent types ([#464](https://github.com/finos/FDC3/pull/464))
@@ -25,10 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Corrected that definition of the `Context` type in documentation ([#406](https://github.com/finos/FDC3/pull/406)])
 * Corrected syntax errors in context schema examples ([#424](https://github.com/finos/FDC3/pull/424))
 * Corrected a minor error in the ViewQuote Intent example ([#439](https://github.com/finos/FDC3/pull/439))
-* Clarified behavior of `fdc3.addContextListene`r when not joined to a channel ([#449](https://github.com/finos/FDC3/pull/449))
-* Clarified existing behavior of joinChannel and addIntentListener when joining a channel ([#454](https://github.com/finos/FDC3/pull/454))
-* Clarified numerous aspects of the existing raiseIntent behavior in the spec and documentation ([#461](https://github.com/finos/FDC3/pull/461))
-* Updated Methods.ts to support the updated signature for addContextListener introduced in FDC3 1.2 ([#462](https://github.com/finos/FDC3/pull/462))
+* Clarified behavior of `fdc3.addContextListener` when not joined to a channel ([#449](https://github.com/finos/FDC3/pull/449))
+* Clarified existing behavior of `joinChannel` and `addIntentListener` when joining a channel ([#454](https://github.com/finos/FDC3/pull/454))
+* Clarified numerous aspects of the existing `raiseIntent` behavior in the spec and documentation ([#461](https://github.com/finos/FDC3/pull/461))
+* Updated Methods.ts to support the updated signature for `addContextListener` introduced in FDC3 1.2 ([#462](https://github.com/finos/FDC3/pull/462))
 
 
 ## [npm v1.2.0] - 2021-04-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+* Definition of the `icons` property of AppMetadata, based on PWA icon spec ([#319](https://github.com/finos/FDC3/pull/319))
+
+### Changed
+### Deprecated
+### Fixed
+
 ## [npm v1.2.0] - 2021-04-19
 
 ### Added


### PR DESCRIPTION
We've not been adding changelog entries to PRs - this PR backfills these for everything merged since 1.2 was released