### PR TITLE
Added the ability to return data from a raised intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added support for raiseIntent without a context via the addition of the `fdc3.nothing` context type ([#375](https://github.com/finos/FDC3/pull/375))
 * Added [**FDC3 Workbench**](https://fdc3.finos.org/toolbox/fdc3-workbench/), an FDC3 API developer application ([#457](https://github.com/finos/FDC3/pull/457))
 * Added advice on how to `broadcast` complex context types, composed of other types, so that other apps can listen for both the complex type and simpler constituent types ([#464](https://github.com/finos/FDC3/pull/464))
+* Added the ability to return data from an intent, via the addition of an IntentHandler type and a `getData()` to IntentResolution, both of which return a Promise of a Context object. ([#XXX](https://github.com/finos/FDC3/pull/XXX))
 
 ### Changed
 * Consolidated `Listener` documentation with other types ([#404](https://github.com/finos/FDC3/pull/404))

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -30,7 +30,7 @@ interface DesktopAgent {
   findIntentsByContext(context: Context): Promise<Array<AppIntent>>;
   raiseIntent(intent: string, context: Context, app?: TargetApp): Promise<IntentResolution>;
   raiseIntentForContext(context: Context, app?: TargetApp): Promise<IntentResolution>;
-  addIntentListener(intent: string, handler: ContextHandler): Listener;
+  addIntentListener(intent: string, handler: IntentHandler): Listener;
 
   // channels
   getOrCreateChannel(channelId: string): Promise<Channel>;
@@ -71,27 +71,39 @@ const contactListener = fdc3.addContextListener('fdc3.contact', contact => { ...
 #### See also
 * [`Listener`](Types#listener)
 * [`Context`](Types#context)
+* [`ContextHandler`](Types#contexthandler)
 
 
 
 ### `addIntentListener`
 
 ```ts
-addIntentListener(intent: string, handler: ContextHandler): Listener;
+addIntentListener(intent: string, handler: IntentHandler): Listener;
 ```
- Adds a listener for incoming Intents from the Agent.
+Adds a listener for incoming Intents from the Agent. The handler function may return void or a promise that should resolve to a context object representing any data that should be returned to app that raised the intent. If an error is thrown by the handler function, or the promise returned is rejected, then the Desktop Agent MUST reject the promise returned by the `getData()` function of the `IntentResolution`. 
 
 #### Examples
 
 ```js
+//Handle a raised intent
 const listener = fdc3.addIntentListener('StartChat', context => {
-  // start chat has been requested by another application
+    // start chat has been requested by another application
+    return;
+});
+
+//Handle a raised intent and return Context data via a promise
+fdc3.addIntentListener("trade", (context) => {
+    return new Promise<Context>((resolve) => {
+        // go place trade
+        resolve({result: "trade placed successfully"});
+   });
 });
 ```
 
 #### See also
 * [`Listener`](Types#listener)
 * [`Context`](Types#context)
+* [`IntentHandler`](Types#intenthandler)
 
 
 
@@ -389,7 +401,7 @@ Alternatively, the specific app to target can also be provided. A list of valid 
 
 If you wish to raise an Intent without a context, use the `fdc3.nothing` context type. This type exists so that apps can explicitly declare support for raising an intent without context.
 
-Returns an `IntentResolution` object with details of the app that was selected to respond to the intent.
+Returns an `IntentResolution` object with details of the app that was selected to respond to the intent. If the application that resolves the intent returns a promise of Context data, this may be retrieved via the `getData()` function of the IntentResolution object. If an error is thrown by the handler function, or the promise returned is rejected, then the Desktop Agent MUST reject the promise returned by the `getData()` function of the `IntentResolution`. 
 
 If a target app for the intent cannot be found with the criteria provided, an `Error` with a string from the [`ResolveError`](Errors#resolverrror) enumeration is returned.
 
@@ -432,7 +444,7 @@ Alternatively, the specific app to target can also be provided, in which case an
 
 Using `raiseIntentForContext` is similar to calling `findIntentsByContext`, and then raising an intent against one of the returned apps, except in this case the desktop agent has the opportunity to provide the user with a richer selection interface where they can choose both the intent and target app.
 
-Returns an `IntentResolution` object with a handle to the app that responded to the selected intent.
+Returns an `IntentResolution` object with details of the app that was selected to respond to the intent. If the application that resolves the intent returns a promise of Context data, this may be retrieved via the `getData()` function of the IntentResolution object. If an error is thrown by the handler function, or the promise returned is rejected, then the Desktop Agent MUST reject the promise returned by the `getData()` function of the `IntentResolution`. 
 
 If a target app for the intent cannot be found with the criteria provided, an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration is returned.
 

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -126,21 +126,44 @@ The Interface used to describe an Intent within the platform.
 
 ```ts
 interface IntentResolution {
-  source: TargetApp;
+/**
+   * The application that resolved the intent.
+   */
+  readonly source: TargetApp;
   /**
-  * @deprecated not assignable from intent listeners
-  */
-  data?: object;
-  version: string;
+   * The version number of the Intents schema being used.
+   */
+  readonly version?: string;
+  /**
+   * Retrieves a promise that will resolve to data returned by the
+   * application that resolves the raised intent. The promise will 
+   * reject if an error is thrown by the intent handler or the promise
+   * returned by the intent handler is reject. If the intent handler 
+   * does not return a promise this function will return null.
+   */
+  getData(): Promise<Context> | null;
 }
 ```
 
 IntentResolution provides a standard format for data returned upon resolving an intent.
 
-#### Example
+#### Examples
 ```js
-// resolve a "Chain" type intent
-const intentResolution = await fdc3.raiseIntent("intentName", context);
+//resolve a "Chain" type intent
+let resolution = await agent.raiseIntent("intentName", context);
+
+//resolve a "Client-Service" type intent with a data response
+let resolution = await agent.raiseIntent("intentName", context);
+try {
+	   const result = await resolution.getData();
+    if (result) {
+        console.log(`${resolution.source} returned ${JSON.stringify(result)}`);
+    } else {
+        console.error(`${resolution.source} didn't return data`
+    }
+} catch(error) {
+    console.error(`${resolution.source} returned an error: ${error}`);
+}
 ```
 
 #### See also

--- a/docs/api/ref/Types.md
+++ b/docs/api/ref/Types.md
@@ -41,12 +41,26 @@ type ContextHandler = (context: Context) => void;
 
 Describes a callback that handles a context event.
 
-Used when attaching listeners for context broadcasts and raised intents.
+Used when attaching listeners for context broadcasts.
+
+#### See also
+* [`Context`](#context)
+* [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
+* [`Channel.addContextListener`](Channel#addcontextlistener)
+
+## `IntentHandler`
+
+```typescript
+type IntentHandler = (context: Context) => Promise<Context> | void;
+```
+
+Describes a callback that handles a context event and may return a promise of a Context object to be returned to the application that raised the intent.
+
+Used when attaching listeners for raised intents.
 
 #### See also
 * [`Context`](#context)
 * [`DesktopAgent.addIntentListener`](DesktopAgent#addintentlistener)
-* [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
 * [`Channel.addContextListener`](Channel#addcontextlistener)
 
 ## `Listener`

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -42,7 +42,7 @@ The global `window.fdc3` must only be available after the API is ready to use. T
 
 ```js
 function fdc3Stuff() {
-  // Make some fdc3 API calls here
+  // Make fdc3 API calls here
 }
 
 if (window.fdc3) {
@@ -99,11 +99,13 @@ Intents provide a way for an app to request functionality from another app and d
 - **Remote API**: An app wants to remote an entire API that it owns to another App.  In this case, the API for the App cannot be standardized.  However, the FDC3 API can address how an App connects to another App in order to get access to a proprietary API.
 
 #### Intents and Context
-When raising an Intent a specific context may be provided. The type of the provided context may determine which applications can resolve the Intent.
+When raising an Intent a specific context may be provided as input. The type of the provided context may determine which applications can resolve the Intent.
 
 A Context type may also be associated with multiple Intents. For example, an `fdc3.instrument` could be associated with `ViewChart`, `ViewNews`, `ViewAnalysis` or other Intents. In addition to raising a specific intent, you can raise an Intent for a specific Context allowing the Desktop Agent or the user (if the Intent is ambiguous) to select the appropriate Intent for the selected Context and then to raise that Intent for resolution.
 
 To raise an Intent without a context, use the `fdc3.nothing` context type. This type exists so that applications can explicitly declare that they support raising an intent without a context (when registering an Intent listener or in an App Directory).
+
+An optional context object may also be returned as output by an application resolving an intent. For example, an application resolving a `CreateOrder` intent might return a context representing the order and including an ID, allowing the application that raised the intent to make further calls using that ID.  
 
 #### Intent Resolution
 Raising an Intent will return a Promise-type object that will resolve/reject based on a number of factors.
@@ -119,27 +121,28 @@ Raising an Intent will return a Promise-type object that will resolve/reject bas
 
 ##### Resolution Object
 
-> **Deprecation notice**
->
-> It is not currently possible to provide a value for the `data` property described below,
-as intent listeners don't currently offer a way to return values.
->
-> Future versions of FDC3 plan to remove the optional `data` property from the intent resolution object,
-and include a more robust mechanism for intents that need to return data back to the caller.
-
 If the raising of the intent resolves (or rejects), a standard object will be passed into the resolver function with the following format:
 
 ```js
 {
-    source: String;
-    data?: Object;
-    version: String;
+  /**
+   * The application that resolved the intent.
+   */
+  readonly source: TargetApp;
+  /**
+   * The version number of the Intents schema being used.
+   */
+  readonly version?: string;
+  /**
+   * Retrieves a promise that will resolve to data returned by the
+   * application that resolves the raised intent. The promise will 
+   * reject if an error is thrown by the intent handler or the promise
+   * returned by the intent handler is reject. If the intent handler 
+   * does not return a promise this function will return null.
+   */
+  getData(): Promise<Context> | null;
 }
 ```
-- *source* = identifier for the Application resolving the intent (null if the intent could not be resolved)
-- *data* = return data structure - if one is provided for the given intent
-- *version* = the version number of the Intents schema being used
-
 
 For example, to raise a specific Intent:
 
@@ -152,7 +155,7 @@ catch (er){
 }
 ```
 
-or to raise an unspecified Intent for a specific context, where the user will select an intent from a resolver dialog:
+or to raise an unspecified Intent for a specific context, where the user may select an intent from a resolver dialog:
 ```js
 try {
     const result = await fdc3.raiseIntentForContext(context);
@@ -162,6 +165,21 @@ try {
 }
 catch (er){
     console.log(er.message);
+}
+```
+
+Raise an intent and retrieve data from the IntentResolution:
+```js
+let resolution = await agent.raiseIntent("intentName", context);
+try {
+    const result = await resolution.getData();
+    if (result) {
+        console.log(`${resolution.source} returned ${JSON.stringify(result)}`);
+    } else {
+        console.error(`${resolution.source} didn't return data`
+    }
+} catch(error) {
+    console.error(`${resolution.source} returned an error: ${error}`);
 }
 ```
 

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -5,7 +5,7 @@
 
 import { AppIntent } from './AppIntent';
 import { Channel } from './Channel';
-import { ContextHandler, TargetApp } from './Types';
+import { ContextHandler, IntentHandler, TargetApp } from './Types';
 import { IntentResolution } from './IntentResolution';
 import { Listener } from './Listener';
 import { Context } from '../context/ContextTypes';
@@ -122,25 +122,40 @@ export interface DesktopAgent {
   /**
    * Raises a specific intent for resolution against apps registered with the desktop agent.
    *
-   * The desktop agent will resolve the correct app to target based on the provided intent name and context data. If multiple matching apps are found, the user may be presented with an app picker.
+   * The desktop agent MUST resolve the correct app to target based on the provided intent name and context data. If multiple matching apps are found, the user MAY be presented with a Resolver UI allowing them to pick one, or another method of Resolution applied to select an app.
    * Alternatively, the specific app to target can also be provided. A list of valid target applications can be retrieved via `findIntent`.
    *
-   * Returns an `IntentResolution` object with details of the app that was selected to respond to the intent.
+   * Returns an `IntentResolution` object with details of the app that was selected to respond to the intent. If the application that resolves the intent returns a promise of Context data, this may be retrieved via the `getData()` function of the IntentResolution object. If an error is thrown by the handler function, or the promise returned is rejected, then the Desktop Agent MUST reject the promise returned by the `getData()` function of the `IntentResolution`.
    *
    * If a target app for the intent cannot be found with the criteria provided, an `Error` with a string from the `ResolveError` enumeration is returned.
    *
    * ```javascript
    * // raise an intent for resolution by the desktop agent
-   * // a resolver UI will be displayed if more than one application can resolve the intent
+   * // a resolver UI may be displayed if more than one application can resolve the intent
    * await fdc3.raiseIntent("StartChat", context);
+   *
    * // or find apps to resolve an intent to start a chat with a given contact
    * const appIntent = await fdc3.findIntent("StartChat", context);
    * // use the returned AppIntent object to target one of the returned chat apps by name
    * await fdc3.raiseIntent("StartChat", context, appIntent.apps[0].name);
    * // or use one of the AppMetadata objects returned in the AppIntent object's 'apps' array
    * await fdc3.raiseIntent("StartChat", context, appIntent.apps[0]);
+   *
    * //Raise an intent without a context by using the null context type
    * await fdc3.raiseIntent("StartChat", {type: "fdc3.nothing"});
+   *
+   * //Raise an intent and retrieve data from the IntentResolution
+   * let resolution = await agent.raiseIntent("intentName", context);
+   * try {
+   * 	   const result = await resolution.getData();
+   *     if (result) {
+   *         console.log(`${resolution.source} returned ${JSON.stringify(result)}`);
+   *     } else {
+   *         console.error(`${resolution.source} didn't return data`
+   *     }
+   * } catch(error) {
+   *     console.error(`${resolution.source} returned an error: ${error}`);
+   * }
    * ```
    */
   raiseIntent(intent: string, context: Context, app?: TargetApp): Promise<IntentResolution>;
@@ -148,12 +163,12 @@ export interface DesktopAgent {
   /**
    * Finds and raises an intent against apps registered with the desktop agent based purely on the type of the context data.
    *
-   * The desktop agent SHOULD first resolve to a specific intent based on the provided context if more than one intent is available for the specified context. This MAY be achieved by displaying a resolver UI. It SHOULD then resolve to a specific app to handle the selected intent and specified context.
-   * Alternatively, the specific app to target can also be provided, in which case the resolver should only offer intents supported by the specified application.
+   * The desktop agent will first resolve to a specific intent based on the provided context if more than one intent is available for the specified context. This MAY be achieved by displaying a resolver UI. It SHOULD then resolve to a specific app to handle the selected intent and specified context.
+   * Alternatively, the specific app to target can also be provided, in which case the resolver SHOULD only offer intents supported by the specified application.
    *
    * Using `raiseIntentForContext` is similar to calling `findIntentsByContext`, and then raising an intent against one of the returned apps, except in this case the desktop agent has the opportunity to provide the user with a richer selection interface where they can choose both the intent and target app.
    *
-   * Returns an `IntentResolution` object with a handle to the app that responded to the selected intent.
+   * Returns an `IntentResolution` object with details of the app that was selected to respond to the intent. If the application that resolves the intent returns a promise of Context data, this may be retrieved via the `getData()` function of the IntentResolution object. If an error is thrown by the handler function, or the promise returned is rejected, then the Desktop Agent MUST reject the promise returned by the `getData()` function of the `IntentResolution`.
    *
    * If a target app for the intent cannot be found with the criteria provided, an `Error` with a string from the `ResolveError` enumeration is returned.
    *
@@ -167,9 +182,30 @@ export interface DesktopAgent {
   raiseIntentForContext(context: Context, app?: TargetApp): Promise<IntentResolution>;
 
   /**
-   * Adds a listener for incoming Intents from the Agent.
+   * Adds a listener for incoming Intents from the Agent. The handler function may
+   * return void or a promise that should resolve to a context object representing
+   * any data that should be returned to app that raised the intent. If an error is
+   * thrown by the handler function, or the promise returned is rejected, then the
+   * Desktop Agent MUST reject the promise returned by the `getData()` function of
+   * the `IntentResolution`.
+   *
+   * ```javascript
+   * //Handle a raised intent
+   * const listener = fdc3.addIntentListener('StartChat', context => {
+   *     // start chat has been requested by another application
+   *     return;
+   * });
+   *
+   * //Handle a raised intent and return Context data via a promise
+   * fdc3.addIntentListener("trade", (context) => {
+   *     return new Promise<Context>((resolve) => {
+   *         // go place trade
+   *         resolve({result: "trade placed successfully"});
+   *	   });
+   * });
+   * ```
    */
-  addIntentListener(intent: string, handler: ContextHandler): Listener;
+  addIntentListener(intent: string, handler: IntentHandler): Listener;
 
   /**
    * Adds a listener for incoming context broadcast from the Desktop Agent.

--- a/src/api/IntentResolution.ts
+++ b/src/api/IntentResolution.ts
@@ -3,23 +3,44 @@
  * Copyright 2019 FINOS FDC3 contributors - see NOTICE file
  */
 
+import { Context } from '../context/ContextTypes';
 import { TargetApp } from './Types';
 
 /**
  * IntentResolution provides a standard format for data returned upon resolving an intent.
  * ```javascript
  * //resolve a "Chain" type intent
- * var intentR = await agent.raiseIntent("intentName", context);
- * //resolve a "Client-Service" type intent with data response
- * var intentR = await agent.raiseIntent("intentName", context);
- * var dataR = intentR.data;
+ * let resolution = await agent.raiseIntent("intentName", context);
+ *
+ * //resolve a "Client-Service" type intent with a data response
+ * let resolution = await agent.raiseIntent("intentName", context);
+ * try {
+ * 	   const result = await resolution.getData();
+ *     if (result) {
+ *         console.log(`${resolution.source} returned ${JSON.stringify(result)}`);
+ *     } else {
+ *         console.error(`${resolution.source} didn't return data`
+ *     }
+ * } catch(error) {
+ *     console.error(`${resolution.source} returned an error: ${error}`);
+ * }
  * ```
  */
 export interface IntentResolution {
+  /**
+   * The application that resolved the intent.
+   */
   readonly source: TargetApp;
   /**
-   * @deprecated not assignable from intent listeners
+   * The version number of the Intents schema being used.
    */
-  readonly data?: object;
-  readonly version: string;
+  readonly version?: string;
+  /**
+   * Retrieves a promise that will resolve to data returned by the
+   * application that resolves the raised intent. The promise will
+   * reject if an error is thrown by the intent handler or the promise
+   * returned by the intent handler is reject. If the intent handler
+   * does not return a promise this function will return null.
+   */
+  getData(): Promise<Context> | null;
 }

--- a/src/api/Methods.ts
+++ b/src/api/Methods.ts
@@ -1,4 +1,13 @@
-import { AppIntent, Channel, Context, ContextHandler, IntentResolution, Listener, ImplementationMetadata } from '..';
+import {
+  AppIntent,
+  Channel,
+  Context,
+  ContextHandler,
+  IntentHandler,
+  IntentResolution,
+  Listener,
+  ImplementationMetadata,
+} from '..';
 import { TargetApp } from './Types';
 
 const DEFAULT_TIMEOUT = 5000;
@@ -63,7 +72,7 @@ export function raiseIntentForContext(context: Context, app?: TargetApp): Promis
   return rejectIfNoGlobal(() => window.fdc3.raiseIntentForContext(context, app));
 }
 
-export function addIntentListener(intent: string, handler: ContextHandler): Listener {
+export function addIntentListener(intent: string, handler: IntentHandler): Listener {
   return throwIfNoGlobal(() => window.fdc3.addIntentListener(intent, handler));
 }
 

--- a/src/api/Types.ts
+++ b/src/api/Types.ts
@@ -6,5 +6,21 @@
 import { AppMetadata } from '..';
 import { Context } from '../context/ContextTypes';
 
+/**
+ * Operations that target apps (like open or raiseIntent) can identify
+ * an app just by by its name, or pass full app metadata, giving the
+ * desktop agent more information about the targeted app.
+ */
 export type TargetApp = string | AppMetadata;
+/**
+ * Describes a callback that handles a context event.
+ * Used when attaching listeners for context broadcasts.
+ */
 export type ContextHandler = (context: Context) => void;
+/**
+ * Describes a callback that handles a context event and may return a
+ * promise of a Context object to be returned to the application that
+ * raised the intent.
+ * Used when attaching listeners for raised intents.
+ */
+export type IntentHandler = (context: Context) => Promise<Context> | void;


### PR DESCRIPTION
resolves #432 
Adds the ability for apps resolving intents to also return data that may be retrieved from the `IntentResolution` by the app that raised the intent.
- Introduces an IntentHandler type, similar to ContextHandler, but with an optional return type of Promise<Context>
- Adds a `getData()` function to IntentResolution
- Removes the deprecated `data` field of IntentResolution
- Adds details and examples to the spec and API reference

A different PR will deal with adding support for specifying the desired return type when resolving an intent through the API and for adding metadata to do so to the AppD.