### PR TITLE
476 clarify that getInfo is required for FDC3 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Clarified existing behavior of `joinChannel` and `addIntentListener` when joining a channel ([#454](https://github.com/finos/FDC3/pull/454))
 * Clarified numerous aspects of the existing `raiseIntent` behavior in the spec and documentation ([#461](https://github.com/finos/FDC3/pull/461))
 * Updated Methods.ts to support the updated signature for `addContextListener` introduced in FDC3 1.2 ([#462](https://github.com/finos/FDC3/pull/462))
+* Clarified that implementing `fdc3.getInfo()` is required for compliance with the FDC3 standard ([#515](https://github.com/finos/FDC3/pull/515))
 
 
 ## [npm v1.2.0] - 2021-04-19

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -200,7 +200,7 @@ It is expected that App Directories will also curate listed apps and ensure that
 On the financial desktop, applications often want to broadcast context to any number of applications.  Context sharing needs to support concepts of different groupings of applications as well as data privacy concerns.  Each Desktop Agent will have its own rules for supporting these features. However, a Desktop Agent should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
 
 ### Retrieve Metadata about the Desktop Agent implementation
-From version 1.2 of the FDC3 specification, it is possible to retrieve information about the  version of the FDC3 specification supported by a Desktop Agent implementation and the name of the implementation provider. This metadata can be used to vary the behavior of an application based on the version supported by the Desktop Agent, e.g.:
+From version 1.2 of the FDC3 specification, Desktop Agent implementations MUST provide a `fdc3.getInfo()` function to allow apps to retrieve information about the version of the FDC3 specification supported by a Desktop Agent implementation and the name of the implementation provider. This metadata can be used to vary the behavior of an application based on the version supported by the Desktop Agent, e.g.:
 
 ```js
 import {compareVersionNumbers, versionIsAtLeast} from '@finos/fdc3';

--- a/docs/fdc3-compliance.md
+++ b/docs/fdc3-compliance.md
@@ -32,6 +32,7 @@ For platform providers FDC3 compliance requires:
 * An API implementation that meets the FDC3 API standards MUST be provided to all applications running in the context of the platform, including:
     * Support for FDC3 Context Data and Intents standards
     * Support for Intent and Context resolution using a resolver UI
+    * Support for retrieving information about the version of the FDC3 specification supported by a Desktop Agent implementation and the name of the implementation provider
 * In the case of web applications, a Desktop Agent MUST provide the FDC3 API via a global accessible as `window.fdc3`.
 * At least one workflow of one of the use cases marked as Accepted by the Use Cases working group SHOULD be satisfied by the implementation.
 


### PR DESCRIPTION
resolves #476
Minor clarification in spec and compliance doc