### PR TITLE
Add training link to FDC3 readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The standard currently consists of four specifications:
 The specifications are informed by agreed [business use cases](https://fdc3.finos.org/docs/use-cases/overview),
 and implemented and used by leading [financial industry participants](https://fdc3.finos.org/users).
 
-See https://fdc3.finos.org for more information, including on [compliance] and the [FDC3 charter], as well as a comprehensive [API Reference].
+See https://fdc3.finos.org for more information, including on [compliance] and the [FDC3 charter], as well as a comprehensive [API Reference]. You can also take the free [FDC3 Training](https://www.edx.org/course/fdc3-interoperability-for-the-financial-desktop) for an introduction to FDC3's core concepts and usage.
 
 [FDC3 Charter]: https://fdc3.finos.org/docs/fdc3-charter
 [Compliance]: https://fdc3.finos.org/docs/fdc3-compliance


### PR DESCRIPTION
Added a link to the Readme files intro as requested by @mindthegab. 

If that works for you, let me know. Otherwise raise an alternative PR and I'll review 