### PR TITLE
Adding a trademarks page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added [**FDC3 Workbench**](https://fdc3.finos.org/toolbox/fdc3-workbench/), an FDC3 API developer application ([#457](https://github.com/finos/FDC3/pull/457))
 * Added advice on how to `broadcast` complex context types, composed of other types, so that other apps can listen for both the complex type and simpler constituent types ([#464](https://github.com/finos/FDC3/pull/464))
 * `IntentResolution` now requires the name of the intent raised to included, allowing it to be used to determine the intent raised via `fdc3.raiseIntentForContext()`. ([#507](https://github.com/finos/FDC3/pull/507))
+* A Trademarks page was added to acknowledge trademarks used within the Standard not owned by FINOS or the Linux Foundation ([#534](https://github.com/finos/FDC3/pull/534))
 
 ### Changed
 * Consolidated `Listener` documentation with other types ([#404](https://github.com/finos/FDC3/pull/404))

--- a/docs/trademarks.md
+++ b/docs/trademarks.md
@@ -1,0 +1,22 @@
+---
+title: Trademarks
+---
+
+The trademarks, logos, and service marks not owned on behalf of FDC3 and FINOS and that are displayed on the Site are the registered and unregistered marks of their respective owners. No rights are granted by the FDC3 or FINOS to use such marks, whether by implication, estoppel, or otherwise. 
+
+Trademarks used within this site and the FDC3 Standard include, but are not limited to:
+- Autobahn is a registered trademark of DEUTSCHE BANK AG, LONDON
+- Chromium is a trademark of Google LLC
+- Cosaic is a registered trademark of ChartIQ, Inc.
+- Eikon is a registered trademark of Refinitiv
+- FDC3 is a registered trademark and brand of The Linux Foundation
+- Excel is a Microsoft Corporation product name
+- Finsemble is a registered trademark and product name of ChartIQ, Inc.
+- Glue42 is a trademark of Tick42
+- Java is a registered trademark of Oracle America, Inc.
+- JavaScript  is a registered trademark of Oracle America, Inc.
+- .NET is a trademark of Microsoft Corporation
+- npm is a trademark of npm, Inc.
+- OpenFin is a registered trademark of OpenFin Inc.
+- Outlook is a registered trademark of Microsoft Corporation
+- Python is a registered trademark of the Python Software Foundation

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -86,6 +86,10 @@ class Footer extends React.Component {
               rel="noreferrer noopener">
               Google Groups
             </a>
+            <a
+              href="/docs/next/trademarks">
+                Trademarks
+            </a>
             {/* <a href={this.pageUrl('users.html', this.props.language)}>
               User Showcase
             </a> */}


### PR DESCRIPTION
resolves #510 

Adds a trademarks page to the FDC3 website, linked from the footer:

![image](https://user-images.githubusercontent.com/1701764/146984581-caa8e98f-9059-407a-80c5-77018bbdf59a.png)

![image](https://user-images.githubusercontent.com/1701764/146984611-042e5e34-32d9-4082-b178-fdc211267c4c.png)
