### PR TITLE
527 529 Governance and contributing info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# FDC3 Standard Contribution Policy 1.0
+
+This document provides the contribution policy for the FDC3 Standard and is based on the [Community Specification Contribution Policy 1.0](https://github.com/finos/standards-project-blueprint/edit/master/6._Contributing.md).
+
+_NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS, _OR_ who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [Linux Foundation `EasyCLA` tool](https://easycla.lfx.linuxfoundation.org/#/). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+
+*Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@finos.org](mailto:help@finos.org).*
+
+
+## 1.	Contribution Guidelines. 
+
+This Working Group accepts contributions via pull requests. The following section outlines the process for merging contributions to the specification
+
+**1.1.	Issues.**  Issues are used as the primary method for tracking anything to do with this specification Working Group. 
+
+**1.1.1.	Issue Types.**  A number of issue templates are available in the FDC3 respository:
+
+**1.1.1.1.	Meetings.** Templates for issues that represent meetings and include agendas, teleconference details and minutes.
+
+**1.1.1.2.	Proposals and Enhancement Requests.** Used for items that propose a new ideas or functionality that require a larger discussion. This allows for feedback from others before a specification change is actually written. 
+
+**1.1.1.3.	Minor Issue:** These track minor changes or corrections that don't alter teh Standard significantly but rather correct minor errors or ommisions.
+
+**1.1.1.4.	Question:** May be used to ask questions about FDC3, requests support etc..
+
+## 2.	Issue Lifecycle.
+
+The issue lifecycle is mainly driven by the Maintainer. All issue types follow the same general lifecycle. Differences are noted below.
+
+**2.1.	Issue Creation.**
+
+**2.2.	Triage.**
+
+- The FDC3 Maintainers will apply the proper labels for the issue. This may include labels for priority, type, and metadata.
+
+- (If needed) Clean up the title to succinctly and clearly state the issue. 
+
+**2.3.	Discussion.**
+
+- Issues that change the Standard usually need discussion. You can post comments directly on the issue or can ask for it to be added to a Standards Working Group meeting agenda by emailing [fdc3@finos.org](mailto:fdc3@finos.org), sending a message to the [#fdc3 channel on the FINOS slack](https://finos-lf.slack.com/messages/fdc3/) or tag the FDC3 maintainers (`@finos/fdc3-maintainers`) in your issue.
+
+- Issues that enhance or otherwise change the Standard should be connected to the pull request that resolves it. That can be achieved by prefixing your pull request's description with a keyword and issue number, e.g. `resolves #123`. For more details on linking issues and PRs see [Github's documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+
+**2.4.	Issue Closure.**
+
+## 3.	How to Contribute a Patch.
+
+The Working Group uses pull requests to track changes. To submit a change to the Standard:
+
+**3.1.	Fork the Repo** 
+- (<https://github.com/finos/FDC3/fork>)
+
+**3.2.	Create your feature branch**
+- `git checkout -b feature/fooBar`
+
+**3.3.	Commit your changes** 
+- `git commit -am 'Describe what you changed'`
+
+**3.4.	Push to the branch**
+- `git push origin feature/fooBar`
+
+**3.5.	Create a Pull Request**
+- For help creating a pull request from your fork, [see Github's documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork)
+
+
+## 4.	Pull Request Workflow.
+
+The next section contains more information on the workflow followed for Pull Requests.
+
+**4.1.	Pull Request Creation.**
+
+- We welcome pull requests that are currently in progress. They are a great way to keep track of important work that is in-flight, but useful for others to see. If a pull request is a work in progress, it should be prefaced with "WIP: [title]". Once the pull request is ready for review, remove "WIP" from the title and label.
+
+- It is preferred, but not required, to have a pull request tied to a specific issue. Prefix your PR's description with `resolves #<issue number>` to link it to your issue.
+  - There can be circumstances where if it is a quick fix then an issue might be overkill. The details provided in the pull request description would suffice in this case.
+
+- Ensure that pull requests include a proposed update to the [FDC3 Changelog (CHANGELOG.md)](CHANGELOG.md)
+
+**4.2.	Triage**
+
+- The Maintainers will apply the proper labels for the issue. This may include an indication of the subject area or type (e.g. `deprecation`). 
+
+**4.3.	Reviewing/Discussion.**
+
+- All PRs will be reviewed by at least one of the FDC3 Maintainers and any appointed Editors. PRs are also open to review by FDC3 Participants.
+
+- The FDC3 Maintainers are responsible for ensuring that the the Standard Working Group has been consulted on either an issue (that provides a high-level of detail on the proposed changes) or on the PR itself, a decision has been reached that the change should be made and that that decision has been documented. 
+
+- All reviews will be completed using the Github review tool.
+
+- A "Comment" review should be used when there are questions about the spec that should be answered, but that don't involve spec changes. This type of review does not count as approval.
+
+- A "Changes Requested" review indicates that changes to the spec need to be made before they will be merged.
+
+- Reviewers should update labels as needed (such as needs rebase).
+
+- When a review is approved, the reviewer should add LGTM as a comment.
+
+**4.4.	Responsive.** Pull request owner should try to be responsive to comments by answering questions or changing text. Once all comments have been addressed, the pull request is ready to be merged.
+
+**4.5.	Merge or Close.**
+
+- A pull request should stay open until a Maintainer has marked the pull request as approved.
+
+- Pull requests can be closed by the author without merging.
+
+- Pull requests may be closed by a Maintainer if the decision is made that it is not going to be merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,3 +105,6 @@ The next section contains more information on the workflow followed for Pull Req
 - Pull requests can be closed by the author without merging.
 
 - Pull requests may be closed by a Maintainer if the decision is made that it is not going to be merged.
+
+## 5. Adoption of Contributions.
+Contributions merged into the master branch of the FDC3 repository will form part of the next pre-draft of the FDC3 Standard (as defined by the [FDC3 Governance document](./GOVERNANCE.md)), which must be approved by the Standard Working Group voting participants before it is accepted as a draft and subsequently released as the next version of the Standard.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -42,7 +42,7 @@ Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi
 
 **4.2.	Draft.**  Each Pre-Draft document of the Working Group must first be Approved to become a “Draft Specification”.  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
 
-**4.3.	Working Group Approval.**  Once the Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to “Approved Specification” status. 
+**4.3.	Working Group Approval.**  Once the Working Group believes it has achieved the objectives for its specification as described in the [Scope](./SCOPE), it will Approve that Draft Specification and progress it to “Approved Specification” status. 
 
 **4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer(s) will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Upon enrollment as an [FDC3 voting participant](https://github.com/orgs/finos/te
 FDC3 Editors are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. The appointment of an Editor is approved by the FDC3 Standards Working Group Participants.
 
 ### FDC3 Maintainers
-FDC3 maintainers are responsible for organizing activities around developing, maintaining, and updating the specification developed by the FDC3 Standard Working Group. Maintainers are also responsible for determining consensus and coordinating appeals, as well as FDC3-related planning and communications. The appointment of an Editor is approved by the FDC3 Standards Working Group Participants.
+FDC3 Maintainers are responsible for organizing activities around developing, maintaining, and updating the specification developed by the FDC3 Standard Working Group. Maintainers are also responsible for determining consensus and coordinating appeals, as well as FDC3-related planning and communications. The appointment of a Maintainer is approved by the FDC3 Standards Working Group Participants.
 
 #### Mailing list
 You can contact the FDC3 maintainers by sending an email to [fdc3-maintainers@finos.org](mailto:fdc3-maintainers@finos.org).

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Finally, another great way to interact with the community, is to attend the mont
 ### Need help?
 Email [fdc3@finos.org](mailto:fdc3@finos.org) if you need help getting started in the FDC3 Community. If you encounter technical difficulties accessing repositories, joining Slack, mailing lists or meetings, please email [help@finos.org](mailto:help@finos.org).
 
-## Become an FDC3 Participant or Maintainer
-Email [fdc3@finos.org](mailto:fdc3@finos.org) if you would like to become an FDC3 Participant or Maintainer.
+## Become an FDC3 Participant, Editor or Maintainer
+Email [fdc3@finos.org](mailto:fdc3@finos.org) if you would like to become an FDC3 Participant, Editor or Maintainer. For more details on FDC3's governance please see our [Governance document](GOVERNANCE.md).
 
 ### FDC3 Participants
 FDC3 Participants are those that make and have made contributions to the FDC3 Standard Working Group. The [FDC3 Standard Working Group](https://github.com/finos/FDC3/issues?q=label%3A%22Standard+WG+Meeting%22) has the specific purpose of defining and releasing subsequent updates to the standard. 
@@ -152,8 +152,11 @@ Please note that standard participants are bound to the provisions in the [FINOS
 
 Upon enrollment as an [FDC3 voting participant](https://github.com/orgs/finos/teams/fdc3-participants), you will be invited to join the [FINOS GitHub organization](https://github.com/orgs/finos/people) and the [fdc3-participants](https://github.com/orgs/finos/teams/fdc3-participants) GitHub team.
 
+### FDC3 Editors
+FDC3 Editors are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. The appointment of an Editor is approved by the FDC3 Standards Working Group Participants.
+
 ### FDC3 Maintainers
-FDC3 maintainers are responsible for organizing activities around developing, maintaining, and updating the specification developed by the FDC3 Standard Working Group. Maintainers are also responsible for determining consensus and coordinating appeals, as well as FDC3-related planning and communications. 
+FDC3 maintainers are responsible for organizing activities around developing, maintaining, and updating the specification developed by the FDC3 Standard Working Group. Maintainers are also responsible for determining consensus and coordinating appeals, as well as FDC3-related planning and communications. The appointment of an Editor is approved by the FDC3 Standards Working Group Participants.
 
 #### Mailing list
 You can contact the FDC3 maintainers by sending an email to [fdc3-maintainers@finos.org](mailto:fdc3-maintainers@finos.org).
@@ -162,23 +165,20 @@ You can contact the FDC3 maintainers by sending an email to [fdc3-maintainers@fi
 An archive of FDC3 documentation and meeting notes is available at https://finosfoundation.atlassian.net/wiki/spaces/FDC3/overview. The mailing list archive for fdc3@finos.org is available at https://groups.google.com/a/finos.org/g/fdc3
 
 # Contributing
+If you'd like to contribute to the FDC3 standard, or have noticed something that needs correcting, the first step is to [raise an issue on the FDC3 Github Repo](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue) and describe what you'd like to see changed. There are a number of issue templates that you can choose from [here](https://github.com/finos/FDC3/issues/new/choose).
 
-If you'd like to contribute code to this repository:
+Issues that change the Standard usually need discussion. You can post comments directly on the issue or can ask for it to be added to a Standards Working Group meeting agenda by emailing [fdc3@finos.org](mailto:fdc3@finos.org), sending a message to the [#fdc3 channel on the FINOS slack](https://finos-lf.slack.com/messages/fdc3/) or tag the FDC3 maintainers (`@finos/fdc3-maintainers`) in your issue.
 
-1. Fork it (<https://github.com/finos/FDC3/fork>)
-2. Create your feature branch (`git checkout -b feature/fooBar`)
-3. Read our [contribution guidelines](CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
-4. Commit your changes (`git commit -am 'add some fooBar'`)
-5. Push to the branch (`git push origin feature/fooBar`)
-6. Create a new Pull Request
+To implement changes in the FDC3 repository resolving an issue please read our [contribution guidelines](CONTRIBUTING.md).
 
-_NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS, _OR_ who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the FINOS `cla-bot` tool. Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
+
+_NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS, _OR_ who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [Linux Foundation `EasyCLA` tool](https://easycla.lfx.linuxfoundation.org/#/). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.
 
 *Need an ICLA? Unsure if you are covered under an existing CCLA? Email [help@finos.org](mailto:help@finos.org).*
 
 # License
 
-Copyright 2017-2021 FINOS and FDC3 Participants
+Copyright 2017-2022 FINOS and FDC3 Participants
 
 Version 1.0 of the FDC3 specification is licensed under the [FDC3 1.0 Final Specification License](PATENTS-FDC3-1.0.md).
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ If you'd like to contribute to the FDC3 standard, or have noticed something that
 
 Issues that change the Standard usually need discussion. You can post comments directly on the issue or can ask for it to be added to a Standards Working Group meeting agenda by emailing [fdc3@finos.org](mailto:fdc3@finos.org), sending a message to the [#fdc3 channel on the FINOS slack](https://finos-lf.slack.com/messages/fdc3/) or tag the FDC3 maintainers (`@finos/fdc3-maintainers`) in your issue.
 
-To implement changes in the FDC3 repository resolving an issue please read our [contribution guidelines](CONTRIBUTING.md).
+To implement changes in the FDC3 repository resolving an issue please read our [contribution guidelines](CONTRIBUTING.md). 
+
+Contributions merged into the master branch of the FDC3 repository will form part of the next pre-draft of the FDC3 Standard (as defined by the [FDC3 Governance document](./GOVERNANCE.md)), which must be approved by the Standard Working Group voting participants before it is accepted as a draft and subsequently released as the next version of the Standard.
 
 
 _NOTE:_ Commits and pull requests to FINOS repositories will only be accepted from those contributors with an active, executed Individual Contributor License Agreement (ICLA) with FINOS, _OR_ who are covered under an existing and active Corporate Contribution License Agreement (CCLA) executed with FINOS. Commits from individuals not covered under an ICLA or CCLA will be flagged and blocked by the [Linux Foundation `EasyCLA` tool](https://easycla.lfx.linuxfoundation.org/#/). Please note that some CCLAs require individuals/employees to be explicitly named on the CCLA.

--- a/docs/fdc3-intro.md
+++ b/docs/fdc3-intro.md
@@ -36,7 +36,9 @@ FDC3 was launched in October 2017 by [OpenFin](http://www.openfin.co) in collabo
 
 FDC3 is hosted within, and governed by the policies of, the [Fintech Open Source Foundation](http://finos.org/) (FINOS). FINOS is an independent nonprofit organization focused on promoting open innovation within financial services.
 
-See the [FDC3 Charter](fdc3-charter#licensing) for details of how deliverables are licensed.
+- See the [FDC3 Governance document](https://github.com/finos/FDC3/blob/master/GOVERNANCE.md) for details of how FDC3 is governed.
+- See the [FDC3 Contribution Guide](https://github.com/finos/FDC3/blob/master/CONTRIBUTING.md) for details of how to contribute to FDC3.
+- See the [FDC3 Charter](fdc3-charter#licensing) for details of how deliverables are licensed.
 
 ## Where should I go next?
 


### PR DESCRIPTION
resolves #527, resolves #529 

Adds: 
- a contribution guide to the repository based on the [CSL contribution guide 1.0](https://github.com/finos/standards-project-blueprint/edit/master/6._Contributing.md), 
- link from governance doc to scope doc
- links from fdc3-intro to the contribution guide, governance doc and chart
- links README to contribution guide and reduces duplication
- details about Editors to the README to bring it into line with the Governance doc