### PR TITLE
Add ViewHoldings intent

### DIFF
--- a/docs/intents/ref/ViewHoldings.md
+++ b/docs/intents/ref/ViewHoldings.md
@@ -1,0 +1,48 @@
+---
+id: ViewHoldings
+sidebar_label: ViewHoldings
+title: ViewHoldings
+hide_title: true
+---
+# `ViewHoldings`
+
+Display any holdings for the provided instrument, list of instruments, or organization.
+
+## Intent Name
+
+`ViewHoldings`
+
+## Display Name
+
+`View Holdings`
+
+## Possible Contexts
+
+* [Instrument](../../context/ref/Instrument)
+* [InstrumentList](../../context/ref/InstrumentList)
+* [Organization](../../context/ref/Organization)
+
+## Example
+
+```js
+const instrument = {
+    type: 'fdc3.instrument',
+    name: 'Tesla, Inc.',
+    id: {
+        ticker: 'TSLA'
+    }
+}
+
+fdc3.raiseIntent('ViewHoldings', instrument)
+```
+
+## See Also
+
+Context
+- [Instrument](../../context/ref/Instrument)
+- [InstrumentList](../../context/ref/InstrumentList)
+- [Organization](../../context/ref/Organization)
+
+Intents
+- [ViewInstrument](ViewInstrument)
+- [ViewAnalysis](ViewAnalysis)

--- a/src/intents/Intents.ts
+++ b/src/intents/Intents.ts
@@ -7,4 +7,5 @@ export enum Intents {
   ViewNews = 'ViewNews',
   ViewInstrument = 'ViewInstrument',
   ViewAnalysis = 'ViewAnalysis',
+  ViewHoldings = 'ViewHoldings',
 }

--- a/src/intents/standard intents.json
+++ b/src/intents/standard intents.json
@@ -31,6 +31,10 @@
     {
       "name": "ViewAnalysis",
       "displayName": "Analyze"
+    },
+    {
+      "name": "ViewHoldings",
+      "displayName": "Holdings"
     }
   ]
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -39,7 +39,8 @@
           "intents/ref/ViewQuote",
           "intents/ref/ViewNews",
           "intents/ref/ViewAnalysis",
-          "intents/ref/ViewInstrument"
+          "intents/ref/ViewInstrument",
+          "intents/ref/ViewHoldings"
         ]
       }
     ],


### PR DESCRIPTION
- Add new intent documentation page and include in sidebar.
- Add to Intents enumeration for npm package.
- Add to standard intents JSON file.

Note that this doesn't add an `OrganizationList` context type as suggested in the issue, it is best considered separately.

![image](https://user-images.githubusercontent.com/3295115/148946960-45898938-2fdd-4770-8da8-f147cb80003a.png)

Resolves #497