### PR TITLE
appd examples in correctly use `icons[].url` instead of `icons[].src`

### DIFF
--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -427,7 +427,7 @@ components:
         version: 1.0.0,
         tooltip: FDC3 Workbench
         icons:
-          - url: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+          - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
         images:
           - url: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
             tooltip: FDC3 logo
@@ -502,7 +502,7 @@ components:
             version: 1.0.0,
             tooltip: FDC3 Workbench
             icons:
-              - url: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+              - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
             images:
               - url: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
                 tooltip: FDC3 logo

--- a/src/app-directory/specification/examples/application/fdc3-workbench.json
+++ b/src/app-directory/specification/examples/application/fdc3-workbench.json
@@ -7,7 +7,7 @@
   "tooltip": "FDC3 Workbench",
   "icons": [
     {
-      "url": "http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png"
+      "src": "http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png"
     }
   ],
   "images": [


### PR DESCRIPTION
Correcting a minor issue in the AppD example responses where an `icons[].url` field was used instead of an `icons[].src` field.