### PR TITLE
Fix for stylesheet do not publish #630 at endpoint fdc3-explained/1.2/

### DIFF
--- a/toolbox/fdc3-explained/1.2/index.html
+++ b/toolbox/fdc3-explained/1.2/index.html
@@ -7,7 +7,7 @@
 
 
 <meta charset="UTF-8">
-	<link rel="stylesheet" href="./styles.css">
+	<link rel="stylesheet" href="./styles.css" />
 	<script type="module" src="./main.js" defer></script>
 
 </head>


### PR DESCRIPTION
Fix for no styles found at endpoint 'toolbox/fdc3-explained/1.2/index.html' as described in issue #630 .