### PR TITLE
fixing a number of broken 'see also' links in the API docs

### DIFF
--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -183,7 +183,7 @@ Find all the available instances for a particular application.
 
 If there are no instances of the specified application the returned promise should resolve to an empty array.
 
-If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](ResolveError) enumeration.
+If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration.
 
 ### Example
 ```js
@@ -530,7 +530,7 @@ fdc3.joinUserChannel(selectedChannel.id);
    */
 joinChannel(channelId: string) : Promise<void>;
 ```
-Alias to the [`joinUserChannel`](#joinUserChannel) function provided for backwards compatibility with version 1.1 & 1.2 of the FDC3 standard.
+Alias to the [`joinUserChannel`](#joinuserchannel) function provided for backwards compatibility with version 1.1 & 1.2 of the FDC3 standard.
 
 #### See also
 * [`joinUserChannel`](#joinuserchannel)
@@ -570,9 +570,9 @@ open(app: TargetApp, context?: Context): Promise<AppMetadata>;
 
 Launches an app with target information, which can be either be a string like a name, or an [`AppMetadata`](Metadata#appmetadata) object.
 
-The `open` method differs in use from [`raiseIntent`](#raiseIntent).  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying the App Directory, `open` would be used to open an app returned in the search results.
+The `open` method differs in use from [`raiseIntent`](#raiseintent).  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying the App Directory, `open` would be used to open an app returned in the search results.
 
-**Note**, if the intent, context and target app name are all known, it is recommended to instead use [`raiseIntent`](#raiseIntent) with the `target` argument.
+**Note**, if the intent, context and target app name are all known, it is recommended to instead use [`raiseIntent`](#raiseintent) with the `target` argument.
 
 If a [`Context`](Types#context) object is passed in, this object will be provided to the opened application via a contextListener. The Context argument is functionally equivalent to opening the target app with no context and broadcasting the context directly to it.
 

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -16,8 +16,8 @@ An interface that represents the binding of an intent to apps, returned as part 
 For each intent, it reference the applications that support that intent.
 
 ### See also
-* [`AppMetadata`](AppMetadata)
-* [`IntentMetadata`](IntentMetadata)
+* [`AppMetadata`]#appmetadata)
+* [`IntentMetadata`](#intentmetadata)
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
 * [`DesktopAgent.findIntentsByContext`](DesktopAgent#findintentsbycontext)
 
@@ -72,8 +72,8 @@ Optionally, extra information from the app directory can be returned, to aid in 
 In situations where a desktop agent connects to multiple app directories or multiple versions of the same app exists in a single app directory, it may be necessary to specify `appId` or `version` to target applications that share the same name.
 
 #### See also
-* [`AppIntent.apps`](AppIntent)
-* [`Icon`](Icon)
+* [`AppIntent.apps`](#appintent)
+* [`Icon`](Types#icon)
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 
@@ -138,7 +138,7 @@ The interface used to describe an intent within the platform.
 
 
 ### See also
-* [`AppIntent.intent`](AppIntent)
+* [`AppIntent.intent`](#appintent)
 
 ## `IntentResolution`
 
@@ -215,4 +215,4 @@ try {
 ### See also
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 * [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseintentforcontext)
-* [`TargetApp`](TargetApp)
+* [`TargetApp`](Types#targetapp)

--- a/docs/api/ref/Types.md
+++ b/docs/api/ref/Types.md
@@ -28,10 +28,10 @@ This means that it must at least have a `type` property that indicates what type
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
 * [`DesktopAgent.findIntentsByContext`](DesktopAgent#findintentsbycontext)
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
-* [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseIntentForContext)
+* [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseintentforcontext)
 * [`Channel.broadcast`](Channel#broadcast)
-* [`Channel.getCurrentContext`](Channel#getCurrentContext)
-* [`Channel.addContextListener`](Channel#addContextListener)
+* [`Channel.getCurrentContext`](Channel#getcurrentcontext)
+* [`Channel.addContextListener`](Channel#addcontextlistener)
 
 ## `ContextHandler`
 

--- a/website/versioned_docs/version-1.2/api/ref/DesktopAgent.md
+++ b/website/versioned_docs/version-1.2/api/ref/DesktopAgent.md
@@ -132,7 +132,7 @@ _findIntent_ is effectively granting programmatic access to the Desktop Agent's 
 It returns a promise resolving to the intent, its metadata and metadata about the apps that are registered to handle it.
 This can be used to raise the intent against a specific app.
 
-If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](ResolveError) enumeration.
+If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration.
 
 #### Examples
 ```js
@@ -161,7 +161,7 @@ Find all the available intents for a particular context.
 _findIntentsByContext_ is effectively granting programmatic access to the Desktop Agent's resolver.
 A promise resolving to all the intents, their metadata and metadata about the apps that registered as handlers is returned, based on the context types the intents have registered.
 
- If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](ResolveError) enumeration.
+ If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration.
 
  #### Example
  ```js
@@ -246,7 +246,7 @@ getOrCreateChannel(channelId: string): Promise<Channel>;
 ```
 
 Returns a Channel object for the specified channel, creating it (as an _App_ channel) - if it does not exist.
-`Error` with a string from the [`ChannelError`](ChannelError) enumeration if channel could not be created or access was denied.
+`Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration if channel could not be created or access was denied.
 
 #### Example
 

--- a/website/versioned_docs/version-1.2/api/ref/Metadata.md
+++ b/website/versioned_docs/version-1.2/api/ref/Metadata.md
@@ -18,8 +18,8 @@ An interface that represents the binding of an intent to apps, returned as part 
 For each intent, it reference the applications that support that intent.
 
 #### See also
-* [`AppMetadata`](AppMetadata)
-* [`IntentMetadata`](IntentMetadata)
+* [`AppMetadata`](#appmetadata)
+* [`IntentMetadata`](#intentmetadata)
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
 * [`DesktopAgent.findIntentsByContext`](DesktopAgent#findintentsbycontext)
 
@@ -48,7 +48,7 @@ This includes a title, description, tooltip and icon and image URLs.
 In situations where a desktop agent connects to multiple app directories or multiple versions of the same app exists in a single app directory, it may be neccessary to specify appId and version to target applications that share the same name.
 
 #### See also
-* [`AppIntent.apps`](AppIntent)
+* [`AppIntent.apps`](#appintent)
 
 ## `DisplayMetadata`
 
@@ -106,7 +106,7 @@ public interface ImplementationMetadata {
 Metadata relating to the FDC3 [DesktopAgent](DesktopAgent) object and its provider, including the supported version of the FDC3 specification and the name of the provider of the implementation.
 
 #### See also
-* [`DesktopAgent.getInfo`](DesktopAgent#getInfo)
+* [`DesktopAgent.getInfo`](DesktopAgent#getinfo)
 
 ## `IntentMetadata`
 
@@ -121,7 +121,7 @@ The Interface used to describe an Intent within the platform.
 
 
 #### See also
-* [`AppIntent.intent`](AppIntent)
+* [`AppIntent.intent`](#appintent)
 
 ## `IntentResolution`
 
@@ -147,4 +147,4 @@ const intentResolution = await fdc3.raiseIntent("intentName", context);
 #### See also
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 * [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseintentforcontext)
-* [`TargetApp`](TargetApp)
+* [`TargetApp`](Types#targetapp)


### PR DESCRIPTION
There are a number of bad see also links in teh 1.2 and 2.0 docs, which this PR corrects. 

Note: I didn't check further back, but I think most stem from the consolidation of 'Metadata' and 'Types' under articles of that name hence 1.1 is less likely to be affected.