### PR TITLE
Adjust CSS for showcase logos to resolve display issues at multiple breakpoints

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -46,10 +46,12 @@ header.postHeader:empty + article h1 {
 }
 
 .showcase img {
-  width: 250px;
-  max-height: 150px;
+  max-width: 250px;
+  max-height: 120px;
   padding-left: 15px;
   padding-right: 15px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .finos {


### PR DESCRIPTION
Addition of a logo with different proportions to the others highlighted some issues in the showcase CSS which was distorting the logos dimensions and displaying logos poorly at mobile breakpoints.

Before:
![image](https://user-images.githubusercontent.com/1701764/164204839-3b5d3995-58a2-4e57-bc99-fc44e7686d3f.png)

![image](https://user-images.githubusercontent.com/1701764/164204896-c8ff5fea-1da3-4d05-b0ef-41532d21f943.png)


After:
![image](https://user-images.githubusercontent.com/1701764/164204995-9a0f136c-ea1f-4b79-a4b3-aae09bfb54a1.png)

![image](https://user-images.githubusercontent.com/1701764/164205070-fcec9db4-95ec-4513-941c-38aa63783655.png)

