### PR TITLE
567 AppD more info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * A Trademarks page was added to acknowledge trademarks used within the Standard not owned by FINOS or the Linux Foundation ([#534](https://github.com/finos/FDC3/pull/534))
 * Added details of FDC3's existing versioning and deprecation policies to the FDC3 compliance page ([#539](https://github.com/finos/FDC3/pull/539))
 * Add `IntentDeliveryFailed` to the `ResolveError` enumeration to be used when delivery of an intent and context to a targetted app or instance fails. ([#601](https://github.com/finos/FDC3/pull/601))
-
+* Added a `moreInfo` URL field to AppD application records to enable linking to a web page with more information on an app ([#669](https://github.com/finos/FDC3/pull/669))
 ### Changed
 * Consolidated `Listener` documentation with other types ([#404](https://github.com/finos/FDC3/pull/404))
 * Updated definition of the `Position` context type to support negative (short) positions ([#419](https://github.com/finos/FDC3/pull/419))

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -469,10 +469,16 @@ components:
             $ref: '#/components/schemas/AppImage'
         contactEmail:
           type: string
+          format: email
           description: Optional e-mail to receive queries about the application
         supportEmail:
           type: string
+          format: email
           description: Optional e-mail to receive support requests for the application
+        moreInfo:
+          type: string
+          format: uri
+          description: Optional URL that provides more infomation about the application
         publisher:
           type: string
           description: >-
@@ -568,9 +574,11 @@ components:
             $ref: '#/components/schemas/AppImage'
         contactEmail:
           type: string
+          format: email
           description: Optional e-mail to receive queries about the application
         supportEmail:
           type: string
+          format: email
           description: Optional e-mail to receive support requests for the application
         publisher:
           type: string
@@ -636,6 +644,7 @@ components:
       properties:
         src:
           type: string
+          format: uri
           description: Icon URL
         size:
           type: string
@@ -648,12 +657,14 @@ components:
       properties:
         icon:
           type: string
+          format: uri
           description: Icon URL
     AppImage:
       description: App Image holder
       properties:
         url:
           type: string
+          format: uri
           description: App Image URL
     Intent:
       description: >-
@@ -727,6 +738,7 @@ components:
       properties:
         url:
           type: string
+          format: uri
           description: Application URL.
       additionalProperties: false
     HostManifests:
@@ -761,6 +773,7 @@ components:
             tooltip: FDC3 logo
         contactEmail: fdc3@finos.org
         supportEmail: fdc3-maintainers@finos.org
+        moreInfo: https://fdc3.finos.org #update to point to implementations page when it exists
         publisher: FDC3
         intents: [{
           name: ViewChart,

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -469,10 +469,16 @@ components:
             $ref: '#/components/schemas/AppImage'
         contactEmail:
           type: string
+          format: email
           description: Optional e-mail to receive queries about the application
         supportEmail:
           type: string
+          format: email
           description: Optional e-mail to receive support requests for the application
+        moreInfo:
+          type: string
+          format: uri
+          description: Optional URL that provides more infomation about the application
         publisher:
           type: string
           description: >-
@@ -568,9 +574,11 @@ components:
             $ref: '#/components/schemas/AppImage'
         contactEmail:
           type: string
+          format: email
           description: Optional e-mail to receive queries about the application
         supportEmail:
           type: string
+          format: email
           description: Optional e-mail to receive support requests for the application
         publisher:
           type: string
@@ -636,6 +644,7 @@ components:
       properties:
         src:
           type: string
+          format: uri
           description: Icon URL
         size:
           type: string
@@ -648,12 +657,14 @@ components:
       properties:
         icon:
           type: string
+          format: uri
           description: Icon URL
     AppImage:
       description: App Image holder
       properties:
         url:
           type: string
+          format: uri
           description: App Image URL
     Intent:
       description: >-
@@ -727,6 +738,7 @@ components:
       properties:
         url:
           type: string
+          format: uri
           description: Application URL.
       additionalProperties: false
     HostManifests:
@@ -761,6 +773,7 @@ components:
             tooltip: FDC3 logo
         contactEmail: fdc3@finos.org
         supportEmail: fdc3-maintainers@finos.org
+        moreInfo: https://fdc3.finos.org #update to point to implementations page when it exists
         publisher: FDC3
         intents: [{
           name: ViewChart,


### PR DESCRIPTION
resolves #567

- Adds the more info field
- Adds format tags to string fields that should already have them, e.g. supportEmail:
![image](https://user-images.githubusercontent.com/1701764/164280673-d520f7cf-3862-466c-a606-f24c569b70ef.png)

Change agreed at meeting:
- #664 