### PR TITLE
562 AppD vendor agnostic native apps

### DIFF
--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -426,10 +426,11 @@ components:
           $ref: '#/components/schemas/Type'
         details:
           description: >-
-            The type specific details of the application. Currently only the "browser" type is standardized.
-            "host" type applications should use the hostManifest's object for all application details.
+            The type specific launch details of the application. These details are intended to be 
+            vendor-agnostic and _MAY_ be duplicated or overridden by details provided in the hostManifests 
+            object for a specific host.
           oneOf:
-            - $ref: '#/components/schemas/BrowserDetails'
+            - $ref: '#/components/schemas/LaunchDetails'
         version:
           type: string
           description: >-
@@ -726,28 +727,72 @@ components:
     Type:
       type: string
       description: >-
-        Enumeration describing the supported application types. Currently only the browser application type is officially supported.
-        The host application type allows for host specific application types (e.g. exe, workspaces, citrix, etc.).
+        The technology type that is used to launch and run the application. Particular application types imply
       enum:
-        - browser
-        - host
-    BrowserDetails:
-      description: Properties common to all browser applications.
+        - web
+        - native
+        - citrix
+        - clickonce
+    LaunchDetails:
+      description: Properties used to launch apps of various types. 
+      oneOf:
+        - $ref: '#/components/schemas/WebAppDetails'
+        - $ref: '#/components/schemas/NativeAppDetails'
+        - $ref: '#/components/schemas/CitrixAppDetails'
+        - $ref: '#/components/schemas/OnlineNativeAppDetails'
+    WebAppDetails:
+      description: Properties used to launch web apps.
       required:
         - url
       properties:
         url:
           type: string
-          description: Application URL.
+          formt: uri
+          description: Application start URL.
+      additionalProperties: false
+    NativeAppDetails:
+      description: Properties used to launch native apps installed on a desktop.
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: The path on disk from which the application is launched.
+        arguments:
+          type: string
+          description: Arguments that must be passed on the command line to launch the app in the expected configuration.
+      additionalProperties: false
+    CitrixAppDetails:
+      description: Properties used to launch apps virtualized via Citrix.
+      required:
+        - alias
+      properties:
+        alias:
+          type: string
+          description: Application start URL.
+        arguments:
+          type: string
+          description: Arguments that must be passed on the command line to launch the app in the expected configuration.
+      additionalProperties: false
+    OnlineNativeAppDetails:
+      description: Properties used to launch native application with an online launcher, e.g. online ClickOnce app deployments.
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          formt: uri
+          description: Application start URL.
       additionalProperties: false
     HostManifests:
       type: object
       description: >-
-        A mapping from host string to a host-specific application manifest object or URI
-        from which that manifest can be retrieved. The manifest should provide all details required to
-        launch and use the application within the specified host.
+        A mapping from host name to a host-specific application manifest object or URI
+        from which that manifest can be retrieved. The manifest should provide details required to
+        launch and use the application within the specified host. The manifest _MAY_ duplicate or 
+        override information provided in the `details` field.
       additionalProperties:
-        x-additionalPropertiesName: Host
+        x-additionalPropertiesName: Host name
         oneOf:
           - type: string   # URI pointing to a JSON containing all host specific properties
             format: uri

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -503,10 +503,11 @@ components:
         Launching typically means running for a user on a desktop.
         The details around 'launching' including who or what might do it, and how the launch action is initiated are
         discussed elsewhere in the FDC3 App Directory spec.
-      required:            # details are not required as the host type applications use the hostsManifests mapping instead
+      required:
         - appId
         - name
         - type
+        - details
       allOf:
         - $ref: '#/components/schemas/BaseApplication'
         - type: object

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -426,10 +426,11 @@ components:
           $ref: '#/components/schemas/Type'
         details:
           description: >-
-            The type specific details of the application. Currently only the "browser" type is standardized.
-            "host" type applications should use the hostManifest's object for all application details.
+            The type specific launch details of the application. These details are intended to be 
+            vendor-agnostic and _MAY_ be duplicated or overridden by details provided in the hostManifests 
+            object for a specific host.
           oneOf:
-            - $ref: '#/components/schemas/BrowserDetails'
+            - $ref: '#/components/schemas/LaunchDetails'
         version:
           type: string
           description: >-
@@ -726,28 +727,72 @@ components:
     Type:
       type: string
       description: >-
-        Enumeration describing the supported application types. Currently only the browser application type is officially supported.
-        The host application type allows for host specific application types (e.g. exe, workspaces, citrix, etc.).
+        The technology type that is used to launch and run the application. Particular application types imply
       enum:
-        - browser
-        - host
-    BrowserDetails:
-      description: Properties common to all browser applications.
+        - web
+        - native
+        - citrix
+        - clickonce
+    LaunchDetails:
+      description: Properties used to launch apps of various types. 
+      oneOf:
+        - $ref: '#/components/schemas/WebAppDetails'
+        - $ref: '#/components/schemas/NativeAppDetails'
+        - $ref: '#/components/schemas/CitrixAppDetails'
+        - $ref: '#/components/schemas/OnlineNativeAppDetails'
+    WebAppDetails:
+      description: Properties used to launch web apps.
       required:
         - url
       properties:
         url:
           type: string
-          description: Application URL.
+          formt: uri
+          description: Application start URL.
+      additionalProperties: false
+    NativeAppDetails:
+      description: Properties used to launch native apps installed on a desktop.
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: The path on disk from which the application is launched.
+        arguments:
+          type: string
+          description: Arguments that must be passed on the command line to launch the app in the expected configuration.
+      additionalProperties: false
+    CitrixAppDetails:
+      description: Properties used to launch apps virtualized via Citrix.
+      required:
+        - alias
+      properties:
+        alias:
+          type: string
+          description: Application start URL.
+        arguments:
+          type: string
+          description: Arguments that must be passed on the command line to launch the app in the expected configuration.
+      additionalProperties: false
+    OnlineNativeAppDetails:
+      description: Properties used to launch native application with an online launcher, e.g. online ClickOnce app deployments.
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          formt: uri
+          description: Application start URL.
       additionalProperties: false
     HostManifests:
       type: object
       description: >-
-        A mapping from host string to a host-specific application manifest object or URI
-        from which that manifest can be retrieved. The manifest should provide all details required to
-        launch and use the application within the specified host.
+        A mapping from host name to a host-specific application manifest object or URI
+        from which that manifest can be retrieved. The manifest should provide details required to
+        launch and use the application within the specified host. The manifest _MAY_ duplicate or 
+        override information provided in the `details` field.
       additionalProperties:
-        x-additionalPropertiesName: Host
+        x-additionalPropertiesName: Host name
         oneOf:
           - type: string   # URI pointing to a JSON containing all host specific properties
             format: uri
@@ -764,7 +809,7 @@ components:
         The keys to this object should be language tags as defined by IETF RFC 5646, e.g. en, en-GB or fr-FR.
       additionalProperties:
         x-additionalPropertiesName: Language tag
-        $ref: '#/components/schemas/BaseApplication'
+        $ref: '#/components/schemas/BaseApplication' # due to a bug in redoc this may display as a recursive definition, it is not. It will render correctly in swagger and other OpenAPI parsers.
   examples:
     FDC3WorkbenchAppDefinition:
       value:

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -503,10 +503,11 @@ components:
         Launching typically means running for a user on a desktop.
         The details around 'launching' including who or what might do it, and how the launch action is initiated are
         discussed elsewhere in the FDC3 App Directory spec.
-      required:            # details are not required as the host type applications use the hostsManifests mapping instead
+      required:
         - appId
         - name
         - type
+        - details
       allOf:
         - $ref: '#/components/schemas/BaseApplication'
         - type: object


### PR DESCRIPTION
resolves #562 

Introduces launch details for native application types and adjusts the standardized application types to accommodate. Also adjusts the relationship between `type`, `details` and `hostManifests` by eliminating the `host` application type and allowing `hostManifests` to override `details` if they want/need to.  I believe this makes the (vendor agnostic) `details` field more useful and more likely to be used than if it is simply ommited when a hostManifest is used. This allows `details` to become a required field.

Change was agreed in principle (but not in detail) at meeting:
- #664 