### PR TITLE
566 remove appd create application endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * The `fdc3.joinChannel()`, `fdc3.getCurrentChannel()` and `fdc3.leaveCurrentChannel()` functions have been made optional for FDC3 API compliance, but are recommended through the application of the SHOULD keyword. ([#512](https://github.com/finos/FDC3/pull/512)) 
 * All DesktopAgent and Channel API functions are now async for consistency, changing the return type of the `broadcast`, `addIntentListener`, `addContextListener` and `getInfo` functions ([#516](https://github.com/finos/FDC3/pull/516))
 * App Directory `images` field was replaced with `screenshots` to better align the application record with web application manifest and match its format to that used by `icons` ([#675](https://github.com/finos/FDC3/pull/675))
-* App Directory endpoint for creating applications was removed as these will often be implementation dependent and should not be required for compliance ([#](https://github.com/finos/FDC3/pull/))
+* App Directory endpoint for creating applications was removed as these will often be implementation dependent and should not be required for compliance ([#695](https://github.com/finos/FDC3/pull/695))
 
 ### Deprecated
 * Removed details of the 'global' channel that was deprecated in FDC3 1.2. ([#496](https://github.com/finos/FDC3/pull/496))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Moved the Icon type definition into the Types documentation page for consistency with other types. ([#493](https://github.com/finos/FDC3/pull/493)
 * The `fdc3.joinChannel()`, `fdc3.getCurrentChannel()` and `fdc3.leaveCurrentChannel()` functions have been made optional for FDC3 API compliance, but are recommended through the application of the SHOULD keyword. ([#512](https://github.com/finos/FDC3/pull/512)) 
 * All DesktopAgent and Channel API functions are now async for consistency, changing the return type of the `broadcast`, `addIntentListener`, `addContextListener` and `getInfo` functions ([#516](https://github.com/finos/FDC3/pull/516))
-* AppD `images` field was replaced with `screenshots` to better align the applicaiton record with web application manifest and match its format to that used by `icons` ([#675](https://github.com/finos/FDC3/pull/675))
+* App Directory `images` field was replaced with `screenshots` to better align the application record with web application manifest and match its format to that used by `icons` ([#675](https://github.com/finos/FDC3/pull/675))
+* App Directory endpoint for creating applications was removed as these will often be implementation dependent and should not be required for compliance ([#](https://github.com/finos/FDC3/pull/))
 
 ### Deprecated
 * Removed details of the 'global' channel that was deprecated in FDC3 1.2. ([#496](https://github.com/finos/FDC3/pull/496))

--- a/docs/app-directory/spec.md
+++ b/docs/app-directory/spec.md
@@ -12,7 +12,6 @@ View the [full specification](/schemas/next/app-directory) in [OpenAPI v3.0](htt
  Endpoint           | Method | Description
  ------------------ | ------ | -----------
  `/v2/apps`         | GET    | Retrieve all application definitions
- `/v2/apps`         | POST   | Create a new application definition
  `/v2/apps/{appId}` | GET    | Retrieve an application defintion
  `/v2/apps/search`  | GET    | Retrieve a list of applications
  `/v1/apps`         | POST   | (deprecated v1 API version) Create a new application definition

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -88,49 +88,6 @@ paths:
                 $ref: '#/components/schemas/ErrorDTO'
       tags:
         - Application
-    post:
-      summary: Create a new application definition
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Application'
-              examples:
-                FDC3WorkbenchAppDefinition:
-                  $ref: '#/components/examples/FDC3WorkbenchAppDefinition'
-        '400':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-        '403':
-          description: >-
-            Forbidden: Certificate authentication is not allowed for the
-            requested user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-        '500':
-          description: 'Server error, see response body for further details.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-      tags:
-        - Application
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Application'
-            examples:
-              FDC3WorkbenchAppDefinition:
-                $ref: '#/components/examples/FDC3WorkbenchAppDefinition'
-        required: true
   /v2/apps/search:
     get:
       summary: Retrieve a list of applications based on parameters provided.  Depending on implementation, parameter

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -88,49 +88,6 @@ paths:
                 $ref: '#/components/schemas/ErrorDTO'
       tags:
         - Application
-    post:
-      summary: Create a new application definition
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Application'
-              examples:
-                FDC3WorkbenchAppDefinition:
-                  $ref: '#/components/examples/FDC3WorkbenchAppDefinition'
-        '400':
-          description: Bad request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-        '403':
-          description: >-
-            Forbidden: Certificate authentication is not allowed for the
-            requested user.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-        '500':
-          description: 'Server error, see response body for further details.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorDTO'
-      tags:
-        - Application
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Application'
-            examples:
-              FDC3WorkbenchAppDefinition:
-                $ref: '#/components/examples/FDC3WorkbenchAppDefinition'
-        required: true
   /v2/apps/search:
     get:
       summary: Retrieve a list of applications based on parameters provided.  Depending on implementation, parameter


### PR DESCRIPTION
resolves #566 

Removes the REST endpoint for creating an application from the standard as this will usually be implementation dependent, should not be required for compliance  and doesn't benefit from standardisation (as 3rd parties will rarely be the ones adding apps to an appD). 