### PR TITLE
520 expose originating app identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+
 * Definition of the `icons` property of `AppMetadata`, based on PWA icon spec ([#319](https://github.com/finos/FDC3/pull/319))
 * Added support for raiseIntent without a context via the addition of the `fdc3.nothing` context type ([#375](https://github.com/finos/FDC3/pull/375))
 * Added [**FDC3 Workbench**](https://fdc3.finos.org/toolbox/fdc3-workbench/), an FDC3 API developer application ([#457](https://github.com/finos/FDC3/pull/457))
@@ -14,16 +15,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added the ability to return data from an intent, via the addition of an IntentHandler type and a `getResult()` to IntentResolution, both of which return a Promise of a Context object. ([#495](https://github.com/finos/FDC3/pull/495))
 * Added a field to specify the Context type that intent can return to the AppD Application schema and extended the findIntent API calls to be able to use it for resolution. ([#499](https://github.com/finos/FDC3/pull/499))
 * Added the ability to return a Channel from an intent (via the `IntentResult` type), resolver support for intents that return Channels and the concept of PrivateChannels. ([#508](https://github.com/finos/FDC3/pull/508))
-* Added error `UserCancelled` to the `ResolveError` enumeration to be used when user closes the resolver UI or otherwise cancels resolution of a raised intent ([#522 ](https://github.com/finos/FDC3/pull/522))
+* Added error `UserCancelled` to the `ResolveError` enumeration to be used when user closes the resolver UI or otherwise cancels resolution of a raised intent ([#522](https://github.com/finos/FDC3/pull/522))
 * Added an `instanceId` (and optional `instanceMetadata`) field to `AppMetadata` allowing it to refer to specific app instances and thereby supporting targetting of intents to specific app instances. Also added a `findInstances()` function to the desktop agent and `TargetAppUnavailable` and `TargetInstanceUnavailable` Errors to the `ResolveError` enumeration. ([#509]((https://github.com/finos/FDC3/pull/509))
 * Added a References and Bibliography section to the Standard's documentation to hold links to 'normative references' and other documentation that is useful for understanding the standard ([#530](https://github.com/finos/FDC3/pull/530))
 * `IntentResolution` now requires the name of the intent raised to included, allowing it to be used to determine the intent raised via `fdc3.raiseIntentForContext()`. ([#507](https://github.com/finos/FDC3/pull/507))
 * A Trademarks page was added to acknowledge trademarks used within the Standard not owned by FINOS or the Linux Foundation ([#534](https://github.com/finos/FDC3/pull/534))
 * Added details of FDC3's existing versioning and deprecation policies to the FDC3 compliance page ([#539](https://github.com/finos/FDC3/pull/539))
 * Added a new experimental features policy, which exempts features designated as experimental from the versioning and deprecation policies, to the FDC3 compliance page ([#549](https://github.com/finos/FDC3/pull/549))
-* Add `IntentDeliveryFailed` to the `ResolveError` enumeration to be used when delivery of an intent and context to a targetted app or instance fails. ([#601](https://github.com/finos/FDC3/pull/601))
+* Added `IntentDeliveryFailed` to the `ResolveError` enumeration to be used when delivery of an intent and context to a targetted app or instance fails. ([#601](https://github.com/finos/FDC3/pull/601))
+* Added the optional exposure of originating app metadata to messages received via `addContextListener` and `addIntentListener` via the new `ContextMetadata` type. ([#725](https://github.com/finos/FDC3/pull/725))
 
 ### Changed
+
 * Consolidated `Listener` documentation with other types ([#404](https://github.com/finos/FDC3/pull/404))
 * Updated definition of the `Position` context type to support negative (short) positions ([#419](https://github.com/finos/FDC3/pull/419))
 * Upgraded web access statements from SHOULD to MUST in the API specification ([#440](https://github.com/finos/FDC3/pull/440))
@@ -31,13 +34,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Adjusted wording in API spec and documentation to acknowledge the possibility of methods of intent resolution other than a resolver UI ([#461](https://github.com/finos/FDC3/pull/461))
 * Replaced 'System channels' with 'User channels' throughout the spec, documentation, API and methods.ts. Clarified spec and documentation where it is referring to User channels vs. App channels. Added support to methods.ts for automatic fallback to `getSystemChannels` if `getUserChannels` doesn't exist. ([#470](https://github.com/finos/FDC3/pull/479))
 * Moved the Icon type definition into the Types documentation page for consistency with other types. ([#493](https://github.com/finos/FDC3/pull/493)
-* The `fdc3.joinChannel()`, `fdc3.getCurrentChannel()` and `fdc3.leaveCurrentChannel()` functions have been made optional for FDC3 API compliance, but are recommended through the application of the SHOULD keyword. ([#512](https://github.com/finos/FDC3/pull/512)) 
+* The `fdc3.joinChannel()`, `fdc3.getCurrentChannel()` and `fdc3.leaveCurrentChannel()` functions have been made optional for FDC3 API compliance, but are recommended through the application of the SHOULD keyword. ([#512](https://github.com/finos/FDC3/pull/512))
 * All DesktopAgent and Channel API functions are now async for consistency, changing the return type of the `broadcast`, `addIntentListener`, `addContextListener` and `getInfo` functions ([#516](https://github.com/finos/FDC3/pull/516))
 
 ### Deprecated
+
 * Removed details of the 'global' channel that was deprecated in FDC3 1.2. ([#496](https://github.com/finos/FDC3/pull/496))
 
 ### Fixed
+
 * Removed trailing slashes from schema references (which break refs for schema parsers) ([#374](https://github.com/finos/FDC3/pull/374))
 * Corrected that definition of the `Context` type in documentation ([#406](https://github.com/finos/FDC3/pull/406)])
 * Corrected syntax errors in context schema examples ([#424](https://github.com/finos/FDC3/pull/424))
@@ -52,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [npm v1.2.0] - 2021-04-19
 
 ### Added
+
 * ES6 functions for `getInfo()` and `raiseIntentForContext()` ([#268](https://github.com/finos/FDC3/pull/268), [#324](https://github.com/finos/FDC3/pull/324))
 * `fdc3Ready()` utility function that wraps checks for the window.fdc3 global object and new `fdc3Ready` event ([#360](https://github.com/finos/FDC3/pull/360))
 * `compareVersionNumbers()` and `versionIsAtLeast()` utility functions to complement `getInfo()` ([#324](https://github.com/finos/FDC3/pull/324))
@@ -59,80 +65,93 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * A test environment for the app directory specification and the example application definition ([#437](https://github.com/finos/FDC3/pull/437)
 
 ### Changed
+
 * `addContextListener(contextType, handler)` now supports passing `null` as the context type ([#329](https://github.com/finos/FDC3/pull/329))
 * All other API type changes and additions from the [FDC3 Standard 1.2](https://github.com/finos/FDC3/releases/tag/v1.2) release
 * The Application schema by removing the `manifestType` and `manifest` properties, introducing new `type` (required), `details` and `hostManifests` properties ([#437](https://github.com/finos/FDC3/pull/437)
 
 ### Deprecated
+
 * `addContextListener(handler)` ([#329](https://github.com/finos/FDC3/pull/329))
 * `IntentResolution.data` ([#341](https://github.com/finos/FDC3/pull/341))
 
 ## [FDC3 Standard 1.2] - 2021-04-19
+
 ### Added
+
 * New `raiseIntentForContext()` method ([#268](https://github.com/finos/FDC3/pull/268))
 * New `fdc3Ready` event ([#269](https://github.com/finos/FDC3/pull/269))
 * New `getInfo()` method that returns implementation metadata ([#324](https://github.com/finos/FDC3/pull/324))
 
 ### Changed
+
 * `fdc3.open()` and `fdc3.raiseIntent()` now takes `TargetApp`, which resolves to `string | AppMetadata` ([#272](https://github.com/finos/FDC3/pull/272))
 * `AppMetadata` return type can now optionally include `appId` and `version` ([#273](https://github.com/finos/FDC3/pull/273))
 * `addContextListener(contextType, handler)` now supports passing `null` as the context type ([#329](https://github.com/finos/FDC3/pull/329))
 * Simplify API reference documentation and add info about supported platforms, including npm package ([#349](https://github.com/finos/FDC3/pull/349))
 
 ### Deprecated
+
 * `addContextListener(handler)` ([#329](https://github.com/finos/FDC3/pull/329))
 * `IntentResolution.data` and `'global'` channel concept ([#341](https://github.com/finos/FDC3/pull/341))
 
 ### Fixed
+
 * Return type of `getCurrentChannel()` should be `Promise<Channel | null>` ([#282](https://github.com/finos/FDC3/pull/282))
 * `leaveCurrentChannel()` is missing from `DesktopAgent` interface ([#283](https://github.com/finos/FDC3/pull/283))
 
 ## [npm v1.1.1] - 2021-04-15
-### Fixed
-* `Intents` enum should contain `StartChat` not `StartChart` ([#364](https://github.com/finos/FDC3/pull/364))
 
 ### Fixed
+
+* `Intents` enum should contain `StartChat` not `StartChart` ([#364](https://github.com/finos/FDC3/pull/364))
 * Return type of `getCurrentChannel()` should be `Promise<Channel | null>` ([#282](https://github.com/finos/FDC3/pull/282))
 * Missing `leaveCurrentChannel()` export ([#283](https://github.com/finos/FDC3/pull/283))
 
 ## [npm v1.1.0] - 2021-04-14
+
 ### Added
+
 * Build an npm package with exported TypeScript typings for API, Context Data and `window.fdc3` global ([#252](https://github.com/finos/FDC3/pull/252))
 * Export helper enums for names of standardised `Intents` and `ContextTypes` ([#264](https://github.com/finos/FDC3/pull/264))
 * Export API operations as ES6 functions that can be directly imported ([#266](https://github.com/finos/FDC3/pull/266))
 * Check for the existence of `window.fdc3` in ES6 functions, and reject or throw if not defined ([#356](https://github.com/finos/FDC3/pull/356))
 
 ### Fixed
+
 * Return type of `getCurrentChannel()` should be `Promise<Channel>` ([#222](https://github.com/finos/FDC3/pull/222))
 
 ## [FDC3 Standard 1.1] - 2020-04-09
+
 ### Added
+
 * JSON Schema definitions for agreed context types ([#119](https://github.com/finos/FDC3/pull/119)):
-    - `fdc3.context`
-    - `fdc3.instrument`
-    - `fdc3.instrumentList`
-    - `fdc3.contact`
-    - `fdc3.contactList`
-    - `fdc3.organization`
-    - `fdc3.country`
-    - `fdc3.position`
-    - `fdc3.portfolio`
+  * `fdc3.context`
+  * `fdc3.instrument`
+  * `fdc3.instrumentList`
+  * `fdc3.contact`
+  * `fdc3.contactList`
+  * `fdc3.organization`
+  * `fdc3.country`
+  * `fdc3.position`
+  * `fdc3.portfolio`
 * API entry point for web - `window.fdc3` ([#139](https://github.com/finos/FDC3/pull/139))
 * Use Case 17 ([#153](https://github.com/finos/FDC3/pull/153))
 * Channels API ([#154](https://github.com/finos/FDC3/pull/154)):
-    - `fdc3.getSystemChannels`
-    - `fdc3.getOrCreateChannel`
-    - `fdc3.joinChannel`
-    - `fdc3.leaveCurrentChannel`
-    - `fdc3.getCurrentChannel`
-    - `Channel` interface
-    - `DisplayMetadata` interface
-    - `ChannelError` type
+  * `fdc3.getSystemChannels`
+  * `fdc3.getOrCreateChannel`
+  * `fdc3.joinChannel`
+  * `fdc3.leaveCurrentChannel`
+  * `fdc3.getCurrentChannel`
+  * `Channel` interface
+  * `DisplayMetadata` interface
+  * `ChannelError` type
 * Type filtering support for `getCurrentContext` ([#161](https://github.com/finos/FDC3/pull/161))
 * Publish versioned JSON schemas to FDC3 website ([#170](https://github.com/finos/FDC3/pull/170))
 * Intent Reference and Context Data Reference documentation ([#172](https://github.com/finos/FDC3/pull/172))
 
 ### Changed
+
 * Remove FactSet-specific examples from docs ([#88](https://github.com/finos/FDC3/pull/88))
 * Apply FINOS branding, styles and logos to the website ([#96](https://github.com/finos/FDC3/pull/96))
 * Include ChartIQ in "Who is using FDC3?" section on website ([#100](https://github.com/finos/FDC3/pull/100))
@@ -140,17 +159,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Restructure some docs ([#190](https://github.com/finos/FDC3/pull/190))
 
 ### Fixed
+
 * Several typos and broken links in docs
 * Various security vulnerabilities
 
 ## [FDC3 Standard 1.0] - 2019-03-28
+
 ### Added
+
 * Documentation website (generated with [Docusaurus]) and content from old separate FDC3 repos ([#5](https://github.com/finos/FDC3/pull/5)):
-  - [FDC3/API](https://github.com/FDC3/API)
-  - [FDC3/ContextData](https://github.com/FDC3/ContextData)
-  - [FDC3/Intents](https://github.com/FDC3/Intents)
-  - [FDC3/appd-api](https://github.com/FDC3/appd-api)
-  - [FDC3/use-cases](https://github.com/FDC3/use-cases)
+  * [FDC3/API](https://github.com/FDC3/API)
+  * [FDC3/ContextData](https://github.com/FDC3/ContextData)
+  * [FDC3/Intents](https://github.com/FDC3/Intents)
+  * [FDC3/appd-api](https://github.com/FDC3/appd-api)
+  * [FDC3/use-cases](https://github.com/FDC3/use-cases)
 * Use Case 15 ([#49](https://github.com/finos/FDC3/pull/49))
 * FDC3 Roadmap ([#55](https://github.com/finos/FDC3/pull/55))
 * FDC3 feature icons on website landing page ([#57](https://github.com/finos/FDC3/pull/57))
@@ -159,11 +181,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [Docusaurus]: https://docusaurus.io
 
 ### Changed
+
 * General cleanup of spelling, grammar and punctuation ([#34](https://github.com/finos/FDC3/pull/34))
 * Use cases callout on website landing page ([#54](https://github.com/finos/FDC3/pull/54))
 * Proofreading of docs ([#62](https://github.com/finos/FDC3/pull/62))
 
 ### Fixed
+
 * Remove unnecessary dates from use case file names ([#41](https://github.com/finos/FDC3/pull/41))
 * Header colouring on responsive website ([#56](https://github.com/finos/FDC3/pull/56))
 * Workflow numbers in Use Case 1 ([#60](https://github.com/finos/FDC3/pull/60))

--- a/docs/api/ref/Channel.md
+++ b/docs/api/ref/Channel.md
@@ -19,10 +19,12 @@ interface Channel {
   type: "user" | "app" | "private";
   displayMetadata?: DisplayMetadata;
 
-  // methods
+  // functions
   broadcast(context: Context): Promise<void>;
   getCurrentContext(contextType?: string): Promise<Context|null>;
   addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener>;
+  
+  //deprecated functions
   /**
    * @deprecated Use `addContextListener(null, handler)` instead of `addContextListener(handler)`
    */
@@ -68,8 +70,7 @@ DisplayMetadata can be used to provide display hints for User Channels intended 
 
 * [`DisplayMetadata`](Metadata#displaymetadata)
 
-## Methods
-
+## Functions
 
 ### `addContextListener`
 
@@ -81,15 +82,7 @@ Adds a listener for incoming contexts of the specified _context type_ whenever a
 
 If, when this function is called, the channel already contains context that would be passed to the listener it is NOT called or passed this context automatically (this behavior differs from that of the [`fdc3.addContextListener`](DesktopAgent#addcontextlistener) function). Apps wishing to access to the current context of the channel should instead call the [`getCurrentContext(contextType)`](#getcurrentcontext) function.
 
-
-```ts
-/**
- * @deprecated Use `addContextListener(null, handler)` instead of `addContextListener(handler)`
- */
-public addContextListener(handler: ContextHandler): Promise<Listener>;
-```
-Adds a listener for incoming contexts whenever a broadcast happens on the channel.
-
+Optional metadata about each context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
 
 #### Examples
 
@@ -210,3 +203,19 @@ try {
 * [`broadcast`](#broadcast)
 * [`addContextListener`](#addcontextlistener)
 
+## Deprecated Functions
+
+### `addContextListener` (deprecated)
+
+```ts
+/**
+ * @deprecated Use `addContextListener(null, handler)` instead of `addContextListener(handler)`
+ */
+public addContextListener(handler: ContextHandler): Promise<Listener>;
+```
+
+Adds a listener for incoming contexts whenever a broadcast happens on the channel.
+
+#### See also
+
+* [`addContextListener`](#addcontextlistener)

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -68,9 +68,11 @@ addContextListener(contextType: string | null, handler: ContextHandler): Promise
  */
 addContextListener(handler: ContextHandler): Promise<Listener>;
 ```
-Adds a listener for incoming context broadcasts from the Desktop Agent. If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types. 
+Adds a listener for incoming context broadcasts from the Desktop Agent. If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
 
 Context broadcasts are only received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
+
+Optional metadata about each context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
 
 #### Examples
 ```js
@@ -79,14 +81,18 @@ const listener = await fdc3.addContextListener(null, context => { ... });
 
 // listener for a specific type
 const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
+
+// listener that logs metadata for the message a specific type
+const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => { 
+  console.log(`Received context message\nContext: ${contact}\nOriginating app: ${metadata?.sourceAppMetadata}`);
+  //do something else with the context
+});
 ```
 
 #### See also
 * [`Listener`](Types#listener)
 * [`Context`](Types#context)
 * [`ContextHandler`](Types#contexthandler)
-
-
 
 ### `addIntentListener`
 
@@ -100,12 +106,20 @@ The Desktop Agent MUST reject the promise returned by the `getResult()` function
 
 The [`PrivateChannel`](PrivateChannel) type is provided to support synchronisation of data transmitted over returned channels, by allowing both parties to listen for events denoting subscription and unsubscription from the returned channel. `PrivateChannels` are only retrievable via raising an intent.
 
+Optional metadata about each intent & context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
+
 #### Examples
 
 ```js
 //Handle a raised intent
 const listener = fdc3.addIntentListener('StartChat', context => {
-    // start chat has been requested by another application
+  // start chat has been requested by another application
+  return;
+});
+
+//Handle a raised intent and log the originating app metadata
+const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => { 
+  console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.sourceAppMetadata}`);
     return;
 });
 
@@ -122,7 +136,7 @@ fdc3.addIntentListener("QuoteStream", async (context) => {
   const channel: PrivateChannel = await fdc3.createPrivateChannel();
   const symbol = context.id.symbol;
 
-// Called when the remote side adds a context listener
+  // Called when the remote side adds a context listener
   const addContextListener = channel.onAddContextListener((contextType) => {
     // broadcast price quotes as they come in from our quote feed
     feed.onQuote(symbol, (price) => {

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -12,10 +12,12 @@ interface AppIntent {
   readonly apps: Array<AppMetadata>;
 }
 ```
+
 An interface that represents the binding of an intent to apps, returned as part of intent disocvery.
 For each intent, it reference the applications that support that intent.
 
 #### See also
+
 * [`AppMetadata`](#appmetadata)
 * [`IntentMetadata`](#intentmetadata)
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
@@ -72,11 +74,29 @@ Optionally, extra information from the app directory can be returned, to aid in 
 In situations where a desktop agent connects to multiple app directories or multiple versions of the same app exists in a single app directory, it may be necessary to specify `appId` or `version` to target applications that share the same name.
 
 #### See also
+
 * [`AppIntent.apps`](#appintent)
 * [`Icon`](Types#icon)
 * [`DesktopAgent.findIntent`](DesktopAgent#findintent)
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 
+## `ContextMetadata`
+
+```ts
+interface ContextMetadata {
+  /** Metadata relating to the app that sent the context and/or intent. */
+  readonly sourceAppMetadata: AppMetadata;
+}
+```
+
+Metadata relating to a context or intent & context received through the `addContextListener` and `addIntentListener` functions.
+
+#### See also
+
+* [`AppMetadata`](#appmetadata)
+* [`addIntentListener`](DesktopAgent#addintentlistener)
+* [`addContextListener`](DesktopAgent#addcontextlistener)
+* [`Channel.addContextListener`](Channel#addcontextlistener)
 
 ## `DisplayMetadata`
 
@@ -100,6 +120,7 @@ interface DisplayMetadata {
 A desktop agent (typically for _system_ channels) may want to provide additional information about how a channel can be represented in a UI. A common use case is for color linking.
 
 #### See also
+
 * [`Channel`](Channel)
 * [`DesktopAgent.getUserChannels`](DesktopAgent#getuserchannels)
 
@@ -121,6 +142,7 @@ interface ImplementationMetadata {
 Metadata relating to the FDC3 [DesktopAgent](DesktopAgent) object and its provider, including the supported version of the FDC3 specification and the name of the provider of the implementation.
 
 #### See also
+
 * [`DesktopAgent.getInfo`](DesktopAgent#getinfo)
 
 ## `IntentMetadata`
@@ -138,6 +160,7 @@ The interface used to describe an intent within the platform.
 
 
 #### See also
+
 * [`AppIntent.intent`](#appintent)
 
 ## `IntentResolution`
@@ -182,6 +205,7 @@ interface IntentResolution {
 IntentResolution provides a standard format for data returned upon resolving an intent.
 
 #### Examples
+
 ```js
 //resolve a "Chain" type intent
 let resolution = await agent.raiseIntent("intentName", context);
@@ -199,7 +223,7 @@ catch (err) { ... }
 //resolve a "Client-Service" type intent with a data or channel response
 let resolution = await agent.raiseIntent("intentName", context);
 try {
-	  const result = await resolution.getResult();
+    const result = await resolution.getResult();
     if (result && result.broadcast) { //detect whether the result is Context or a Channel
         console.log(`${resolution.source} returned a channel with id ${result.id}`);
     } else if (result){
@@ -213,6 +237,7 @@ try {
 ```
 
 #### See also
+
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 * [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseintentforcontext)
 * [`TargetApp`](Types#targetapp)

--- a/docs/api/ref/Types.md
+++ b/docs/api/ref/Types.md
@@ -36,30 +36,37 @@ This means that it must at least have a `type` property that indicates what type
 ## `ContextHandler`
 
 ```typescript
-type ContextHandler = (context: Context) => void;
+type ContextHandler = (context: Context, metadata?: ContextMetadata) => void;
 ```
 
-Describes a callback that handles a context event.
+Describes a callback that handles a context event. Optional metadata about the context message, including the app that originated the message, may be provided.
 
 Used when attaching listeners for context broadcasts.
 
+Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
+
 #### See also
+
 * [`Context`](#context)
+* [`ContextMetadata`](Metadata#contextmetadata)
 * [`DesktopAgent.addContextListener`](DesktopAgent#addcontextlistener)
 * [`Channel.addContextListener`](Channel#addcontextlistener)
 
 ## `IntentHandler`
 
 ```typescript
-type IntentHandler = (context: Context) => Promise<IntentResult> | void;
+type IntentHandler = (context: Context, metadata?: ContextMetadata) => Promise<IntentResult> | void;
 ```
 
 Describes a callback that handles a context event and may return a promise of a Context or Channel object to be returned to the application that raised the intent.
 
 Used when attaching listeners for raised intents.
 
+Optional metadata about the intent & context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
+
 #### See also
 * [`Context`](#context)
+* [`ContextMetadata`](Metadata#contextmetadata)
 * [`PrivateChannel`](PrivateChannel)
 * [`DesktopAgent.addIntentListener`](DesktopAgent#addintentlistener)
 * [`Channel.addContextListener`](Channel#addcontextlistener)

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -258,49 +258,59 @@ try {
 ```
 
 ### Register an Intent Handler
+
 Applications need to let the system know the intents they can support.  Typically, this is done via registration with an [App Directory](../app-directory/spec).  It is also possible for intents to be registered at the application level as well to support ad-hoc registration which may be helpful at development time.  Although dynamic registration is not part of this specification, a Desktop Agent agent may choose to support any number of registration paths.
 
 When an instance of an application is launched, it is expected to add an [`IntentHandler`](ref/Types#intenthandler) function to the desktop agent for each intent it has registered by calling the [`fdc3.addIntentListener`](ref/DesktopAgent#addintentlistener) function of the Desktop Agent. Doing so allows the Desktop Agent to pass incoming intents and contexts to that instance of the application. Hence, if the application instance was spawned in response to the raised intent, then the Desktop Agent must wait for the relevant intent listener to be added by that instance, before it can deliver the intent and context to it. In order to facilitate accurate error responses, calls to `fdc3.raiseIntent` should not return an `IntentResolution` until the intent handler has been added and the intent delivered to the target app.
 
-#### Compliance with Intent Standards
+### Originating App Metadata
+
+Optional metadata about each intent & context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation to registered intent handlers. As this metadata is optional, apps making use of it MUST handle cases where it is not provided.
+
+### Compliance with Intent Standards
+
 Intents represent a contract with expected behaviour if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation SHOULD enforce compliance and return an error if the interface is not met.
 
 It is expected that App Directories SHOULD also curate listed apps and ensure that they are complying with declared intents.
-
 
 ## Context Channels
 
 Context channels allows a set of apps to share a stateful piece of data between them, and be alerted when it changes.  Use cases for channels include color linking between applications to automate the sharing of context and topic based pub/sub such as theme.
 
 ### Types of Channel
+
 There are three types of channels, which have different visibility and discoverability semantics:
 
-1. **_User channels_**, which: 
-    * facilitate the creation of user-controlled context links between applications (often via the selection of a color channel),
-    * are created and named by the desktop agent,
-    * are discoverable (via the [`getUserChannels()`](ref/DesktopAgent#getuserchannels) API call),
-    * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
+1. **_User channels_**, which:
 
-    > **Note:** Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+  * facilitate the creation of user-controlled context links between applications (often via the selection of a color channel),
+  * are created and named by the desktop agent,
+  * are discoverable (via the [`getUserChannels()`](ref/DesktopAgent#getuserchannels) API call),
+  * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
 
-    > **Note:** Earlier versions of FDC3 included the concept of a 'global' system channel
-    which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
+  > **Note:** Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
 
-2. **_App channels_**, which: 
-    * facilitate developer controlled messaging between applications,
-    * are created and named by applications (via the [`getOrCreateChannel()`](ref/DesktopAgent#getorcreatechannel) API call),
-    * are not discoverable,
-    * are interacted with via the [Channel API](ref/Channel) (accessed via the desktop agent [`getOrCreateChannel`](ref/DesktopAgent#getorcreatechannel) API call)
+  > **Note:** Earlier versions of FDC3 included the concept of a 'global' system channel
+  which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
 
-3. **_Private_** channels, which: 
-    * facilitate private communication between two parties, 
-    * have an auto-generated identity and can only be retrieved via a raised intent.
+2. **_App channels_**, which:
+
+  * facilitate developer controlled messaging between applications,
+  * are created and named by applications (via the [`getOrCreateChannel()`](ref/DesktopAgent#getorcreatechannel) API call),
+  * are not discoverable,
+  * are interacted with via the [Channel API](ref/Channel) (accessed via the desktop agent [`getOrCreateChannel`](ref/DesktopAgent#getorcreatechannel) API call)
+
+3. **_Private_** channels, which:
+
+  * facilitate private communication between two parties, 
+  * have an auto-generated identity and can only be retrieved via a raised intent.
 
 Channels are interacted with via `broadcast` and `addContextListener` functions, allowing an application to send and receive Context objects via the channel. For User channels, these functions are provided on the Desktop Agent, e.g. [`fdc3.broadcast(context)`](ref/DesktopAgent#broadcast), and apply to channels joined via [`fdc3.joinUserChannel`](ref/DesktopAgent#joinuserchannel). For App channels, a channel object must be retrieved, via [`fdc3.getOrCreateChannel(channelName)`](ref/DesktopAgent#getorcreatechannel), which provides the functions, i.e. [`myChannel.broadcast(context)`](ref/Channel#broadcast) and [`myChannel.addContextListener(context)`](ref/Channel#addcontextlistener). For `PrivateChannels`, a channel object must also be retrieved, but via an intent raised with [`fdc3.raiseIntent(intent, context)`](ref/DesktopAgent#raiseintent) and returned as an [`IntentResult`](ref/Types#intentresult).
 
 Channel implementations SHOULD ensure that context messages broadcast by an application on a channel are not delivered back to that same application if they are also listening on the channel.
 
 ### Joining User Channels
+
 Apps can join _User channels_.  An app can only be joined to one User channel at a time.  
 
 When an app is joined to a User channel, calls to [`fdc3.broadcast`](ref/DesktopAgent#broadcast) will be routed to that channel and listeners added through [`fdc3.addContextListener`](ref/DesktopAgent#addcontextlistener) will receive context broadcasts from other apps also joined to that channel. If an app is not joined to a User channel [`fdc3.broadcast`](ref/DesktopAgent#broadcast) will be a no-op and handler functions added with  [`fdc3.addContextListener`](ref/DesktopAgent#addcontextlistener) will not receive any broadcasts. However, apps can still choose to listen and broadcast to specific channels (both User and App channels) via the methods on the [`Channel`](ref/Channel) class.
@@ -389,3 +399,6 @@ The [Context specification](../../context/spec#assumptions) recommends that comp
 
 To facilitate context linking in such situations it is recommended that applications `broadcast` each context type that other apps (listening on a User Channel or App Channel) may wish to process, starting with the simpler types, followed by the complex type. Doing so allows applications to filter the context types they receive by adding listeners for specific context types - but requires that the application broadcasting context make multiple broadcast calls in quick succession when sharing its context.
 
+### Originating App Metadata
+
+Optional metadata about each context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation to registered context handlers on all types of channel. As this metadata is optional, apps making use of it MUST handle cases where it is not provided.

--- a/docs/fdc3-glossary.md
+++ b/docs/fdc3-glossary.md
@@ -26,6 +26,7 @@ For the purposes of this Standard, the following definitions apply. Other terms 
 - **interoperability**: the ability of software applications to exchange and make use of information and invoke specified actions.
 - **intent**: A verb, with a pre-agreed meaning (expected behavior), used to invoke an action between applications. A set of such verbs can, in conjunction with Context Data acting as nouns, be used to put together common cross-application workflows on the financial desktop.
 - **Listener**: API interface which allows unsubscribing from Intents or Context Channels.
+- **Originating App**: The application that sent a particular context message or raised an intent.
 - **Platform Provider**: An environment that provides an implementation of the FDC3 API that applications can use.
 - **raising an intent**: The act of requesting, via the FDC3 API/Desktop Agent that a specified action be performed by another application, using specified context data as input.
 - **resolver**: A facility of a Desktop Agent used to map a raised intent and associated context object to an application that will perform the action represented by the intent, using the context object as input. Where multiple applications can resolve the intent, a resolver will often display a user-interface allowing a user to pick from the available applications that support the intent and type of context supplied.

--- a/src/api/ContextMetadata.ts
+++ b/src/api/ContextMetadata.ts
@@ -1,0 +1,15 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright FINOS FDC3 contributors - see NOTICE file
+ */
+
+import { AppMetadata } from "./AppMetadata";
+
+/**
+ * Metadata relating to a context or intent and context received through the
+ * `addContextListener` and `addIntentListener` functions.
+ */
+export interface ContextMetadata {
+  /** Metadata relating to the app that sent the context and/or intent. */
+  readonly sourceAppMetadata: AppMetadata;
+}

--- a/src/api/ContextMetadata.ts
+++ b/src/api/ContextMetadata.ts
@@ -3,7 +3,7 @@
  * Copyright FINOS FDC3 contributors - see NOTICE file
  */
 
-import { AppMetadata } from "./AppMetadata";
+import { AppMetadata } from './AppMetadata';
 
 /**
  * Metadata relating to a context or intent and context received through the

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -289,6 +289,8 @@ export interface DesktopAgent {
    * The Desktop Agent MUST reject the promise returned by the `getResult()` function of `IntentResolution` if: (1) the intent handling function's returned promise rejects, (2) the intent handling function doesn't return a promise, or (3) the returned promise resolves to an invalid type.
    *
    * The `PrivateChannel` type is provided to support synchronisation of data transmitted over returned channels, by allowing both parties to listen for events denoting subscription and unsubscription from the returned channel. `PrivateChannels` are only retrievable via raising an intent.
+   * 
+   * Optional metadata about the raised intent, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
    *
    * ```javascript
    * //Handle a raised intent
@@ -338,6 +340,10 @@ export interface DesktopAgent {
   /**
    * Adds a listener for incoming context broadcasts from the Desktop Agent via User channels. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
    * Context broadcasts are only received from apps that are joined to the same User channel as the listening application, hence, if the application is not currently joined to a channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
+   * 
+   * 
+   * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
+   * 
    * ```javascript
    * // any context
    * const listener = fdc3.addContextListener(null, context => { ... });

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -289,7 +289,7 @@ export interface DesktopAgent {
    * The Desktop Agent MUST reject the promise returned by the `getResult()` function of `IntentResolution` if: (1) the intent handling function's returned promise rejects, (2) the intent handling function doesn't return a promise, or (3) the returned promise resolves to an invalid type.
    *
    * The `PrivateChannel` type is provided to support synchronisation of data transmitted over returned channels, by allowing both parties to listen for events denoting subscription and unsubscription from the returned channel. `PrivateChannels` are only retrievable via raising an intent.
-   * 
+   *
    * Optional metadata about the raised intent, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
    *
    * ```javascript
@@ -340,10 +340,10 @@ export interface DesktopAgent {
   /**
    * Adds a listener for incoming context broadcasts from the Desktop Agent via User channels. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
    * Context broadcasts are only received from apps that are joined to the same User channel as the listening application, hence, if the application is not currently joined to a channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
-   * 
-   * 
+   *
+   *
    * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
-   * 
+   *
    * ```javascript
    * // any context
    * const listener = fdc3.addContextListener(null, context => { ... });

--- a/src/api/Types.ts
+++ b/src/api/Types.ts
@@ -15,7 +15,7 @@ export type TargetApp = string | AppMetadata;
 /**
  * Describes a callback that handles a context event.
  * Used when attaching listeners for context broadcasts.
- * 
+ *
  * Optional metadata about the context message, including the app that originated
  * the message, SHOULD be provided by the desktop agent implementation.
  */
@@ -30,7 +30,7 @@ export type IntentResult = Context | Channel;
  * promise of a Context or Channel object to be returned to the
  * application that raised the intent.
  * Used when attaching listeners for raised intents.
- * 
+ *
  * Optional metadata about the raised intent, including the app that originated
  * the message, SHOULD be provided by the desktop agent implementation.
  */

--- a/src/api/Types.ts
+++ b/src/api/Types.ts
@@ -3,7 +3,7 @@
  * Copyright FINOS FDC3 contributors - see NOTICE file
  */
 
-import { AppMetadata, Channel } from '..';
+import { AppMetadata, Channel, ContextMetadata } from '..';
 import { Context } from '../context/ContextTypes';
 
 /**
@@ -15,8 +15,11 @@ export type TargetApp = string | AppMetadata;
 /**
  * Describes a callback that handles a context event.
  * Used when attaching listeners for context broadcasts.
+ * 
+ * Optional metadata about the context message, including the app that originated
+ * the message, SHOULD be provided by the desktop agent implementation.
  */
-export type ContextHandler = (context: Context) => void;
+export type ContextHandler = (context: Context, metadata?: ContextMetadata) => void;
 /**
  * Intents can return results that are either context data objects
  * or a reference to a Channel.
@@ -27,5 +30,8 @@ export type IntentResult = Context | Channel;
  * promise of a Context or Channel object to be returned to the
  * application that raised the intent.
  * Used when attaching listeners for raised intents.
+ * 
+ * Optional metadata about the raised intent, including the app that originated
+ * the message, SHOULD be provided by the desktop agent implementation.
  */
-export type IntentHandler = (context: Context) => Promise<IntentResult> | void;
+export type IntentHandler = (context: Context, metadata?: ContextMetadata) => Promise<IntentResult> | void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { DesktopAgent } from './api/DesktopAgent';
 export * from './api/AppIntent';
 export * from './api/AppMetadata';
 export * from './api/Channel';
+export * from './api/ContextMetadata';
 export * from './api/Types';
 export * from './api/DesktopAgent';
 export * from './api/DisplayMetadata';


### PR DESCRIPTION
resolves #520 

Adds an optional, but recommended (SHOULD), `ContextMetadata` object to the arguments passed to ContextHandler and IntentHandler which will contain the originating app's `AppMetadata`. 

@hampshan @bingenito @symphony-adnane @thorsent I believe you were all interested in this change.

(also applied markdown linter to CHANGELOG.md)