### PR TITLE
734 return app identifier and add function to retrieve app metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added `categories` field and recommended categories list to AppD application records to enable category based browsing of AppDs ([#673](https://github.com/finos/FDC3/pull/673))
 * Added an `interop` field to AppD application records, replacing the `intents` field, to more fully describe an app's use of FDC3 and enable search for apps that 'interoperate' with a selected app ([#697](https://github.com/finos/FDC3/pull/697))
 * Added `AppIdentifier` type, which is a new parent of `AppMetadata` and clarifies required fields for API call parameters which now prefer `appId` and `instanceId` over `name` ([#722](https://github.com/finos/FDC3/pull/722))
+* Added a `getAppMetdata()` function to the desktop agent that can be used to retrieve the full `AppMetadata` for an `AppIdentifier` and reduced types such as `IntentResolution.source` and `ContextMetadata.source` from `AppMetadata` to `AppIdentifier` to clarify what fields a developer can rely on and that they should manually retrieve the full `AppMetadata` when they need it for display purposes. ([#751](https://github.com/finos/FDC3/pull/751))
 
 ### Changed
 

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -15,8 +15,8 @@ It is expected that the `DesktopAgent` interface is made availabe via the [`wind
 ```ts
 interface DesktopAgent {
   // apps
-  open(app: AppIdentifier, context?: Context): Promise<AppMetadata>;
-  findInstances(app: AppIdentifier): Promise<Array<AppMetadata>>;
+  open(app: AppIdentifier, context?: Context): Promise<AppIdentifier>;
+  findInstances(app: AppIdentifier): Promise<Array<AppIdentifier>>;
 
   // context
   broadcast(context: Context): Promise<void>;
@@ -46,7 +46,7 @@ interface DesktopAgent {
   addContextListener(handler: ContextHandler): Promise<Listener>;
   getSystemChannels(): Promise<Array<Channel>>;
   joinChannel(channelId: string) : Promise<void>;
-  open(name: String, context?: Context): Promise<AppMetadata>;
+  open(name: String, context?: Context): Promise<AppIdentifier>;
   raiseIntent(intent: string, context: Context, name: String): Promise<IntentResolution>;
   raiseIntentForContext(context: Context, name: String): Promise<IntentResolution>;
 }
@@ -60,7 +60,7 @@ interface DesktopAgent {
 addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener>;
 ```
 
-Adds a listener for incoming context broadcasts from the Desktop Agent. If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types. 
+Adds a listener for incoming context broadcasts from the Desktop Agent. If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
 
 Context broadcasts are only received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
 
@@ -77,7 +77,7 @@ const contactListener = await fdc3.addContextListener('fdc3.contact', contact =>
 
 // listener that logs metadata for the message a specific type
 const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => { 
-  console.log(`Received context message\nContext: ${contact}\nOriginating app: ${metadata?.sourceAppMetadata}`);
+  console.log(`Received context message\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
   //do something else with the context
 });
 ```
@@ -113,7 +113,7 @@ const listener = fdc3.addIntentListener('StartChat', context => {
 
 //Handle a raised intent and log the originating app metadata
 const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => { 
-  console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.sourceAppMetadata}`);
+  console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
     return;
 });
 
@@ -186,14 +186,14 @@ fdc3.broadcast(instrument);
 ### `findInstances`
 
 ```ts
-findInstances(app: AppIdentifier): Promise<Array<AppMetadata>>;
+findInstances(app: AppIdentifier): Promise<Array<AppIdentifier>>;
 ```
 
 Find all the available instances for a particular application.
 
 If there are no instances of the specified application the returned promise should resolve to an empty array.
 
-If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration.
+If the request fails for another reason, the promise will return an `Error` with a string from the `ResolveError` enumeration.
 
 #### Example
 
@@ -231,14 +231,14 @@ const appIntent = await fdc3.findIntent("StartChat");
 // {
 //   intent: { name: "StartChat", displayName: "Chat" },
 //   apps: [
-//    { name: "Skype" }, 
-//    { name: "Symphony" }, 
-//    { name: "Slack" }
+//    { appId: "Skype" }, 
+//    { appId: "Symphony" }, 
+//    { appId: "Slack" }
 //   ]
 // }
 
 // raise the intent against a particular app
-await fdc3.raiseIntent(appIntent.intent.name, context, appIntent.apps[0].name);
+await fdc3.raiseIntent(appIntent.intent.name, context, appIntent.apps[0]);
 
 //later, we want to raise 'StartChat' intent again
 const appIntent = await fdc3.findIntent("StartChat");
@@ -247,10 +247,10 @@ const appIntent = await fdc3.findIntent("StartChat");
 // {
 //   intent: { name: "StartChat", displayName: "Chat" },
 //   apps: [
-//    { name: "Skype" }, 
-//    { name: "Symphony" }, 
-//    { name: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" }, 
-//    { name: "Slack" }
+//    { appId: "Skype" }, 
+//    { appId: "Symphony" }, 
+//    { appId: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" }, 
+//    { appId: "Slack" }
 //   ]
 ```
 
@@ -269,14 +269,14 @@ const appIntent = await fdc3.findIntent("ViewContact", "fdc3.ContactList");
 // returns only apps that return the specified result type:
 // {
 //     intent: { name: "ViewContact", displayName: "View Contact Details" },
-//     apps: { name: "MyCRM", resultType: "fdc3.ContactList"}]
+//     apps: { appId: "MyCRM", resultType: "fdc3.ContactList"}]
 // }
 
 const appIntent = await fdc3.findIntent("QuoteStream", instrument, "channel<fdc3.Quote>");
 // returns only apps that return a channel which will receive the specified input and result types:
 // {
 //     intent: { name: "QuoteStream", displayName: "Quotes stream" },
-//     apps: { name: "MyOMS", resultType: "channel<fdc3.Quote>"}]
+//     apps: { appId: "MyOMS", resultType: "channel<fdc3.Quote>"}]
 // }
 ```
 
@@ -297,7 +297,7 @@ A promise resolving to all the intents, their metadata and metadata about the ap
 
 If the resolution fails, the promise will return an `Error` with a string from the [`ResolveError`](Errors#resolveerror) enumeration.
 
-The optional `resultType` argument may be a type name, the string `"channel"` (which indicates that the app will return a channel) or a string indicating a channel that returns a specific type, e.g. `"channel<fdc3,instrument>"`. If intent resolution to an app returning a channel is requested, the desktop agent MUST include both apps that are registered as returning a channel and those registered as returning a channel with a specific type in the response.
+The optional `resultType` argument may be a type name, the string `"channel"` (which indicates that the app will return a channel) or a string indicating a channel that returns a specific type, e.g. `"channel<fdc3,instrument>"`. If intent resolution to an app returning a channel is requested without a specified context type, the desktop agent MUST include both apps that are registered as returning a channel and those registered as returning a channel with a specific type in the response.
 
 #### Example
 
@@ -310,20 +310,20 @@ const appIntents = await fdc3.findIntentsByContext(context);
 // [
 //   {
 //     intent: { name: "StartCall", displayName: "Call" },
-//     apps: [{ name: "Skype" }]
+//     apps: [{ appId: "Skype" }]
 //   },
 //   {
 //     intent: { name: "StartChat", displayName: "Chat" }, 
 //     apps: [
-//       { name: "Skype" }, 
-//       { name: "Symphony" }, 
-//       { name: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" }, 
-//       { name: "Slack" }
+//       { appId: "Skype" }, 
+//       { appId: "Symphony" }, 
+//       { appId: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" }, 
+//       { appId: "Slack" }
 //     ]
 //   },
 //   {
 //     intent: { name: "ViewContact", displayName: "View Contact" },
-//     apps: [{ name: "Symphony" }, { name: "MyCRM", resultType: "fdc3.ContactList"}]
+//     apps: [{ appId: "Symphony" }, { appId: "MyCRM", resultType: "fdc3.ContactList"}]
 //   }
 // ];
 ```
@@ -335,7 +335,7 @@ const appIntentsForType = await fdc3.findIntentsByContext(context, "fdc3.Contact
 // returns for example:
 // [{
 //     intent: { name: "ViewContact", displayName: "View Contact" },
-//     apps: [{ name: "Symphony" }, { name: "MyCRM", resultType: "fdc3.ContactList"}]
+//     apps: [{ appId: "Symphony" }, { appId: "MyCRM", resultType: "fdc3.ContactList"}]
 // }];
  
 // select a particular intent to raise
@@ -401,7 +401,6 @@ The `ImplementationMetadata` object returned also includes the metadata for the 
 ```js
 let implementationMetadata = await fdc3.getInfo();
 let {appId, instanceId} = implementationMetadata.appMetadata;
-
 ```
 
 #### See also
@@ -415,8 +414,9 @@ let {appId, instanceId} = implementationMetadata.appMetadata;
 getOrCreateChannel(channelId: string): Promise<Channel>;
 ```
 
-Returns a `Channel` object for the specified channel, creating it (as an _App_ channel) - if it does not exist.
-`Error` with a string from the [`ChannelError`](Errors#channelerror) enumeration if the channel could not be created or access was denied.
+Returns a `Channel` object for the specified channel, creating it (as an _App_ channel) if it does not exist.
+
+If the Channel cannot be created or access was denied, the returned promise MUST be rejected with an error string from the `ChannelError` enumeration.
 
 #### Example
 
@@ -566,33 +566,30 @@ redChannel.addContextListener(null, channelListener);
 ### `open`
 
 ```ts
-open(app: AppIdentifier, context?: Context): Promise<AppMetadata>;
+open(app: AppIdentifier, context?: Context): Promise<AppIdentifier>;
 ```
 
-Launches an app with target information, which can be either be a string like a name, or an [`AppMetadata`](Metadata#appmetadata) object.
+Launches an app, specified via an [`AppIdentifier`](Metadata#appidentifier) object.
 
-The `open` method differs in use from [`raiseIntent`](#raiseintent).  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying the App Directory, `open` would be used to open an app returned in the search results.
+The `open` method differs in use from [`raiseIntent`](#raiseintent).  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying an App Directory, `open` would be used to open an app returned in the search results.
 
 **Note**, if the intent, context and target app name are all known, it is recommended to instead use [`raiseIntent`](#raiseintent) with the `target` argument.
 
 If a [`Context`](Types#context) object is passed in, this object will be provided to the opened application via a contextListener. The Context argument is functionally equivalent to opening the target app with no context and broadcasting the context directly to it.
 
-Returns an [`AppMetadata`](Metadata#appmetadata) object with the `instanceId` field set identifying the instance of the application opened by this call.
+Returns an [`AppIdentifier`](Metadata#appidentifier) object with the `instanceId` field set to identify the instance of the application opened by this call.
 
 If opening errors, it returns an `Error` with a string from the [`OpenError`](Errors#openerror) enumeration.
 
 #### Example
 
  ```js
-// Open an app without context, using the app name
-let instanceMetadata = await fdc3.open('myApp');
-
-// Open an app without context, using an AppMetadata object to specify the target
-let appMetadata = {name: 'myApp', appId: 'myApp-v1.0.1', version: '1.0.1'};
-let instanceMetadata = await fdc3.open(appMetadata);
+// Open an app without context, using an AppIdentifier object to specify the target
+let appIdentifier = { appId: 'myApp-v1.0.1' };
+let instanceIdentifier = await fdc3.open(appIdentifier);
 
 // Open an app with context 
-let instanceMetadata = await fdc3.open(appMetadata, context);
+let instanceIdentifier = await fdc3.open(appIdentifier, context);
 ```
 
 #### See also
@@ -608,7 +605,7 @@ let instanceMetadata = await fdc3.open(appMetadata, context);
 raiseIntent(intent: string, context: Context, app?: AppIdentifier): Promise<IntentResolution>;
 ```
 
-Raises a specific intent for resolution against apps registered with the desktop agent. 
+Raises a specific intent for resolution against apps registered with the desktop agent.
 
 The desktop agent MUST resolve the correct app to target based on the provided intent name and context data. If multiple matching apps are found, a method for resolving the intent to a target app, such as presenting the user with a resolver UI allowing them to pick an app, SHOULD be provided.
 Alternatively, the specific app or app instance to target can also be provided. A list of valid target applications and instances can be retrieved via [`findIntent`](DesktopAgent#findintent).  
@@ -687,7 +684,7 @@ If a target app for the intent cannot be found with the criteria provided or the
 const intentResolution = await fdc3.raiseIntentForContext(context);
 
 // Resolve against all intents registered by a specific target app for the specified context
-await fdc3.raiseIntentForContext(context, targetAppMetadata);
+await fdc3.raiseIntentForContext(context, targetAppIdentifier);
 ```
 
 #### See also
@@ -709,8 +706,8 @@ addContextListener(handler: ContextHandler): Promise<Listener>;
 Adds a listener for incoming context broadcasts from the Desktop Agent. Provided for backwards compatibility with versions FDC3 standard <2.0.
 
 #### See also
-* [`addContextListener`](#addcontextlistener)
 
+* [`addContextListener`](#addcontextlistener)
 
 ### `getSystemChannels` (deprecated)
 
@@ -720,6 +717,7 @@ getSystemChannels() : Promise<Array<Channel>>;
 
 Alias to the [`getUserChannels`](#getuserchannels) function provided for backwards compatibility with version 1.1 & 1.2 of the FDC3 standard.
 #### See also
+
 * [`getUserChannels`](#getuserchannels)
 
 ### `joinChannel` (deprecated)
@@ -736,7 +734,7 @@ Alias to the [`joinUserChannel`](#joinuserchannel) function provided for backwar
 ### `open` (deprecated)
 
 ```ts
-open(name: String, context?: Context): Promise<AppMetadata>;
+open(name: String, context?: Context): Promise<AppIdentifier>;
 ```
 
 Version of `open` that launches an app by name rather than `AppIdentifier`. Provided for backwards compatibility with versions of the FDC3 Standard <2.0.

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -17,6 +17,7 @@ interface DesktopAgent {
   // apps
   open(app: AppIdentifier, context?: Context): Promise<AppIdentifier>;
   findInstances(app: AppIdentifier): Promise<Array<AppIdentifier>>;
+  getAppMetadata(app: AppIdentifier): Promise<AppMetadata>;
 
   // context
   broadcast(context: Context): Promise<void>;
@@ -352,6 +353,26 @@ await fdc3.raiseIntent(startChat.intent.name, context, selectedApp);
 
 * [`findIntent()`](#findintent)
 * [`ResolveError`](Errors#resolveerror)
+
+### `getAppMetadata`
+
+```ts
+getAppMetadata(app: AppIdentifier): Promise<AppMetadata>;
+```
+
+Retrieves the [`AppMetadata`](Metadata#appmetadata) for an [`AppIdentifier`](Types#appidentifier), which provides additional metadata (such as icons, a title and description) from the App Directory record for the application, that may be used for display purposes.
+
+#### Examples
+
+```js
+let appIdentifier = { appId: "MyAppId@my.appd.com" }
+let appMetadata = await fdc3.getAppMetadata(appIdentifier);
+```
+
+#### See also
+
+* [`AppMetadata`](Metadata#appmetadata)
+* [`AppIdentifier`](Types#appidentifier)
 
 ### `getCurrentChannel`
 

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -101,10 +101,10 @@ Note that as `AppMetadata` instances are also `AppIdentifiers` they may be passe
 
 ```ts
 interface ContextMetadata {
-  /** Metadata identifying the app that sent the context and/or intent. 
-   *  @experimental
+  /** Identifier for the app instance that sent the context and/or intent. 
+   *  @experimental 
    */
-  readonly source: AppMetadata;
+  readonly source: AppIdentifier;
 }
 ```
 

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -378,4 +378,4 @@ try {
 
 * [`DesktopAgent.raiseIntent`](DesktopAgent#raiseintent)
 * [`DesktopAgent.raiseIntentForContext`](DesktopAgent#raiseintentforcontext)
-* [`TargetApp`](Types#targetapp)
+* [`AppIdentifier`](Types#appidentifier)

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -32,7 +32,6 @@ For each intent, it reference the applications that support that intent.
 
 ```ts
 interface AppMetadata extends AppIdentifier {
-  /** 
   /**
    *  The 'friendly' app name. This field was used with the `open` and
    *  `raiseIntent` calls in FDC3 <2.0, which now require an `AppIdentifier`
@@ -105,7 +104,7 @@ interface ContextMetadata {
   /** Metadata identifying the app that sent the context and/or intent. 
    *  @experimental
    */
-  readonly sourceAppMetadata: AppMetadata;
+  readonly source: AppMetadata;
 }
 ```
 
@@ -308,11 +307,11 @@ The interface used to describe an intent within the platform.
 ```ts
 interface IntentResolution {
 
-  /** Metadata about the app instance that was selected (or started) to resolve
+  /** Identifier for the app instance that was selected (or started) to resolve
    *  the intent. `source.instanceId` MUST be set, indicating the specific app 
    *  instance that received the intent.
    */
-  readonly source: AppMetadata;
+  readonly source: AppIdentifier;
 
   /** The intent that was raised. May be used to determine which intent the user
    *  chose in response to `fdc3.raiseIntentForContext()`.

--- a/docs/api/ref/Types.md
+++ b/docs/api/ref/Types.md
@@ -8,7 +8,7 @@ FDC3 API operations make use of several type declarations.
 
 Identifies an application, or instance of an application, and is used to target FDC3 API calls at specific applications.
 Will always include at least an `appId` property, which can be used with `fdc3.open`, `fdc3.raiseIntent` etc..
-If the `instanceId` field is set then the `AppMetadata` object represents a specific instance of the application that may be addressed using that Id.
+If the `instanceId` field is set then the `AppIdentifier` object represents a specific instance of the application that may be addressed using that Id.
 
 ```ts
 interface AppIdentifier {

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -153,11 +153,11 @@ let {appId, instanceId} = implementationMetadata.appMetadata;
 
 ### Reference apps or app instance(s) and retrieve their metadata
 
-To construct workflows between applications, you need to be able to reference specific applications and instance of those applications. 
+To construct workflows between applications, you need to be able to reference specific applications and instances of those applications. 
 
 From version 2.0 of the FDC3 Standard, Desktop Agent functions that reference or return information about other applications do so via an [`AppIdentifier`](ref/Types#appidentifier) type. [`AppIdentifier`](ref/Types#appidentifier) references specific applications via an `appId` from an [App Directory](../app-directory/overview) record and instances of that application via an `instanceId` assigned by the Desktop Agent.
 
-Additional metadata for an application can be retrieved via the [`fdc3.getAppMetadata(appIdentifier)`](ref/DesktopAgent#getappmetadata) function, which returns an [`AppMetadata`](ref/Metadata#appmetadata) object. The additional metadata may include a title, description,  icons, etc., which may be used for display purposes.
+Additional metadata for an application can be retrieved via the [`fdc3.getAppMetadata(appIdentifier)`](ref/DesktopAgent#getappmetadata) function, which returns an [`AppMetadata`](ref/Metadata#appmetadata) object. The additional metadata may include a title, description, icons, etc., which may be used for display purposes.
 
 Identifiers for instances of an application may be retrieved via the [`fdc3.findInstances(appIdentifier)`](ref/DesktopAgent#findinstances) function.
 

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -107,29 +107,7 @@ An actual connection protocol between Desktop Agents is not currently available 
 
 ## Functional Use Cases
 
-### Retrieve Metadata about the Desktop Agent implementation
-
-From version 1.2 of the FDC3 specification, Desktop Agent implementations MUST provide a `fdc3.getInfo()` function to allow apps to retrieve information about the version of the FDC3 specification supported by a Desktop Agent implementation and the name of the implementation provider. This metadata can be used to vary the behavior of an application based on the version supported by the Desktop Agent, e.g.:
-
-```js
-import {compareVersionNumbers, versionIsAtLeast} from '@finos/fdc3';
-
-if (fdc3.getInfo && versionIsAtLeast(await fdc3.getInfo(), '1.2')) {
-  await fdc3.raiseIntentForContext(context);
-} else {
-  await fdc3.raiseIntent('ViewChart', context);
-}
-```
-
-The `ImplementationMetadata` object returned also includes the metadata for the calling application, according to the Desktop Agent. This allows the application to retrieve its own `appId`, `instanceId` and other details, e.g.:
-
-```js
-let implementationMetadata = await fdc3.getInfo();
-let {appId, instanceId} = implementationMetadata.appMetadata;
-
-```
-
-### Open an Application by Name
+### Open an Application
 
 Linking from one application to another is a critical basic workflow that the web revolutionized via the hyperlink.  Supporting semantic addressing of applications across different technologies and platform domains greatly reduces friction in linking different applications into a single workflow.
 
@@ -148,6 +126,40 @@ Intents provide a way for an app to request functionality from another app and d
 On the financial desktop, applications often want to broadcast [context](../context/spec) to any number of applications.  Context sharing needs to support different groupings of applications, which is supported via the concept of 'channels', over which context is broadcast and received by other applications listening to the channel.  
 
 In some cases, an application may want to communicate with a single application or service and to prevent other applications from participating in the communication. For single transactions, this can instead be implemented via a raised intent, which will be delivered to a single application that can, optionally, respond with data. Alternatively, it may instead respond with a [`Channel`](ref/Channel) or [`PrivateChannel`](ref/PrivateChannel) over which a stream of responses or a dialog can be supported.
+
+### Retrieve Metadata about the Desktop Agent implementation
+
+An application may wish to retrieve information about the version of the FDC3 Standard supported by a Desktop Agent implementation and the name of the implementation provider. 
+
+Since version 1.2 of the FDC3 Standard it may do so via the [`fdc3.getInfo()`](ref/DesktopAgent#getinfo) function. The metadata returned can be used, for example, to vary the behavior of an application based on the version supported by the Desktop Agent, e.g.:
+
+```js
+import {compareVersionNumbers, versionIsAtLeast} from '@finos/fdc3';
+
+if (fdc3.getInfo && versionIsAtLeast(await fdc3.getInfo(), '1.2')) {
+  await fdc3.raiseIntentForContext(context);
+} else {
+  await fdc3.raiseIntent('ViewChart', context);
+}
+```
+
+The [`ImplementationMetadata`](ref/Metadata#implementationmetadata) object returned also includes the metadata for the calling application, according to the Desktop Agent. This allows the application to retrieve its own `appId`, `instanceId` and other details, e.g.:
+
+```js
+let implementationMetadata = await fdc3.getInfo();
+let {appId, instanceId} = implementationMetadata.appMetadata;
+
+```
+
+### Reference apps or app instance(s) and retrieve their metadata
+
+To construct workflows between applications, you need to be able to reference specific applications and instance of those applications. 
+
+From version 2.0 of the FDC3 Standard, Desktop Agent functions that reference or return information about other applications do so via an [`AppIdentifier`](ref/Types#appidentifier) type. [`AppIdentifier`](ref/Types#appidentifier) references specific applications via an `appId` from an [App Directory](../app-directory/overview) record and instances of that application via an `instanceId` assigned by the Desktop Agent.
+
+Additional metadata for an application can be retrieved via the [`fdc3.getAppMetadata(appIdentifier)`](ref/DesktopAgent#getappmetadata) function, which returns an [`AppMetadata`](ref/Metadata#appmetadata) object. The additional metadata may include a title, description,  icons, etc., which may be used for display purposes.
+
+Identifiers for instances of an application may be retrieved via the [`fdc3.findInstances(appIdentifier)`](ref/DesktopAgent#findinstances) function.
 
 ## Raising Intents
 

--- a/src/api/ContextMetadata.ts
+++ b/src/api/ContextMetadata.ts
@@ -3,7 +3,7 @@
  * Copyright FINOS FDC3 contributors - see NOTICE file
  */
 
-import { AppMetadata } from './AppMetadata';
+import { AppIdentifier } from './AppIdentifier';
 
 /**
  * Metadata relating to a context or intent and context received through the
@@ -12,9 +12,9 @@ import { AppMetadata } from './AppMetadata';
  * @experimental Introduced in FDC3 2.0 and may be refined by further changes outside the normal FDC3 versioning policy.
  */
 export interface ContextMetadata {
-  /** Metadata relating to the app that sent the context and/or intent.
+  /** Identifier for the app instance that sent the context and/or intent.
    *
    *  @experimental
    */
-  readonly sourceAppMetadata: AppMetadata;
+  readonly source: AppIdentifier;
 }

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -53,7 +53,7 @@ export interface DesktopAgent {
    * Find out more information about a particular intent by passing its name, and optionally its context and/or a desired result context type.
    *
    * `findIntent` is effectively granting programmatic access to the Desktop Agent's resolver.
-   * It returns a promise resolving to the intent, its metadata and metadata about the apps and app instances that registered it is returned.
+   * It returns a promise resolving to the intent, its metadata and metadata about the apps and app instances that registered that intent.
    * This can be used to raise the intent against a specific app or app instance.
    *
    * If the resolution fails, the promise will return an `Error` with a string from the `ResolveError` enumeration.
@@ -309,7 +309,7 @@ export interface DesktopAgent {
    * //Handle a raised intent and log the originating app metadata
    * const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => {
    *   console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
-   *     return;
+   *   return;
    * });
    *
    * //Handle a raised intent and return Context data via a promise

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -26,7 +26,7 @@ import { AppIdentifier } from './AppIdentifier';
 
 export interface DesktopAgent {
   /**
-   * Launches an app.
+   * Launches an app, specified via an `AppIdentifier` object.
    *
    * The `open` method differs in use from `raiseIntent`.  Generally, it should be used when the target application is known but there is no specific intent.  For example, if an application is querying the App Directory, `open` would be used to open an app returned in the search results.
    *
@@ -34,33 +34,34 @@ export interface DesktopAgent {
    *
    * If a Context object is passed in, this object will be provided to the opened application via a contextListener. The Context argument is functionally equivalent to opening the target app with no context and broadcasting the context directly to it.
    *
-   * Returns an `AppMetadata` object with the `instanceId` field set identifying the instance of the application opened by this call.
+   * Returns an `AppIdentifier` object with the `instanceId` field set identifying the instance of the application opened by this call.
    *
    * If opening errors, it returns an `Error` with a string from the `OpenError` enumeration.
    *
    * ```javascript
    * //Open an app without context, using an AppIdentifier object to specify the target by `appId`.
    * let appIdentifier = {appId: 'myApp-v1.0.1'};
-   * let instanceMetadata = await fdc3.open(appIdentifier);
+   * let instanceIdentifier = await fdc3.open(appIdentifier);
    *
    * //Open an app with context
-   * let instanceMetadata = await fdc3.open(appIdentifier, context);
+   * let instanceIdentifier = await fdc3.open(appIdentifier, context);
    * ```
    */
-  open(app: AppIdentifier, context?: Context): Promise<AppMetadata>;
+  open(app: AppIdentifier, context?: Context): Promise<AppIdentifier>;
 
   /**
-   * Find out more information about a particular intent by passing its name, and optionally its context and/or a desired result type.
+   * Find out more information about a particular intent by passing its name, and optionally its context and/or a desired result context type.
    *
-   * findIntent is effectively granting programmatic access to the Desktop Agent's resolver.
-   * A promise resolving to the intent, its metadata and metadata about the apps and app instances that registered it is returned.
+   * `findIntent` is effectively granting programmatic access to the Desktop Agent's resolver.
+   * It returns a promise resolving to the intent, its metadata and metadata about the apps and app instances that registered it is returned.
    * This can be used to raise the intent against a specific app or app instance.
    *
    * If the resolution fails, the promise will return an `Error` with a string from the `ResolveError` enumeration.
    *
-   * Output types may be a type name, the string "channel" (which indicates that the app
+   * Result types may be a type name, the string "channel" (which indicates that the app
    * will return a channel) or a string indicating a channel that returns a specific type,
    * e.g. "channel<fdc3.instrument>".
+   * 
    * If intent resolution to an app returning a channel is requested, the desktop agent
    * MUST include both apps that are registered as returning a channel and those registered
    * as returning a channel with a specific type in the response.
@@ -73,14 +74,14 @@ export interface DesktopAgent {
    * // {
    * //     intent: { name: "StartChat", displayName: "Chat" },
    * //   apps: [
-   * //    { name: "Skype" },
-   * //    { name: "Symphony" },
-   * //    { name: "Slack" }
+   * //    { appId: "Skype" },
+   * //    { appId: "Symphony" },
+   * //    { appId: "Slack" }
    * //   ]
    * // }
    *
    * // raise the intent against a particular app
-   * await fdc3.raiseIntent(appIntent.intent.name, context, appIntent.apps[0].name);
+   * await fdc3.raiseIntent(appIntent.intent.name, context, appIntent.apps[0]);
    *
    * //later, we want to raise 'StartChat' intent again
    * const appIntent = await fdc3.findIntent("StartChat");
@@ -89,10 +90,10 @@ export interface DesktopAgent {
    * // {
    * //   intent: { name: "StartChat", displayName: "Chat" },
    * //   apps: [
-   * //    { name: "Skype" },
-   * //    { name: "Symphony" },
-   * //    { name: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" },
-   * //    { name: "Slack" }
+   * //    { appId: "Skype" },
+   * //    { appId: "Symphony" },
+   * //    { appId: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" },
+   * //    { appId: "Slack" }
    * //   ]
    * ```
    *
@@ -104,7 +105,7 @@ export interface DesktopAgent {
    * // returns only apps that support the type of the specified input context:
    * // {
    * //     intent: { name: "StartChat", displayName: "Chat" },
-   * //     apps: [{ name: "Symphony" }]
+   * //     apps: [{ appId: "Symphony" }]
    * // }
    *
    * const appIntent = await fdc3.findIntent("ViewContact", contact, "fdc3.ContactList");
@@ -112,7 +113,7 @@ export interface DesktopAgent {
    * // returns only apps that return the specified result Context type:
    * // {
    * //     intent: { name: "ViewContact", displayName: "View Contact Details" },
-   * //     apps: { name: "MyCRM", resultType: "fdc3.ContactList"}]
+   * //     apps: { appId: "MyCRM", resultType: "fdc3.ContactList"}]
    * // }
    *
    * const appIntent = await fdc3.findIntent("QuoteStream", instrument, "channel<fdc3.Quote>");
@@ -120,7 +121,7 @@ export interface DesktopAgent {
    * // returns only apps that return a channel which will receive the specified input and result types:
    * // {
    * //     intent: { name: "QuoteStream", displayName: "Quotes stream" },
-   * //     apps: [{ name: "MyOMS", resultType: "channel<fdc3.Quote>"}]
+   * //     apps: [{ appId: "MyOMS", resultType: "channel<fdc3.Quote>"}]
    * // }
    * ```
    */
@@ -129,15 +130,16 @@ export interface DesktopAgent {
   /**
    * Find all the available intents for a particular context, and optionally a desired result context type.
    *
-   * findIntents is effectively granting programmatic access to the Desktop Agent's resolver.
+   * `findIntentsByContext` is effectively granting programmatic access to the Desktop Agent's resolver.
    * A promise resolving to all the intents, their metadata and metadata about the apps and app instance that registered it is returned, based on the context types the intents have registered.
    *
    * If the resolution fails, the promise will return an `Error` with a string from the `ResolveError` enumeration.
    *
-   * Result types may be a type name, the string "channel" (which indicates that the app should return a
-   * channel) or a string indicating a channel that returns a specific type, e.g. "channel<fdc3.instrument>".
-   * If intent resolution to an app returning a channel is requested, the desktop agent MUST also include apps
-   * that are registered as returning a channel with a specific type in the response.
+   * The optional `resultType` argument may be a type name, the string "channel" (which indicates that the app 
+   * should return a channel) or a string indicating a channel that returns a specific type, 
+   * e.g. "channel<fdc3.instrument>". If intent resolution to an app returning a channel is requested without 
+   * a specified context type, the desktop agent MUST also include apps that are registered as returning a
+   * channel with a specific type in the response.
    *
    * ```javascript
    * // I have a context object, and I want to know what I can do with it, hence, I look for intents and apps to resolve them...
@@ -152,10 +154,10 @@ export interface DesktopAgent {
    * //   {
    * //     intent: { name: "StartChat", displayName: "Chat" },
    * //     apps: [
-   * //       { name: "Skype" },
-   * //       { name: "Symphony" },
-   * //       { name: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" },
-   * //       { name: "Slack" }
+   * //       { appId: "Skype" },
+   * //       { appId: "Symphony" },
+   * //       { appId: "Symphony", instanceId: "93d2fe3e-a66c-41e1-b80b-246b87120859" },
+   * //       { appId: "Slack" }
    * //     ]
    * //   }
    * // ];
@@ -165,7 +167,7 @@ export interface DesktopAgent {
    * // returns for example:
    * // [{
    * //     intent: { name: "ViewContact", displayName: "View Contacts" },
-   * //     apps: [{ name: "MyCRM", resultType: "fdc3.ContactList"}]
+   * //     apps: [{ appId: "MyCRM", resultType: "fdc3.ContactList"}]
    * // }];
    *
    * // select a particular intent to raise
@@ -196,13 +198,18 @@ export interface DesktopAgent {
    * ```
    * @param app
    */
-  findInstances(app: AppIdentifier): Promise<Array<AppMetadata>>;
+  findInstances(app: AppIdentifier): Promise<Array<AppIdentifier>>;
 
   /**
    * Publishes context to other apps on the desktop.  Calling `broadcast` at the `DesktopAgent` scope will push the context to whatever _User Channel_ the app is joined to.  If the app is not currently joined to a channel, calling `fdc3.broadcast` will have no effect.  Apps can still directly broadcast and listen to context on any channel via the methods on the `Channel` class.
    *
    * DesktopAgent implementations should ensure that context messages broadcast to a channel by an application joined to it should not be delivered back to that same application.
    *
+   * If you are working with complex context types composed of other simpler types then you should broadcast
+   * each individual type (starting with the simpler types, followed by the complex type) that you want other
+   * apps to be able to respond to. Doing so allows applications to filter the context types they receive by
+   * adding listeners for specific context types.
+   * 
    * ```javascript
    * const instrument = {
    *   type: 'fdc3.instrument',
@@ -278,7 +285,7 @@ export interface DesktopAgent {
    * await fdc3.raiseIntentForContext(context);
    *
    * // Resolve against all intents registered by a specific target app for the specified context
-   * await fdc3.raiseIntentForContext(context, targetAppMetadata);
+   * await fdc3.raiseIntentForContext(context, targetAppIdentifier);
    * ```
    */
   raiseIntentForContext(context: Context, app?: AppIdentifier): Promise<IntentResolution>;
@@ -296,6 +303,12 @@ export interface DesktopAgent {
    * //Handle a raised intent
    * const listener = fdc3.addIntentListener('StartChat', context => {
    *     // start chat has been requested by another application
+   *     return;
+   * });
+   * 
+   * //Handle a raised intent and log the originating app metadata
+   * const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => { 
+   *   console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
    *     return;
    * });
    *
@@ -333,16 +346,23 @@ export interface DesktopAgent {
 
   /**
    * Adds a listener for incoming context broadcasts from the Desktop Agent via User channels. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
+   * 
    * Context broadcasts are only received from apps that are joined to the same User channel as the listening application, hence, if the application is not currently joined to a channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
-   *
    *
    * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
    *
    * ```javascript
    * // any context
-   * const listener = fdc3.addContextListener(null, context => { ... });
+   * const listener = await fdc3.addContextListener(null, context => { ... });
+   * 
    * // listener for a specific type
-   * const contactListener = fdc3.addContextListener('fdc3.contact', contact => { ... });
+   * const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
+   * 
+   * // listener that logs metadata for the message a specific type
+   * const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => { 
+   *   console.log(`Received context message\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
+   *   //do something else with the context
+   * });
    * ```
    */
   addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener>;
@@ -356,9 +376,13 @@ export interface DesktopAgent {
    * Optional function that joins the app to the specified User channel. In most cases, applications SHOULD be joined to channels via UX provided to the application by the desktop agent, rather than calling this function directly.
    *
    * If an app is joined to a channel, all `fdc3.broadcast` calls will go to the channel, and all listeners assigned via `fdc3.addContextListener` will listen on the channel.
+   * 
    * If the channel already contains context that would be passed to context listeners assed via `fdc3.addContextListener` then those listeners will be called immediately with that context.
+   * 
    * An app can only be joined to one channel at a time.
+   * 
    * Rejects with an error if the channel is unavailable or the join request is denied. The error string will be drawn from the `ChannelError` enumeration.
+   * 
    * ```javascript
    *   // get all system channels
    *   const channels = await fdc3.getUserChannels();
@@ -370,9 +394,9 @@ export interface DesktopAgent {
   joinUserChannel(channelId: string): Promise<void>;
 
   /**
-   * Returns a channel with the given identity. Either stands up a new channel or returns an existing channel. It is up to applications to manage how to share knowledge of these custom channels across windows and to manage channel ownership and lifecycle.
+   * Returns a `Channel` object for the specified channel, creating it (as an _App_ channel) if it does not exist.
    *
-   * If the Channel cannot be created, the returned promise MUST be rejected with an error string from the `ChannelError` enumeration.
+   * If the Channel cannot be created or access was denied, the returned promise MUST be rejected with an error string from the `ChannelError` enumeration.
    *
    * ```javascript
    * try {
@@ -451,9 +475,32 @@ export interface DesktopAgent {
   leaveCurrentChannel(): Promise<void>;
 
   /**
-   * Retrieves information about the FDC3 Desktop Agent implementation, such as
-   * the implemented version of the FDC3 specification and the name of the implementation
-   * provider.
+   * Retrieves information about the FDC3 Desktop Agent implementation, including the supported version
+   * of the FDC3 specification, the name of the provider of the implementation, its own version number
+   * and the metadata of the calling application according to the desktop agent.
+   * 
+   * Returns an [`ImplementationMetadata`](Metadata#implementationmetadata) object.  This metadata object can
+   * be used to vary the behavior of an application based on the version supported by the Desktop Agent and
+   * for logging purposes.
+   * 
+   * ```js
+   * import {compareVersionNumbers, versionIsAtLeast} from '@finos/fdc3';
+   * 
+   * if (fdc3.getInfo && versionIsAtLeast(await fdc3.getInfo(), "1.2")) {
+   *   await fdc3.raiseIntentForContext(context);
+   * } else {
+   *   await fdc3.raiseIntent("ViewChart", context);
+   * }
+   * ```
+   * 
+   * The `ImplementationMetadata` object returned also includes the metadata for the calling application, 
+   * according to the Desktop Agent. This allows the application to retrieve its own `appId`, `instanceId` 
+   * and other details, e.g.:
+   * 
+   * ```js
+   * let implementationMetadata = await fdc3.getInfo();
+   * let {appId, instanceId} = implementationMetadata.appMetadata;
+   * ```
    */
   getInfo(): Promise<ImplementationMetadata>;
 
@@ -485,7 +532,7 @@ export interface DesktopAgent {
    * let instanceMetadata = await fdc3.open('myApp');
    * ```
    */
-  open(name: String, context?: Context): Promise<AppMetadata>;
+  open(name: String, context?: Context): Promise<AppIdentifier>;
 
   /**
    * @deprecated version of `raiseIntent` that targets an app by by name rather than `AppIdentifier`. Provided for backwards compatibility with versions FDC3 standard <2.0.

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -11,8 +11,8 @@ import { Listener } from './Listener';
 import { Context } from '../context/ContextTypes';
 import { ImplementationMetadata } from './ImplementationMetadata';
 import { PrivateChannel } from './PrivateChannel';
-import { AppMetadata } from './AppMetadata';
 import { AppIdentifier } from './AppIdentifier';
+import { AppMetadata } from './AppMetadata';
 
 /**
  * A Desktop Agent is a desktop component (or aggregate of components) that serves as a
@@ -61,7 +61,7 @@ export interface DesktopAgent {
    * Result types may be a type name, the string "channel" (which indicates that the app
    * will return a channel) or a string indicating a channel that returns a specific type,
    * e.g. "channel<fdc3.instrument>".
-   * 
+   *
    * If intent resolution to an app returning a channel is requested, the desktop agent
    * MUST include both apps that are registered as returning a channel and those registered
    * as returning a channel with a specific type in the response.
@@ -135,9 +135,9 @@ export interface DesktopAgent {
    *
    * If the resolution fails, the promise will return an `Error` with a string from the `ResolveError` enumeration.
    *
-   * The optional `resultType` argument may be a type name, the string "channel" (which indicates that the app 
-   * should return a channel) or a string indicating a channel that returns a specific type, 
-   * e.g. "channel<fdc3.instrument>". If intent resolution to an app returning a channel is requested without 
+   * The optional `resultType` argument may be a type name, the string "channel" (which indicates that the app
+   * should return a channel) or a string indicating a channel that returns a specific type,
+   * e.g. "channel<fdc3.instrument>". If intent resolution to an app returning a channel is requested without
    * a specified context type, the desktop agent MUST also include apps that are registered as returning a
    * channel with a specific type in the response.
    *
@@ -209,7 +209,7 @@ export interface DesktopAgent {
    * each individual type (starting with the simpler types, followed by the complex type) that you want other
    * apps to be able to respond to. Doing so allows applications to filter the context types they receive by
    * adding listeners for specific context types.
-   * 
+   *
    * ```javascript
    * const instrument = {
    *   type: 'fdc3.instrument',
@@ -305,9 +305,9 @@ export interface DesktopAgent {
    *     // start chat has been requested by another application
    *     return;
    * });
-   * 
+   *
    * //Handle a raised intent and log the originating app metadata
-   * const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => { 
+   * const listener = fdc3.addIntentListener('StartChat', (contact, metadata) => {
    *   console.log(`Received intent StartChat\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
    *     return;
    * });
@@ -346,7 +346,7 @@ export interface DesktopAgent {
 
   /**
    * Adds a listener for incoming context broadcasts from the Desktop Agent via User channels. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
-   * 
+   *
    * Context broadcasts are only received from apps that are joined to the same User channel as the listening application, hence, if the application is not currently joined to a channel no broadcasts will be received. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
    *
    * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
@@ -354,12 +354,12 @@ export interface DesktopAgent {
    * ```javascript
    * // any context
    * const listener = await fdc3.addContextListener(null, context => { ... });
-   * 
+   *
    * // listener for a specific type
    * const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
-   * 
+   *
    * // listener that logs metadata for the message a specific type
-   * const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => { 
+   * const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => {
    *   console.log(`Received context message\nContext: ${contact}\nOriginating app: ${metadata?.source}`);
    *   //do something else with the context
    * });
@@ -376,13 +376,13 @@ export interface DesktopAgent {
    * Optional function that joins the app to the specified User channel. In most cases, applications SHOULD be joined to channels via UX provided to the application by the desktop agent, rather than calling this function directly.
    *
    * If an app is joined to a channel, all `fdc3.broadcast` calls will go to the channel, and all listeners assigned via `fdc3.addContextListener` will listen on the channel.
-   * 
+   *
    * If the channel already contains context that would be passed to context listeners assed via `fdc3.addContextListener` then those listeners will be called immediately with that context.
-   * 
+   *
    * An app can only be joined to one channel at a time.
-   * 
+   *
    * Rejects with an error if the channel is unavailable or the join request is denied. The error string will be drawn from the `ChannelError` enumeration.
-   * 
+   *
    * ```javascript
    *   // get all system channels
    *   const channels = await fdc3.getUserChannels();
@@ -478,31 +478,42 @@ export interface DesktopAgent {
    * Retrieves information about the FDC3 Desktop Agent implementation, including the supported version
    * of the FDC3 specification, the name of the provider of the implementation, its own version number
    * and the metadata of the calling application according to the desktop agent.
-   * 
-   * Returns an [`ImplementationMetadata`](Metadata#implementationmetadata) object.  This metadata object can
-   * be used to vary the behavior of an application based on the version supported by the Desktop Agent and
-   * for logging purposes.
-   * 
+   *
+   * Returns an `ImplementationMetadata` object.  This metadata object can be used to vary the behavior
+   * of an application based on the version supported by the Desktop Agent and for logging purposes.
+   *
    * ```js
    * import {compareVersionNumbers, versionIsAtLeast} from '@finos/fdc3';
-   * 
+   *
    * if (fdc3.getInfo && versionIsAtLeast(await fdc3.getInfo(), "1.2")) {
    *   await fdc3.raiseIntentForContext(context);
    * } else {
    *   await fdc3.raiseIntent("ViewChart", context);
    * }
    * ```
-   * 
-   * The `ImplementationMetadata` object returned also includes the metadata for the calling application, 
-   * according to the Desktop Agent. This allows the application to retrieve its own `appId`, `instanceId` 
+   *
+   * The `ImplementationMetadata` object returned also includes the metadata for the calling application,
+   * according to the Desktop Agent. This allows the application to retrieve its own `appId`, `instanceId`
    * and other details, e.g.:
-   * 
+   *
    * ```js
    * let implementationMetadata = await fdc3.getInfo();
    * let {appId, instanceId} = implementationMetadata.appMetadata;
    * ```
    */
   getInfo(): Promise<ImplementationMetadata>;
+
+  /**
+   * Retrieves the `AppMetadata` for an `AppIdentifier`, which provides additional metadata (such as icons,
+   * a title and description) from the App Directory record for the application, that may be used for display
+   * purposes.
+   *
+   * ```js
+   * let appIdentifier = { appId: "MyAppId@my.appd.com" }
+   * let appMetadata = await fdc3.getAppMetadata(appIdentifier);
+   * ```
+   */
+  getAppMetadata(app: AppIdentifier): Promise<AppMetadata>;
 
   //---------------------------------------------------------------------------------------------
   //Deprecated function signatures

--- a/src/api/IntentResolution.ts
+++ b/src/api/IntentResolution.ts
@@ -4,12 +4,11 @@
  */
 
 import { IntentResult } from './Types';
-import { AppMetadata } from './AppMetadata';
 import { AppIdentifier } from './AppIdentifier';
 
 /**
  * IntentResolution provides a standard format for data returned upon resolving an intent.
- * 
+ *
  * ```javascript
  * //resolve a "Chain" type intent
  * let resolution = await agent.raiseIntent("intentName", context);
@@ -28,7 +27,7 @@ import { AppIdentifier } from './AppIdentifier';
  * } catch(error) {
  *     console.error(`${resolution.source} returned an error: ${error}`);
  * }
- * 
+ *
  * // Use metadata about the resolving app instance to target a further intent
  * await agent.raiseIntent("intentName", context, resolution.source);
  * ```

--- a/src/api/IntentResolution.ts
+++ b/src/api/IntentResolution.ts
@@ -5,9 +5,11 @@
 
 import { IntentResult } from './Types';
 import { AppMetadata } from './AppMetadata';
+import { AppIdentifier } from './AppIdentifier';
 
 /**
  * IntentResolution provides a standard format for data returned upon resolving an intent.
+ * 
  * ```javascript
  * //resolve a "Chain" type intent
  * let resolution = await agent.raiseIntent("intentName", context);
@@ -26,17 +28,18 @@ import { AppMetadata } from './AppMetadata';
  * } catch(error) {
  *     console.error(`${resolution.source} returned an error: ${error}`);
  * }
+ * 
  * // Use metadata about the resolving app instance to target a further intent
  * await agent.raiseIntent("intentName", context, resolution.source);
  * ```
  */
 export interface IntentResolution {
   /**
-   * Metadata about the app instance that was selected (or started) to resolve the intent.
+   * Identifier for the app instance that was selected (or started) to resolve the intent.
    * `source.instanceId` MUST be set, indicating the specific app instance that
    * received the intent.
    */
-  readonly source: AppMetadata;
+  readonly source: AppIdentifier;
   /**
    * The intent that was raised. May be used to determine which intent the user
    * chose in response to `fdc3.raiseIntentForContext()`.

--- a/src/api/Methods.ts
+++ b/src/api/Methods.ts
@@ -1,6 +1,5 @@
 import {
   AppIdentifier,
-  AppMetadata,
   AppIntent,
   Channel,
   Context,
@@ -9,6 +8,7 @@ import {
   IntentResolution,
   Listener,
   ImplementationMetadata,
+  AppMetadata,
 } from '..';
 
 const DEFAULT_TIMEOUT = 5000;
@@ -159,6 +159,10 @@ export function leaveCurrentChannel(): Promise<void> {
 
 export function getInfo(): Promise<ImplementationMetadata> {
   return rejectIfNoGlobal(() => window.fdc3.getInfo());
+}
+
+export function getAppMetadata(app: AppIdentifier): Promise<AppMetadata> {
+  return rejectIfNoGlobal(() => window.fdc3.getAppMetadata(app));
 }
 
 /**

--- a/src/api/Methods.ts
+++ b/src/api/Methods.ts
@@ -61,7 +61,7 @@ function isString(app: AppIdentifier | String): app is String {
   return typeof app === 'string';
 }
 
-export function open(app: AppIdentifier | String, context?: Context): Promise<AppMetadata> {
+export function open(app: AppIdentifier | String, context?: Context): Promise<AppIdentifier> {
   if (isString(app)) {
     return rejectIfNoGlobal(() => window.fdc3.open(app, context));
   } else {

--- a/test/Methods.test.ts
+++ b/test/Methods.test.ts
@@ -12,6 +12,7 @@ import {
   findIntentsByContext,
   getCurrentChannel,
   getInfo,
+  getAppMetadata,
   getOrCreateChannel,
   getUserChannels,
   getSystemChannels,
@@ -273,6 +274,14 @@ describe('test ES6 module', () => {
 
       expect(window.fdc3.getInfo).toHaveBeenCalledTimes(1);
       expect(window.fdc3.getInfo).toHaveBeenCalledWith();
+    });
+
+    test('getAppMetadata should delegate to window.fdc3.getAppMetadata', async () => {
+      const dummyApp = { appId: 'dummy' };
+      await getAppMetadata(dummyApp);
+
+      expect(window.fdc3.getAppMetadata).toHaveBeenCalledTimes(1);
+      expect(window.fdc3.getAppMetadata).toHaveBeenCalledWith(dummyApp);
     });
   });
 

--- a/website/README.md
+++ b/website/README.md
@@ -16,6 +16,7 @@ This website was created with [Docusaurus](https://docusaurus.io/).
 # Install dependencies
 $ yarn
 ```
+
 2. Run your dev server:
 
 ```sh
@@ -50,11 +51,11 @@ my-docusaurus/
 
 # Versioning
 
-Docusaurus uses the `docusaurus-version` command to create a snapshot of the documents in the `docs` folder with a particular version number, 
-and places them in the `versioned_docs/version-<version>` folder. It also creates a `versioned_sidebars/version-<version>-sidebars.json` 
-to save the navigation structure at the time the snapshot was taken. 
+Docusaurus uses the `docusaurus-version` command to create a snapshot of the documents in the `docs` folder with a particular version number,
+and places them in the `versioned_docs/version-<version>` folder. It also creates a `versioned_sidebars/version-<version>-sidebars.json`
+to save the navigation structure at the time the snapshot was taken.
 
-See https://docusaurus.io/docs/en/versioning for more info.
+See <https://docusaurus.io/docs/en/versioning> for more info.
 
 ## Versioning scheme
 
@@ -67,22 +68,26 @@ Before creating a version, please make sure docs/fdc3-intro.md has been updated 
 Since the website also uses some generated and copied static files (like schemas), extra tasks need to be performed as part of creating a new version.
 
 To create a new version, use this command:
+
 ```sh
 VERSION=<version> yarn run version
 ```
+
 e.g.
+
 ```sh
 VERSION=1.2 yarn run version
 ```
 
 The `VERSION` environment variable and `version` script are used to:
-- Run the `docusaurus-version` command
-- Copy schemas from the `/website/static/schemas/next` (which matches `master`) to `/website/static/schemas/<version>`
-- Copy the app-directory OpenAPI html file from `/website/pages/schemas/next` to `/website/pages/schemas/<version>`
-- Update paths referring to `/schemas/next` to point to `/schemas/<version>`
-- Update the version number in the app directory schema from `version: next` to `version: <version>`
+* Run the `docusaurus-version` command
+* Copy schemas from the `/website/static/schemas/next` (which matches `master`) to `/website/static/schemas/<version>`
+* Copy the app-directory OpenAPI html file from `/website/pages/schemas/next` to `/website/pages/schemas/<version>`
+* Update paths referring to `/schemas/next` to point to `/schemas/<version>`
+* Update the version number in the app directory schema from `version: next` to `version: <version>`
 
 After a new version is created with the script, the following step also needs to be performed:
+
 1. Change `defaultVersionShown` in `siteConfig.js` to match the latest version (if the new version is now the latest version).
 2. Change `versions.json` to have the version `stable` at the top, followed by the actual version numbers in descending order, e.g. `[stable, 1.3, 1.2, 1.1]`. (Docusaurus will add the new version number at the top of the array.)
 
@@ -91,10 +96,13 @@ These steps are needed because we follow a workaround for an [issue with permane
 ## Delete a version
 
 To delete a version, use this command:
+
 ```sh
 VERSION=<version> yarn run version:delete
 ```
+
 e.g.
+
 ```sh
 VERSION=1.2 yarn run version:delete
 ```
@@ -125,6 +133,7 @@ For more information about docs, click [here](https://docusaurus.io/docs/en/navi
 Edit blog posts by navigating to `website/blog` and editing the corresponding post:
 
 `website/blog/post-to-be-edited.md`
+
 ```markdown
 ---
 id: post-needs-edit
@@ -174,6 +183,7 @@ For more information about adding new docs, click [here](https://docusaurus.io/d
 1. Make sure there is a header link to your blog in `website/siteConfig.js`:
 
 `website/siteConfig.js`
+
 ```javascript
 headerLinks: [
     ...
@@ -204,6 +214,7 @@ For more information about blog posts, click [here](https://docusaurus.io/docs/e
 1. Add links to docs, custom pages or external links by editing the headerLinks field of `website/siteConfig.js`:
 
 `website/siteConfig.js`
+
 ```javascript
 {
   headerLinks: [
@@ -228,6 +239,7 @@ For more information about the navigation bar, click [here](https://docusaurus.i
 1. If you want your page to show up in your navigation header, you will need to update `website/siteConfig.js` to add to the `headerLinks` element:
 
 `website/siteConfig.js`
+
 ```javascript
 {
   headerLinks: [
@@ -243,7 +255,7 @@ For more information about custom pages, click [here](https://docusaurus.io/docs
 
 ## Custom CSS & Design Changes
 
-1. Changing logos for the Header and Footer and Favicon are done in website/siteConfig.js file in the /* path to images for header/footer */ section
+1. Changing logos for the Header and Footer and Favicon are done in website/siteConfig.js file in the /*path to images for header/footer*/ section
 
 Note: make sure that you add your new logos to the website/static/img folder first.
 
@@ -253,7 +265,7 @@ Note: make sure that you add your new logos to the website/static/img folder fir
 
 3. Change the background color and the background transparent image in the website/static/css/custom.css file.
 
-Go to the section labeled: .homeContainer 
+Go to the section labeled: .homeContainer
 
 Change "background-image" - and insert your new background image file. Note - make sure you add your new background transparent image file to the website/static/img folder first.
 


### PR DESCRIPTION
resolves #734 

Adds a new function to retrieve `AppMetadata` for an `AppIdentifier` and reduces several other return types to only specify `AppIdentifier` rather than `AppMetadata` (which is a superset of `AppIdentifier`'s fields). This helps clarify what fields developers can expect in returns from functions (i.e. only the minimal set in `AppIdentifier`) and that they should manually retrieve any  additional metadata (i.e. an `AppMetadata`) if they need it (for display purposes).

Key areas to review (preview links):

- API overview: https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/spec#reference-apps-or-app-instances-and-retrieve-their-metadata
- `getAppMetadata()` fn reference: https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/ref/desktopagent#getappmetadata
- Other types that had references changed to `AppIdentifier` from `AppMetadata`:
  - [`ContextMetadata`](https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/ref/metadata#contextmetadata)
  - [`IntentResolution`](https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/ref/metadata#intentresolution)
  - [`findInstances`](https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/ref/desktopagent#findinstances)
  - [`open`](https://deploy-preview-751--lambent-kulfi-cf51a7.netlify.app/docs/next/api/ref/desktopagent#open)
  
Finally, please note that the `AppIntent` returned by `findIntent` still uses `AppMetadata` (as the use case will pretty much always require it) as does the `ImplementationMetadata` returned by `getInfo`.