### PR TITLE
Changed to "community" rather than just implementations.  

### DIFF
--- a/docs/fdc3-intro.md
+++ b/docs/fdc3-intro.md
@@ -31,7 +31,7 @@ From its inception, the standards have been informed by real-world [business use
 
 ## Who is using FDC3?
 
-The Financial Desktop Connectivity and Collaboration Consortium (FDC3) standards are created and used by [leading organizations across the financial industry](/users). For more detail on who's using FDC3, developer tools, training and examples, see the [implementations page](/implementations).
+The Financial Desktop Connectivity and Collaboration Consortium (FDC3) standards are created and used by [leading organizations across the financial industry](/users). For more detail on who's using FDC3, developer tools, training and examples, see the [community page](/community).
 
 ## How is FDC3 governed?
 

--- a/website/data/community.json
+++ b/website/data/community.json
@@ -13,7 +13,7 @@
         "infoLink": "https://cosaic.io/chartiq/",
         "docsLink": "https://documentation.chartiq.com/",
         "type": "application-provider",
-        "badges": [{"text": "Supporting FDC3 1.2"} ],
+        "badges": [{"text": "FDC3 1.2 Supported"} ],
         "description": "<p>ChartIQ is a powerful and flexible HTML5 charting library with millions of users worldwide. Written in JavaScript, it runs entirely within the browser. With state of the art integrations, including  third-party apps, educational components, analysis, and more, you can create efficient workflows and streamline the way to work.</p><p>ChartIQ works on any platform (mobile, web, desktop) and any framework (Angular, React).</p><p>Most companies have at least one financial charting library for each platform or app they target—web, C#, Java, Android, iOS, etc., so developers have multiple code bases to maintain. With ChartIQ, write your code once and use it everywhere.</p>"
     },
     {
@@ -23,7 +23,7 @@
         "infoLink": "https://github.com/finos/electron-fdc3",
         "docsLink": "https://github.com/finos/electron-fdc3",
         "type": "platform-provider",
-        "badges": [ {"text": "Supporting FDC3 1.2"}, {"text": "Open Source"} ],
+        "badges": [ {"text": "FDC3 1.2 Supported"}, {"text": "Open Source"} ],
         "description": "<p>This project provides a fully open source implementation of the FDC3 interoperability standard. </p><p>Includes a fully featured and secure electron desktop agent featuring intent resolution, channel linking, directory search and a local file-based app directory implementation. </p>"
     },
     {
@@ -33,7 +33,7 @@
         "infoLink": "https://github.com/finos/fdc3-desktop-agent",
         "docsLink": "https://github.com/finos/fdc3-desktop-agent",
         "type": "platform-provider",
-        "badges": [ {"text": "Supporting FDC3 1.2"}, {"text": "Open Source"} ],
+        "badges": [ {"text": "FDC3 1.2 Supported"}, {"text": "Open Source"} ],
         "description": "<p>The FDC3 Desktop Agent is an open source implementation of FDC3 as a Chrome Extension. </p><p> Its purpose is to provide a quick and easy way for app developers to get started with the FDC3 APIs. </p> "
     },
     {
@@ -43,7 +43,7 @@
         "infoLink": "https://cosaic.io/finsemble/",
         "docsLink": "https://documentation.finsemble.com/",
         "type": "platform-provider",
-        "badges": [ {"text": "Supporting FDC3 1.2"} ],
+        "badges": [ {"text": "FDC3 1.2 Supported"} ],
         "description": "<p>Finsemble is a no code/low code smart desktop platform that helps you achieve both visual and logical integration of various types of apps that you already use (web, native, in-house, and third-party, including Citrix virtual apps).</p><p>Connect apps into automated workflows to improve user efficiency and reduce error rates. With <a href='https://documentation.finsemble.com/tutorial-ControllingInformationFlow.html' alt='Controlling information flow through FDC3 in Finsemble'>SelectConnect</a>, you are in full control over which apps communicate and which are excluded.</p><p>Build a fully customizable UI to work across multiple windows and monitors.</p><p>Use our <a href='https://documentation.finsemble.com/tutorial-SDD-01-Welcome.html' alt='The Smart Desktop Designer: fast-track to interoperability'>Smart Desktop Designer</a> to create and share fully functioning, highly customized, integrated desktops in a few hours, no coding knowledge needed.</p>"
     },
     {
@@ -82,7 +82,7 @@
         "infoLink": "https://glue42.com/enterprise/",
         "docsLink": "https://docs.glue42.com/",
         "type": "platform-provider",
-        "badges": [ {"text": "Supporting FDC3 1.2"} ],
+        "badges": [ {"text": "FDC3 1.2 Supported"} ],
         "description": "<p>Glue42 enables organizations to build intelligent desktops that support configurable workflows between web and desktop applications. We’re working with some of the world’s biggest financial organizations to help them optimize complex processes and become more efficient.</p><p>Our flagship product, Glue42 Enterprise, is a desktop application integration platform that helps organizations create a simplified desktop experience by connecting the UI and data of any application, e.g., legacy, in-house or web. The platform supports open-source standards, including FINOS-FDC3, thus reducing delivery time and avoiding vendor lock-in.</p>"
     },
     {

--- a/website/data/community.json
+++ b/website/data/community.json
@@ -1,5 +1,5 @@
 [
-    {   "//": "Implementations page content - required fields: title, image, type, badges, description",
+    {   "//": "community page content - required fields: title, image, type, badges, description",
         "//": "Image link may be external or images may be added to the /website/static/img/users directory for hosting on the FDC3 website",
         "//": "Please keep descriptions to (at most) 100 words.",
         "//": "Description content may be formatted in basic HTML (e.g. <p>, <i> and <a> tags)",
@@ -13,7 +13,7 @@
         "infoLink": "https://cosaic.io/chartiq/",
         "docsLink": "https://documentation.chartiq.com/",
         "type": "application-provider",
-        "badges": [{"text": "FDC3 1.2 Supported"} ],
+        "badges": [{"text": "Supporting FDC3 1.2"} ],
         "description": "<p>ChartIQ is a powerful and flexible HTML5 charting library with millions of users worldwide. Written in JavaScript, it runs entirely within the browser. With state of the art integrations, including  third-party apps, educational components, analysis, and more, you can create efficient workflows and streamline the way to work.</p><p>ChartIQ works on any platform (mobile, web, desktop) and any framework (Angular, React).</p><p>Most companies have at least one financial charting library for each platform or app they target—web, C#, Java, Android, iOS, etc., so developers have multiple code bases to maintain. With ChartIQ, write your code once and use it everywhere.</p>"
     },
     {
@@ -23,7 +23,7 @@
         "infoLink": "https://github.com/finos/electron-fdc3",
         "docsLink": "https://github.com/finos/electron-fdc3",
         "type": "platform-provider",
-        "badges": [ {"text": "FDC3 1.2 Supported"}, {"text": "Open Source"} ],
+        "badges": [ {"text": "Supporting FDC3 1.2"}, {"text": "Open Source"} ],
         "description": "<p>This project provides a fully open source implementation of the FDC3 interoperability standard. </p><p>Includes a fully featured and secure electron desktop agent featuring intent resolution, channel linking, directory search and a local file-based app directory implementation. </p>"
     },
     {
@@ -33,7 +33,7 @@
         "infoLink": "https://github.com/finos/fdc3-desktop-agent",
         "docsLink": "https://github.com/finos/fdc3-desktop-agent",
         "type": "platform-provider",
-        "badges": [ {"text": "FDC3 1.2 Supported"}, {"text": "Open Source"} ],
+        "badges": [ {"text": "Supporting FDC3 1.2"}, {"text": "Open Source"} ],
         "description": "<p>The FDC3 Desktop Agent is an open source implementation of FDC3 as a Chrome Extension. </p><p> Its purpose is to provide a quick and easy way for app developers to get started with the FDC3 APIs. </p> "
     },
     {
@@ -43,7 +43,7 @@
         "infoLink": "https://cosaic.io/finsemble/",
         "docsLink": "https://documentation.finsemble.com/",
         "type": "platform-provider",
-        "badges": [ {"text": "FDC3 1.2 Supported"} ],
+        "badges": [ {"text": "Supporting FDC3 1.2"} ],
         "description": "<p>Finsemble is a no code/low code smart desktop platform that helps you achieve both visual and logical integration of various types of apps that you already use (web, native, in-house, and third-party, including Citrix virtual apps).</p><p>Connect apps into automated workflows to improve user efficiency and reduce error rates. With <a href='https://documentation.finsemble.com/tutorial-ControllingInformationFlow.html' alt='Controlling information flow through FDC3 in Finsemble'>SelectConnect</a>, you are in full control over which apps communicate and which are excluded.</p><p>Build a fully customizable UI to work across multiple windows and monitors.</p><p>Use our <a href='https://documentation.finsemble.com/tutorial-SDD-01-Welcome.html' alt='The Smart Desktop Designer: fast-track to interoperability'>Smart Desktop Designer</a> to create and share fully functioning, highly customized, integrated desktops in a few hours, no coding knowledge needed.</p>"
     },
     {
@@ -82,7 +82,7 @@
         "infoLink": "https://glue42.com/enterprise/",
         "docsLink": "https://docs.glue42.com/",
         "type": "platform-provider",
-        "badges": [ {"text": "FDC3 1.2 Supported"} ],
+        "badges": [ {"text": "Supporting FDC3 1.2"} ],
         "description": "<p>Glue42 enables organizations to build intelligent desktops that support configurable workflows between web and desktop applications. We’re working with some of the world’s biggest financial organizations to help them optimize complex processes and become more efficient.</p><p>Our flagship product, Glue42 Enterprise, is a desktop application integration platform that helps organizations create a simplified desktop experience by connecting the UI and data of any application, e.g., legacy, in-house or web. The platform supports open-source standards, including FINOS-FDC3, thus reducing delivery time and avoiding vendor lock-in.</p>"
     },
     {

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -14,10 +14,11 @@ const implData = require(`${process.cwd()}/data/community.json`);
 
 const badgeTitles = {
 	"Open Source": "Indicates that the project source code is available to download and modify, under an Apache 2.0 or similar license.",
-	"Supporting FDC3 1.2": "Indicates that this product is promoting compatibility with the FDC3 1.2 Standard. ",
+	"FDC3 1.2 Supported": "Indicates that this product advertises compatibility with the FDC3 1.2 Standard. ",
+	"FDC3 2.0 Supported ": "Indicates that this product advertises compatibility with the FDC3 2.0 Standard. ", 
 	"FDC3 1.2 Compliant": "This badge is applied to desktop agents that have passed the FINOS FDC3 1.2 Conformance testing process.",
-	"Supporting FDC3 2.0 ": "Indicates that this product is promoting compatibility with the FDC3 2.0 Standard. ", 
-	"FDC3 2.0 Compliant": "This badge is applied to desktop agents that have passed the FINOS FDC3 2.0 Conformance testing process."
+	"FDC3 2.0 Compliant": "This badge is applied to desktop agents that have passed the FINOS FDC3 2.0 Conformance testing process.",
+	"FDC3 2.0 Support Coming Soon": "This product is working towards attaining the FDC3 2.0 Standard.",
 }
 
 

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -10,13 +10,13 @@ const React = require('react');
 const { useState, useEffect } = React;
 const CompLibrary = require('../../core/CompLibrary.js');
 const Container = CompLibrary.Container;
-const implData = require(`${process.cwd()}/data/implementations.json`);
+const implData = require(`${process.cwd()}/data/community.json`);
 
 const badgeTitles = {
 	"Open Source": "Indicates that the project source code is available to download and modify, under an Apache 2.0 or similar license.",
-	"FDC3 1.2 Supported": "This badge is given as an indicator that the agent vendor is marketing the desktop agent as supporting the FDC3 1.2 Standard. ",
+	"Supporting FDC3 1.2": "Indicates that this product is promoting compatibility with the FDC3 1.2 Standard. ",
 	"FDC3 1.2 Compliant": "This badge is applied to desktop agents that have passed the FINOS FDC3 1.2 Conformance testing process.",
-	"FDC3 2.0 Supported": "This badge is given as an indicator that the agent vendor is marketing the desktop agent as supporting the FDC3 2.0 Standard.", 
+	"Supporting FDC3 2.0 ": "Indicates that this product is promoting compatibility with the FDC3 2.0 Standard. ", 
 	"FDC3 2.0 Compliant": "This badge is applied to desktop agents that have passed the FINOS FDC3 2.0 Conformance testing process."
 }
 
@@ -99,13 +99,13 @@ function Implementations(props) {
 	const editUrl = `${repoUrl}/edit/master/website/data/implementations.json`;
 
 	return <Container>
-		<h1>FDC3 Implementations</h1>
+		<h1>FDC3 Community</h1>
 		<div className="prose">
 			<p>
 				The Financial Desktop Connectivity and Collaboration Consortium (FDC3) standard is maintained and used by leading organizations across the financial industry through a variety of different implementations.
 			</p>
 			<p>
-				For more detail on who's implementing the Desktop Agent (a "Platform Provider"), using FDC3 to enable interop with their apps (an "Application Provider") or details on where to find tools, examples apps and training materials see below.
+				For more detail on who's implementing the Desktop Agent (a "Platform Provider"), using FDC3 to enable interop with their apps (an "App Provider") or details on where to find tools, examples apps and training materials see below.
 			</p>
 			<p>
 				<i>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -160,7 +160,7 @@ class Index extends React.Component {
       return (
         <div className="userShowcase productShowcaseSection paddingTop paddingBottom">
           <h2>Who is Using FDC3?</h2>
-          <p>The Financial Desktop Connectivity and Collaboration Consortium (FDC3) standards are created and used by <a href="/users">leading organizations across the financial industry</a>. For more detail on who's using FDC3, developer tools, training and examples see the <a href="/implementations">implementations page</a>.</p>
+          <p>The Financial Desktop Connectivity and Collaboration Consortium (FDC3) standards are created and used by <a href="/users">leading organizations across the financial industry</a>. For more detail on who's using FDC3, developer tools, training and examples see the <a href="/community">community page</a>.</p>
           <Showcase users={pinnedUsers} />
           {/* exclude button to users page for now, all users shown on main page */}
           {/* <div className="more-users">

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -26,7 +26,7 @@ const siteConfig = {
     {doc: 'fdc3-intro', label: 'Getting Started'},   
     {page: 'fdc3-roadmap', label: 'Roadmap'},
     {doc: 'use-cases/overview', label: 'Use Cases'},
-    {page: 'implementations', label: 'Implementations'},
+    {page: 'community', label: 'Community'},
     {doc: 'fdc3-standard', label: 'The Standard'},
     {page: 'get-involved', label: 'Get Involved'},
     {href: 'https://www.edx.org/course/fdc3-interoperability-for-the-financial-desktop', label: 'Training', external: true}


### PR DESCRIPTION
Hi,

I'd like to change the wording on this page to be about "Community" rather than just implementations.  Couple of reasons:
- Some of the content is about training courses etc.  I have a load more to add in that ilk.  These aren't implementations
- I'm going to do the mail shot on Tuesday.  I'd like to be as inclusive as possible, especially for people who are thinking about building stuff but maybe have nothing concrete to show yet.  