### PR TITLE
Fixing minor error in findInstances example

### DIFF
--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -200,7 +200,7 @@ If the request fails for another reason, the promise will return an `Error` with
 
 ```js
 // Retrieve a list of instances of an application
-let instances = await fdc3.findInstances({name: "MyApp"});
+let instances = await fdc3.findInstances({appId: "MyAppId"});
 
 // Target a raised intent at a specific instance
 let resolution = fdc3.raiseIntent("ViewInstrument", context, instances[0]);

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -191,7 +191,7 @@ export interface DesktopAgent {
    *
    * ```javascript
    * // Retrieve a list of instances of an application
-   * let instances = await fdc3.findInstances({appId: "MyApp"});
+   * let instances = await fdc3.findInstances({appId: "MyAppId"});
    *
    * // Target a raised intent at a specific instance
    * let resolution = fdc3.raiseIntent("ViewInstrument", context, instances[0]);


### PR DESCRIPTION
I noticed an error in the Desktop Agent's `findInstances` function in the docs (was correct in source comments.). It was using a FDC3 1.2 style `AppMetadata` with `name` field rather than an FDC3 2.0 style `AppIdentifier` with `appId`