### PR TITLE
Fixing image links in use-case docs

### DIFF
--- a/docs/use-cases/004-client-side-fx-trader.md
+++ b/docs/use-cases/004-client-side-fx-trader.md
@@ -15,7 +15,7 @@ layout: use_case
 1. The FX Trader clicks button to book a trade in the third-party trading app (e.g. Autobahn FX)
 1. The trading app executes an interop action to the client in-house proprietary credit check application to check the trader's credit limit. If this check indicates the limit has been reached, the trading app presents a rejection dialog as a standard error dialog box with an informational message which may be a standard message (e.g. "Credit Limit Reached") or may include an interop link/action (provided by the credit check application) to resolve the limit breach.
 
-![Use Case 4 Workflow](../assets/uc4.png)
+![Use Case 4 Workflow](/docs/assets/uc4.png)
 
 ## Required Features
 

--- a/docs/use-cases/017-fine-tuning-interop-with-channels.md
+++ b/docs/use-cases/017-fine-tuning-interop-with-channels.md
@@ -25,7 +25,7 @@ In vendor application 1, the user maintains a personal watchlist. When selecting
 ## Workflow 3
 In vendor application 2, the user have a tool for ad-hoc company look ups. When selecting a company there, the user wants a chart and a news component in vendor application 1 to update (not the ones from WF 1), a detailed company report in vendor application 2 and a separate trading screen in vendor application 4 (not the one in WF2).
 
-![Use Case 17 Workflow](../assets/uc17.png)
+![Use Case 17 Workflow](/docs/assets/uc17.png)
 
 ## Interoperability Points
 - API


### PR DESCRIPTION
Fixing links to images in use-case docs that are broken in the /next version