### PR TITLE
846 Corrected schema definition for appD interop.intents.listensFor element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Clarified the description of the addContextListener functions from the Desktop Agent and Channel APIs in spec and docs. ([#492](https://github.com/finos/FDC3/pull/492))
 * Clarified that implementing `fdc3.getInfo()` is required for compliance with the FDC3 standard ([#515](https://github.com/finos/FDC3/pull/515))
 * Corrected syntax errors in valuation schema ([#834](https://github.com/finos/FDC3/pull/834))
+* Corrected schema definition for appD `interop.intents.listensFor` element ([#847](https://github.com/finos/FDC3/pull/847))
 
 ## [npm v1.2.0] - 2021-04-19
 

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -650,8 +650,7 @@ components:
                 Used to support intent resolution by desktop agents. Replaces the `intents` element used in appD records prior to FDC3 2.0. 
               additionalProperties:
                 x-additionalPropertiesName: Intent name
-                items:
-                  $ref: '#/components/schemas/Intent'
+                $ref: '#/components/schemas/Intent'
             raises:
               type: object
               description: | 

--- a/website/static/schemas/2.0/app-directory.yaml
+++ b/website/static/schemas/2.0/app-directory.yaml
@@ -650,8 +650,7 @@ components:
                 Used to support intent resolution by desktop agents. Replaces the `intents` element used in appD records prior to FDC3 2.0. 
               additionalProperties:
                 x-additionalPropertiesName: Intent name
-                items:
-                  $ref: '#/components/schemas/Intent'
+                $ref: '#/components/schemas/Intent'
             raises:
               type: object
               description: | 

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -650,8 +650,7 @@ components:
                 Used to support intent resolution by desktop agents. Replaces the `intents` element used in appD records prior to FDC3 2.0. 
               additionalProperties:
                 x-additionalPropertiesName: Intent name
-                items:
-                  $ref: '#/components/schemas/Intent'
+                $ref: '#/components/schemas/Intent'
             raises:
               type: object
               description: | 


### PR DESCRIPTION
resolves #846
appD schema contained an error that turned the `interop.intents.listensFor` element values (keyed on intent name) into an array of intents instead of a single intent definition - hence it did not match the example (which is correct according to the issue that introduced this element). 