### PR TITLE
Replace images with screenshots in app metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/src/api/AppMetadata.ts
+++ b/src/api/AppMetadata.ts
@@ -40,8 +40,8 @@ export interface AppMetadata extends AppIdentifier {
   /** A list of icon URLs for the application that can be used to render UI elements */
   readonly icons?: Array<Icon>;
 
-  /** A list of image URLs for the application that can be used to render UI elements */
-  readonly images?: Array<Image>;
+  /** Images representing the app in common usage scenarios that can be used to render UI elements  */
+  readonly screenshots?: Array<Image>;
 
   /** The type of output returned for any intent specified during resolution. May express a particular context type (e.g. "fdc3.instrument"), channel (e.g. "channel") or a channel that will receive a specified type (e.g. "channel<fdc3.instrument>"). */
   readonly resultType?: string | null;


### PR DESCRIPTION
The AppMetadata documentation was updated to replace the `AppMetadata.images` field with `AppMetadata.screenshots`: https://fdc3.finos.org/docs/api/ref/Metadata#appmetadata

However, the corresponding [source file](https://github.com/finos/FDC3/blob/add64f8302c6dcdc8437cf0e245101e927b69ec2/src/api/AppMetadata.ts#L44) was not. This PR updates it to match and rolls the (beta) version number of the NPM module to release the change/correction.