### PR TITLE
Confirm that App channels do not re-play past contexts when a listener is added

### DIFF
--- a/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
+++ b/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
@@ -105,7 +105,7 @@ _These are some basic sanity tests implemented in the FDC3 Conformance Framework
 | A   | 1. createChannel        |`fdc3.getOrCreateChannel("test-channel")`       |
 | B   | 2. createChannel        | `fdc3.getOrCreateChannel("test-channel")`   |
 | B   | 3. Broadcast          | `testChannel.broadcast()` the instrument context.<br>`testChannel.broadcast()` a contact context. |
-| A   | 4. addContextListener | A adds a context listener to the channel *after* B has completed all its broadcasts. It should NOT receive any context via this listener (past context is only retrieved bya getCurrentCOntext on App channels). 
+| A   | 4. addContextListener | A adds a context listener to the channel *after* B has completed all its broadcasts. It should NOT receive any context via this listener (past context is only retrieved by a getCurrentContext on App channels). 
 | A   | 5. Receive Context    | `testChannel.getCurrentContext('fdc3.instrument')` returns the last broadcast instrument<br>`testChannel.getCurrentContext('fdc3.contact')` returns the last broadcast contact                                                              |
 
 -  `ACContextHistoryTyped`: Perform above test.

--- a/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
+++ b/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
@@ -105,7 +105,8 @@ _These are some basic sanity tests implemented in the FDC3 Conformance Framework
 | A   | 1. createChannel        |`fdc3.getOrCreateChannel("test-channel")`       |
 | B   | 2. createChannel        | `fdc3.getOrCreateChannel("test-channel")`   |
 | B   | 3. Broadcast          | `testChannel.broadcast()` the instrument context.<br>`testChannel.broadcast()` a contact context. |
-| A   | 4. Receive Context    | `testChannel.getCurrentContext('fdc3.instrument')` returns the last broadcast instrument<br>`testChannel.getCurrentContext('fdc3.contact')` returns the last broadcast contact                                                              |
+| A   | 4. addContextListener | A adds a context listener to the channel *after* B has completed all its broadcasts. It should NOT receive any context via this listener (past context is only retrieved bya getCurrentCOntext on App channels). 
+| A   | 5. Receive Context    | `testChannel.getCurrentContext('fdc3.instrument')` returns the last broadcast instrument<br>`testChannel.getCurrentContext('fdc3.contact')` returns the last broadcast contact                                                              |
 
 -  `ACContextHistoryTyped`: Perform above test.
 -  `ACContextHistoryMultiple`: **B** Broadcasts multiple history items of both types.  Only the last version of each type is received by **A**.


### PR DESCRIPTION
Small addition to one of the app channel tests - we need to confirm that App Channels, listened to via the `Channel` interface do not auto-replay context messages (as System/User channels listened to through the fdc3/Desktop Agent interface do). 

A different PR will add this to the 2.0 test cases.

Background:

The Standards Working Group re-affirmed under issue #511 at meeting #683 that the difference in the behaviour of the `fdc3`/`DesktopAgent` and `Channel` interfaces was intentional and necessary to implement certain use cases with App Channels. It was decided that this would not change in FDC3 2.0, hence it remains the case in 2.0.