### PR TITLE
Remove malformed context test case as correct behavior is not defined

### DIFF
--- a/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
+++ b/toolbox/fdc3-conformance/FDC3-1.2-Conformance-Test-Cases.md
@@ -146,7 +146,6 @@ _These are some basic sanity tests implemented in the FDC3 Conformance Framework
 | A   | 3. Promise         | - receives a rejection from the open promise with “App Timeout’ from <br>https://fdc3.finos.org/docs/api/ref/Errors#openerror |
 
 -  `AOpensBMultipleListen`:  The correct (first) context listener should receive the context, and the promise resolves successfully in **A**.
--  `AOpensBMalformedContext`: **A** tries to pass malformed context to **B** (i.e. no `type` field on the context object).  Context listeners receive nothing, promise completes successfully.
 
 ## 5. Intents
 


### PR DESCRIPTION
The FDC3 Standard does not define the expected behavior on receipt of a malformed context (by `fdc3.open`, or indeed any other function). Hence, it is not possible to adequately define test cases for it. There currently only exists a test case for `fdc3.open` which this PR will remove.

See issue https://github.com/finos/FDC3/issues/872 for a request to refine this FDC3 so that we can test it in a future version.