### PR TITLE
fix/855 Fix incorrect format and rename 'public' property

### DIFF
--- a/docs/context/ref/ChatInitSettings.md
+++ b/docs/context/ref/ChatInitSettings.md
@@ -26,7 +26,7 @@ https://fdc3.finos.org/schemas/next/chatInitSettings.schema.json
 | `members`                      | ContactList | No       | ContactList - cf. below                                              |
 | `initMessage`                  | string      | No       | `'Hello!'`                                                           |
 | `options.groupRecipients`      | boolean     | No       | `true`: if false a separate chat will be created for each member     |
-| `options.public`               | boolean     | No       | `true`: the room will be visible to everyone in the chat application |
+| `options.isPublic`             | boolean     | No       | `true`: the room will be visible to everyone in the chat application |
 | `options.allowHistoryBrowsing` | boolean     | No       | `true`: members will be allowed to browse past messages             |
 | `options.allowMessageCopy`     | boolean     | No       | `true`: members will be allowed to copy/paste messages               |
 | `options.allowAddUser`         | boolean     | No       | `true`: members will be allowed to add other members to the chat     |
@@ -58,7 +58,7 @@ const initSettings = {
     },
     options: {
         groupRecipients: true, // one chat with both contacts
-        public: false, // private chat room
+        isPublic: false, // private chat room
         allowHistoryBrowsing: true,
         allowMessageCopy: true
     }

--- a/docs/intents/ref/StartChat.md
+++ b/docs/intents/ref/StartChat.md
@@ -51,7 +51,7 @@ const initSettings = {
     },
     options: {
         groupRecipients: true, // one chat with both contacts
-        public: false, // private chat room
+        isPublic: false, // private chat room
         allowHistoryBrowsing: true,
         allowMessageCopy: true,
         allowAddUser: false, // John won't be authorized to add other users to the chat

--- a/src/context/schemas/chatInitSettings.schema.json
+++ b/src/context/schemas/chatInitSettings.schema.json
@@ -17,11 +17,14 @@
             "type": "string"
         },
         "options": {
-            "groupRecipients": "boolean",
-            "public": "boolean",
-            "allowHistoryBrowsing": "boolean",
-            "allowMessageCopy": "boolean",
-            "allowAddUser": "boolean"
+            "type": "object",
+            "properties": {
+              "groupRecipients": {"type": "boolean"},
+              "isPublic": {"type": "boolean"},
+              "allowHistoryBrowsing":  {"type": "boolean"},
+              "allowMessageCopy":  {"type": "boolean"},
+              "allowAddUser":  {"type": "boolean"}
+            }
         }
     },
     "required": [

--- a/website/static/schemas/2.0/chatInitSettings.schema.json
+++ b/website/static/schemas/2.0/chatInitSettings.schema.json
@@ -17,11 +17,14 @@
             "type": "string"
         },
         "options": {
-            "groupRecipients": "boolean",
-            "public": "boolean",
-            "allowHistoryBrowsing": "boolean",
-            "allowMessageCopy": "boolean",
-            "allowAddUser": "boolean"
+            "type": "object",
+            "properties": {
+              "groupRecipients": {"type": "boolean"},
+              "public": {"type": "boolean"},
+              "allowHistoryBrowsing":  {"type": "boolean"},
+              "allowMessageCopy":  {"type": "boolean"},
+              "allowAddUser":  {"type": "boolean"}
+            }
         }
     },
     "required": [

--- a/website/static/schemas/next/chatInitSettings.schema.json
+++ b/website/static/schemas/next/chatInitSettings.schema.json
@@ -17,11 +17,14 @@
             "type": "string"
         },
         "options": {
-            "groupRecipients": "boolean",
-            "public": "boolean",
-            "allowHistoryBrowsing": "boolean",
-            "allowMessageCopy": "boolean",
-            "allowAddUser": "boolean"
+            "type": "object",
+            "properties": {
+              "groupRecipients": {"type": "boolean"},
+              "public": {"type": "boolean"},
+              "allowHistoryBrowsing":  {"type": "boolean"},
+              "allowMessageCopy":  {"type": "boolean"},
+              "allowAddUser":  {"type": "boolean"}
+            }
         }
     },
     "required": [

--- a/website/versioned_docs/version-2.0/context/ref/ChatInitSettings.md
+++ b/website/versioned_docs/version-2.0/context/ref/ChatInitSettings.md
@@ -27,7 +27,7 @@ https://fdc3.finos.org/schemas/2.0/chatInitSettings.schema.json
 | `members`                      | ContactList | No       | ContactList - cf. below                                              |
 | `initMessage`                  | string      | No       | `'Hello!'`                                                           |
 | `options.groupRecipients`      | boolean     | No       | `true`: if false a separate chat will be created for each member     |
-| `options.public`               | boolean     | No       | `true`: the room will be visible to everyone in the chat application |
+| `options.isPublic`             | boolean     | No       | `true`: the room will be visible to everyone in the chat application |
 | `options.allowHistoryBrowsing` | boolean     | No       | `true`: members will be allowed to browse past messages             |
 | `options.allowMessageCopy`     | boolean     | No       | `true`: members will be allowed to copy/paste messages               |
 | `options.allowAddUser`         | boolean     | No       | `true`: members will be allowed to add other members to the chat     |
@@ -59,7 +59,7 @@ const initSettings = {
     },
     options: {
         groupRecipients: true, // one chat with both contacts
-        public: false, // private chat room
+        isPublic: false, // private chat room
         allowHistoryBrowsing: true,
         allowMessageCopy: true
     }

--- a/website/versioned_docs/version-2.0/intents/ref/StartChat.md
+++ b/website/versioned_docs/version-2.0/intents/ref/StartChat.md
@@ -52,7 +52,7 @@ const initSettings = {
     },
     options: {
         groupRecipients: true, // one chat with both contacts
-        public: false, // private chat room
+        isPublic: false, // private chat room
         allowHistoryBrowsing: true,
         allowMessageCopy: true,
         allowAddUser: false, // John won't be authorized to add other users to the chat


### PR DESCRIPTION
Fix issue: https://github.com/finos/FDC3/issues/855

**Changes**

- Fix incorrect schema format  
- Rename 'public' property name because 'public' is a reserved word in JS/Typescript.

See comment: https://github.com/finos/FDC3/issues/855#issuecomment-1337268416