### PR TITLE
Fix minor typo in PrivateChannel inline docs

### DIFF
--- a/src/api/PrivateChannel.ts
+++ b/src/api/PrivateChannel.ts
@@ -35,7 +35,7 @@ export interface PrivateChannel extends Channel {
    * Listener.unsubscribe() on a context listener that it previously added.
    *
    * Desktop Agents MUST call this when disconnect() is called by the other party, for
-   * each listner that they had added.
+   * each listener that they had added.
    */
   onUnsubscribe(handler: (contextType?: string) => void): Listener;
 

--- a/src/api/PrivateChannel.ts
+++ b/src/api/PrivateChannel.ts
@@ -35,7 +35,7 @@ export interface PrivateChannel extends Channel {
    * Listener.unsubscribe() on a context listener that it previously added.
    *
    * Desktop Agents MUST call this when disconnect() is called by the other party, for
-   * each listener that they had added.
+   * each listener that they have added.
    */
   onUnsubscribe(handler: (contextType?: string) => void): Listener;
 


### PR DESCRIPTION
Simple typo in inline documentation on PrivateChannel member.  I did a global search and only found this one occurence.

---
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.
 
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.