### PR TITLE
Deprecating AppD name field and promoting title to required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Updated definition of the `Instrument` context type to include optional market identifiers ([#819](https://github.com/finos/FDC3/pull/819))
 
 ### Deprecated
+* Deprecated the `name` field in AppD records, to match deprecation of API signatures and metadata objects using `name` (see ([#722](https://github.com/finos/FDC3/pull/722))
+)) in 2.0 ([#928])(https://github.com/finos/FDC3/pull/928))
 
 ### Fixed
 

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -299,9 +299,20 @@ components:
           description: >
             The unique application identifier located within a specific
             application directory instance.
+        title:
+          type: string
+          description: >-
+            Title for the application, typically used in a launcher UI.
+        type:
+          $ref: '#/components/schemas/Type'
+        details:
+          $ref: '#/components/schemas/LaunchDetails'
         name:
           type: string
           description: >
+            Deprecated in favour of using `appId` to identify apps and `title`
+            for their display names.
+            
             The name of the application.
 
             The name should be unique within an FDC3 App Directory instance. The
@@ -310,21 +321,13 @@ components:
 
             The same appName could occur in other directories. We are not
             currently specifying app name conventions in the document.
-        type:
-          $ref: '#/components/schemas/Type'
-        details:
-          $ref: '#/components/schemas/LaunchDetails'
+          deprecated: true
         version:
           type: string
           description: >-
             Version of the application. This allows multiple app versions to be
             defined using the same app name. This can be a triplet but can also
             include things like 1.2.5 (BETA)
-        title:
-          type: string
-          description: >-
-            Optional title for the application, if missing use appName,
-            typically used in a launcher UI.
         tooltip:
           type: string
           description: Optional tooltip description e.g. for a launcher
@@ -436,7 +439,7 @@ components:
         discussed elsewhere in the FDC3 App Directory spec.
       required:
         - appId
-        - name
+        - title
         - type
         - details
       allOf:
@@ -872,7 +875,6 @@ components:
     FDC3WorkbenchAppDefinition:
       value:
         appId: fdc3-workbench
-        name: fdc3-workbench
         title: FDC3 Workbench
         description: Development and test tool for FDC3 desktop agents and apps
         categories: [developer tools, training]
@@ -951,7 +953,6 @@ components:
     MyAppDefinition:
       value:
         appId: my-application
-        name: my-application
         title: My Application
         description: An example application that uses FDC3 and fully describes itself in an AppD record.
         categories: [market data, research, news]
@@ -1066,7 +1067,6 @@ components:
       value:
         applications: # you can't $ref inside a $ref so example is repeated here for search response
           - appId: my-application
-            name: my-application
             title: My Application
             description: An example application that uses FDC3 and fully describes itself in an AppD record.
             categories: [market data, research, news]
@@ -1177,7 +1177,6 @@ components:
                 title: Mon application,
                 description: Un exemple d'application qui utilise FDC3 et se décrit entièrement dans un enregistrement AppD.
           - appId: fdc3-workbench
-            name: fdc3-workbench
             title: FDC3 Workbench
             description: Development and test tool for FDC3 desktop agents and apps
             categories: [developer tools, training]

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -299,9 +299,20 @@ components:
           description: >
             The unique application identifier located within a specific
             application directory instance.
+        title:
+          type: string
+          description: >-
+            Title for the application, typically used in a launcher UI.
+        type:
+          $ref: '#/components/schemas/Type'
+        details:
+          $ref: '#/components/schemas/LaunchDetails'
         name:
           type: string
           description: >
+            Deprecated in favour of using `appId` to identify apps and `title`
+            for their display names.
+            
             The name of the application.
 
             The name should be unique within an FDC3 App Directory instance. The
@@ -310,21 +321,13 @@ components:
 
             The same appName could occur in other directories. We are not
             currently specifying app name conventions in the document.
-        type:
-          $ref: '#/components/schemas/Type'
-        details:
-          $ref: '#/components/schemas/LaunchDetails'
+          deprecated: true
         version:
           type: string
           description: >-
             Version of the application. This allows multiple app versions to be
             defined using the same app name. This can be a triplet but can also
             include things like 1.2.5 (BETA)
-        title:
-          type: string
-          description: >-
-            Optional title for the application, if missing use appName,
-            typically used in a launcher UI.
         tooltip:
           type: string
           description: Optional tooltip description e.g. for a launcher
@@ -436,7 +439,7 @@ components:
         discussed elsewhere in the FDC3 App Directory spec.
       required:
         - appId
-        - name
+        - title
         - type
         - details
       allOf:
@@ -872,7 +875,6 @@ components:
     FDC3WorkbenchAppDefinition:
       value:
         appId: fdc3-workbench
-        name: fdc3-workbench
         title: FDC3 Workbench
         description: Development and test tool for FDC3 desktop agents and apps
         categories: [developer tools, training]
@@ -951,7 +953,6 @@ components:
     MyAppDefinition:
       value:
         appId: my-application
-        name: my-application
         title: My Application
         description: An example application that uses FDC3 and fully describes itself in an AppD record.
         categories: [market data, research, news]
@@ -1066,7 +1067,6 @@ components:
       value:
         applications: # you can't $ref inside a $ref so example is repeated here for search response
           - appId: my-application
-            name: my-application
             title: My Application
             description: An example application that uses FDC3 and fully describes itself in an AppD record.
             categories: [market data, research, news]
@@ -1177,7 +1177,6 @@ components:
                 title: Mon application,
                 description: Un exemple d'application qui utilise FDC3 et se décrit entièrement dans un enregistrement AppD.
           - appId: fdc3-workbench
-            name: fdc3-workbench
             title: FDC3 Workbench
             description: Development and test tool for FDC3 desktop agents and apps
             categories: [developer tools, training]


### PR DESCRIPTION
resolves #820

Updates the appD spec to deprecate the `name` field, drop the requirement for it and promote title to required instead.

Current spec to compare with preview: https://fdc3.finos.org/schemas/next/app-directory.html