### PR TITLE
docs: a11y: Add alt text to images on front page

### DIFF
--- a/website/data/features/api.mdx
+++ b/website/data/features/api.mdx
@@ -1,4 +1,4 @@
-<img alt="Features" src="/img/feature-api.svg" />
+<img alt="" src="/img/feature-api.svg" />
 
 ## API
 

--- a/website/data/features/app-directory.mdx
+++ b/website/data/features/app-directory.mdx
@@ -1,4 +1,4 @@
-<img src="/img/feature-appd.svg" />
+<img alt="" src="/img/feature-appd.svg" />
 
 ## App Directory
 

--- a/website/data/features/context-data.mdx
+++ b/website/data/features/context-data.mdx
@@ -1,4 +1,4 @@
-<img src="/img/feature-context.svg" />
+<img alt="" src="/img/feature-context.svg" />
 
 ## Context Data
 

--- a/website/data/features/intents.mdx
+++ b/website/data/features/intents.mdx
@@ -1,4 +1,4 @@
-<img src="/img/feature-intents.svg" />
+<img alt="" src="/img/feature-intents.svg" />
 
 ## Intents
 

--- a/website/data/front/conformance.mdx
+++ b/website/data/front/conformance.mdx
@@ -6,10 +6,10 @@ FDC3 has a [conformance framework](https://github.com/finos/FDC3-Conformance-Fra
 
 Check the [community page](/community) for details of who has passed the conformance tests.
 
-<img className="front-conformance-logo" src="/img/community/certified-1.2.png" />
+<img className="front-conformance-logo" src="/img/community/certified-1.2.png" alt="FDC3 1.2 Certified" />
 
 <ConformanceShowcase badge="/img/community/certified-1.2.png" />
 
-<img className="front-conformance-logo" src="/img/community/certified-2.0.png" />
+<img className="front-conformance-logo" src="/img/community/certified-2.0.png" alt="FDC3 2.0 Certified" />
 
 Coming Soon!

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -174,10 +174,10 @@ module.exports={
           "title": "More",
           "items": [
             {
-              "html": "<a href=\"https://github.com/finos/FDC3\"><img src=\"https://img.shields.io/github/stars/finos/FDC3?label=FDC3&style=social\" /></a>"
+              "html": "<a href=\"https://github.com/finos/FDC3\"><img alt=\"Github\" src=\"https://img.shields.io/github/stars/finos/FDC3?label=FDC3&style=social\" /></a>"
             },
             {
-              "html": "<a href=\"https://twitter.com/FDC3_\"><img src=\"https://img.shields.io/twitter/follow/FDC3_?style=social\" ></a>"
+              "html": "<a href=\"https://twitter.com/FDC3_\"><img alt=\"Twitter\" src=\"https://img.shields.io/twitter/follow/FDC3_?style=social\" ></a>"
             },
             {
               "label": "Users",

--- a/website/src/components/HomeSplash/index.js
+++ b/website/src/components/HomeSplash/index.js
@@ -49,7 +49,7 @@ export default (props) => {
     return (
       <SplashContainer>
           <div className="inner">
-                <img src="/img/fdc3-logo-2019.png"></img>
+                <img src="/img/fdc3-logo-2019.png" alt="FDC3"></img>
                 <ProjectTitle siteConfig={siteConfig} />
                 <PromoSection>
                   <Button href="/docs/fdc3-intro">Get Started</Button>


### PR DESCRIPTION
In this PR, I:
- [x] Added empty alt text to icons
- [x] Removed the alt text "Features" from an icon
- [x] Added alt text to the Twitter and Github links in the footer
- [x] Added alt text "FDC3" to the logo image
- [x] Added alt text "FDC3 1.2/2.0 Certified" to those badges

If you want to test the impact of these changes, here's how you can quickly see the difference using Chrome:
1. Go to the webpage (in Chrome)
2. Open Developer Tools (Win: press F12)
3. In DevTools, go to the "Lighthouse" tab
4. Click "Analyze page load" button

Before this PR, you'll see a score in the 80's, with an indicator that there are several images without alt text
![image](https://user-images.githubusercontent.com/74684272/231530275-f75bfb64-a762-446c-91fc-2a43612e3952.png)
**Lighthouse score for fdc3.finos.org**

After this PR, you'll see a score in the 90's, without any indicators about alt text
![image](https://user-images.githubusercontent.com/74684272/231530559-512b63c8-3e2d-43c2-8b77-ab684ea9e545.png)
**Lighthouse score for dev version of the website, based on this PR**