### PR TITLE
docs: Make references page's hrefs into links

### DIFF
--- a/website/versioned_docs/version-2.0/references.md
+++ b/website/versioned_docs/version-2.0/references.md
@@ -7,27 +7,27 @@ original_id: references
 
 The following normative documents contain provisions, which, through reference in this text, constitute provisions of this Standard. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. However, parties to agreements based on this Standard are encouraged to investigate the possibility of applying the most recent editions of the normative documents indicated below. For undated references, the latest edition of the normative document referred to applies:
 
-- **Apache 2.0 open-source license**, [https://www.apache.org/licenses/LICENSE-2.0].
-- **Community Specification license**, [https://github.com/CommunitySpecification/1.0]
-- **ISO 3166-1**, _Codes for the representation of names of countries and their subdivisions – Part 1: Country codes_, [https://www.iso.org/iso-3166-country-codes.html].
-- **ISO 8601-1:2019**, _Date and time — Representations for information interchange — Part 1: Basic rules_, [https://www.iso.org/standard/70907.html]
-- **JSON Schema**, [https://json-schema.org/].
-- **OpenAPI Standard v3.0**, [https://www.openapis.org/].
-- **RFC 2119**, _Keywords for use in RFCs to Indicate Requirement Levels, March 1997_, [https://datatracker.ietf.org/doc/html/rfc2119].
+- **Apache 2.0 open-source license**, [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+- **Community Specification license**, [https://github.com/CommunitySpecification/1.0](https://github.com/CommunitySpecification/1.0)
+- **ISO 3166-1**, _Codes for the representation of names of countries and their subdivisions – Part 1: Country codes_, [https://www.iso.org/iso-3166-country-codes.html](https://www.iso.org/iso-3166-country-codes.html).
+- **ISO 8601-1:2019**, _Date and time — Representations for information interchange — Part 1: Basic rules_, [https://www.iso.org/standard/70907.html](https://www.iso.org/standard/70907.html)
+- **JSON Schema**, [https://json-schema.org/](https://json-schema.org/).
+- **OpenAPI Standard v3.0**, [https://www.openapis.org/](https://www.openapis.org/).
+- **RFC 2119**, _Keywords for use in RFCs to Indicate Requirement Levels, March 1997_, [https://datatracker.ietf.org/doc/html/rfc2119](https://datatracker.ietf.org/doc/html/rfc2119).
 - **RFC 2782**, _A DNS RR for specifying the location of services (DNS SRV), February 2000_, [https://datatracker.ietf.org/doc/html/rfc2782].
-- **RFC 5646**, _Tags for Identifying Languages, September 2009_, [https://datatracker.ietf.org/doc/html/rfc5646].
-- **TypeScript Programming Language**, [https://www.typescriptlang.org/].
-- **Web Application Manifest**, _W3C Working Draft_, February 2022 [https://www.w3.org/TR/appmanifest/]
+- **RFC 5646**, _Tags for Identifying Languages, September 2009_, [https://datatracker.ietf.org/doc/html/rfc5646](https://datatracker.ietf.org/doc/html/rfc5646).
+- **TypeScript Programming Language**, [https://www.typescriptlang.org/](https://www.typescriptlang.org/).
+- **Web Application Manifest**, _W3C Working Draft_, February 2022 [https://www.w3.org/TR/appmanifest/](https://www.w3.org/TR/appmanifest/)
 
 The following documents may be useful in understanding certain aspects of this Standard; however, knowledge of them is not essential to the creation of a compliant implementation of this Standard:
 
-- **CUSIP**, _Committee on Uniform Security Identification Procedures_, [https://www.cusip.com/identifiers.html#/CUSIP].
-- **FIGI**, _Financial Instrument Global Identifier_, [https://www.openfigi.com/about/figi].
-- **ISIN**, _International Securities Identification Number_, [https://www.isin.org/isin/]
-- **LEI**, _Legal Entity Identifier based on the ISO 17442 standard_, [https://www.legalentityidentifier.co.uk/what-is-lei-code/].
-- **npm**,  [https://docs.npmjs.com/about-npm].
-- **PermID**, _Permanent Identifiers_, [https://permid.org/].
-- **pnpm**, [https://pnpm.io/motivation].
-- **REST**, [https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm], [https://restfulapi.net/].
-- **SEDOL**, _Stock Exchange Daily Official List_, [https://www.lseg.com/sedol].
-- **yarn**, [https://yarnpkg.com/getting-started].
+- **CUSIP**, _Committee on Uniform Security Identification Procedures_, [https://www.cusip.com/identifiers.html#/CUSIP](https://www.cusip.com/identifiers.html#/CUSIP).
+- **FIGI**, _Financial Instrument Global Identifier_, [https://www.openfigi.com/about/figi](https://www.openfigi.com/about/figi).
+- **ISIN**, _International Securities Identification Number_, [https://www.isin.org/isin/](https://www.isin.org/isin/)
+- **LEI**, _Legal Entity Identifier based on the ISO 17442 standard_, [https://www.legalentityidentifier.co.uk/what-is-lei-code/](https://www.legalentityidentifier.co.uk/what-is-lei-code/).
+- **npm**,  [https://docs.npmjs.com/about-npm](https://docs.npmjs.com/about-npm).
+- **PermID**, _Permanent Identifiers_, [https://permid.org/](https://permid.org/).
+- **pnpm**, [https://pnpm.io/motivation](https://pnpm.io/motivation]).
+- **REST**, [https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm](https://www.ics.uci.edu/~fielding/pubs/dissertation/rest_arch_style.htm), [https://restfulapi.net/](https://restfulapi.net/).
+- **SEDOL**, _Stock Exchange Daily Official List_, [https://www.lseg.com/sedol](https://www.lseg.com/sedol).
+- **yarn**, [https://yarnpkg.com/getting-started](https://yarnpkg.com/getting-started).


### PR DESCRIPTION
The FDC3 references page lists a variety of links, but all of the links are in plain text. 

In this PR, I:
- [x] Made all of the plain text HREF's into anchor tags

This way, users can click on the links, instead of having to copy/paste them, if they want to follow the references.

This relates to #921, which referenced a variety of comments I made in #910. This PR addresses one of many issues that I believe falls under #921's umbrella