### PR TITLE
docs: Convert notes blocks to using the admonitions feature

### DIFF
--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -378,11 +378,11 @@ There are three types of channels, which have different visibility and discovera
   * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
 
   :::note
-  Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
   :::
 
   :::note
-  Earlier versions of FDC3 included the concept of a 'global' system channel
+Earlier versions of FDC3 included the concept of a 'global' system channel
   which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
   :::
 

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -377,10 +377,14 @@ There are three types of channels, which have different visibility and discovera
   * are discoverable (via the [`getUserChannels()`](ref/DesktopAgent#getuserchannels) API call),
   * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
 
-  > **Note:** Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+  :::note
+  Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+  :::
 
-  > **Note:** Earlier versions of FDC3 included the concept of a 'global' system channel
+  :::note
+  Earlier versions of FDC3 included the concept of a 'global' system channel
   which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
+  :::
 
 2. **_App channels_**, which:
 
@@ -438,7 +442,9 @@ Channel implementations SHOULD ensure that context messages broadcast by an appl
 
 Desktop Agent implementations SHOULD use the following set of channels, to enable a consistent user experience across different implementations. Desktop Agent implementation MAY support configuration of the user channels.
 
-> Note: Future versions of the FDC3 Standard may support connections between desktop agents, where differing user channel sets may cause user experience issues.
+:::note
+Future versions of the FDC3 Standard may support connections between desktop agents, where differing user channel sets may cause user experience issues.
+:::
 
 ```javascript
 const recommendedChannels = [

--- a/docs/context/spec.md
+++ b/docs/context/spec.md
@@ -133,7 +133,9 @@ Fields representing a currency SHOULD be string encoded using the Alphabetic cod
 
 E.g. `"CURRENCY_ISOCODE": "GBP"`
 
-> Note: ISO 4217 only includes major currency codes, conversions to minor currencies is the responsibility of the consuming system (where required).
+:::note
+ISO 4217 only includes major currency codes, conversions to minor currencies is the responsibility of the consuming system (where required).
+:::
 
 ## Context Data Standard Compliance
 

--- a/docs/fdc3-charter.md
+++ b/docs/fdc3-charter.md
@@ -18,7 +18,9 @@ This Standard is focused specifically on the desktop.  Activities of the desktop
 * Interoperability between mobile apps
 * Interoperability via REST or other client to server communication
 
-Note: While these areas are out of scope, compatibility with Mobile and/or REST are still valid points of consideration for FDC3.
+:::note
+While these areas are out of scope, compatibility with Mobile and/or REST are still valid points of consideration for FDC3.
+:::
 
 ### Success Criteria
 * Commitment from major banks and application vendors to support the standards set out by the FDC3

--- a/docs/intents/ref/ViewContact.md
+++ b/docs/intents/ref/ViewContact.md
@@ -5,7 +5,9 @@ title: ViewContact
 hide_title: true
 ---
 # `ViewContact`
-> **Note:** ViewContact has been deprecated in FDC3 2.0 in favour of the more general [ViewProfile](ViewProfile) intent.
+:::caution
+ViewContact has been deprecated in FDC3 2.0 in favour of the more general [ViewProfile](ViewProfile) intent.
+:::
 
 
 View details for a contact.

--- a/docs/intents/spec.md
+++ b/docs/intents/spec.md
@@ -19,7 +19,9 @@ Naming of Intents SHOULD follow the below guidelines:
 * ‘.’ will be used to namespace the intent (see below).
 * Intent names should be in UpperCamelCase.
 
-> **Note:** The naming guidelines should be adhered to when creating future Intents.  This is to ensure they meet the criteria for addition to the FDC3 standard and to provide a consistent user experience.
+:::note
+The naming guidelines should be adhered to when creating future Intents.  This is to ensure they meet the criteria for addition to the FDC3 standard and to provide a consistent user experience.
+:::
 
 ### Characteristics
 

--- a/website/versioned_docs/version-2.0/api/spec.md
+++ b/website/versioned_docs/version-2.0/api/spec.md
@@ -378,11 +378,11 @@ There are three types of channels, which have different visibility and discovera
   * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
 
   :::note
-  Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
   :::
 
   :::note
-  Earlier versions of FDC3 included the concept of a 'global' system channel
+Earlier versions of FDC3 included the concept of a 'global' system channel
   which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
   :::
 

--- a/website/versioned_docs/version-2.0/api/spec.md
+++ b/website/versioned_docs/version-2.0/api/spec.md
@@ -377,10 +377,14 @@ There are three types of channels, which have different visibility and discovera
   * are discoverable (via the [`getUserChannels()`](ref/DesktopAgent#getuserchannels) API call),
   * can be 'joined' (via the [`joinUserChannel()`](ref/DesktopAgent#joinuserchannel) API call).
 
-  > **Note:** Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+  :::note
+  Prior to FDC3 2.0, 'user' channels were known as 'system' channels. They were renamed in FDC3 2.0 to reflect their intended usage, rather than the fact that they are created by system (which could also create 'app' channels).
+  :::
 
-  > **Note:** Earlier versions of FDC3 included the concept of a 'global' system channel
+  :::note
+  Earlier versions of FDC3 included the concept of a 'global' system channel
   which was deprecated in FDC3 1.2 and removed in FDC3 2.0.
+  :::
 
 2. **_App channels_**, which:
 
@@ -438,7 +442,9 @@ Channel implementations SHOULD ensure that context messages broadcast by an appl
 
 Desktop Agent implementations SHOULD use the following set of channels, to enable a consistent user experience across different implementations. Desktop Agent implementation MAY support configuration of the user channels.
 
-> Note: Future versions of the FDC3 Standard may support connections between desktop agents, where differing user channel sets may cause user experience issues.
+:::note
+Future versions of the FDC3 Standard may support connections between desktop agents, where differing user channel sets may cause user experience issues.
+:::
 
 ```javascript
 const recommendedChannels = [

--- a/website/versioned_docs/version-2.0/context/spec.md
+++ b/website/versioned_docs/version-2.0/context/spec.md
@@ -133,7 +133,9 @@ Fields representing a currency SHOULD be string encoded using the Alphabetic cod
 
 E.g. `"CURRENCY_ISOCODE": "GBP"`
 
-> Note: ISO 4217 only includes major currency codes, conversions to minor currencies is the responsibility of the consuming system (where required).
+:::note
+ISO 4217 only includes major currency codes, conversions to minor currencies is the responsibility of the consuming system (where required).
+:::
 
 ## Context Data Standard Compliance
 
@@ -173,7 +175,9 @@ The following are standard FDC3 context types:
 * [`fdc3.timerange`](ref/TimeRange) ([schema](/schemas/2.0/timerange.schema.json))
 * [`fdc3.valuation`](ref/Valuation) ([schema](/schemas/2.0/valuation.schema.json))
 
-**Note:** The below examples show how the base context data interface can be used to define specific context data objects.
+:::note
+The below examples show how the base context data interface can be used to define specific context data objects.
+:::
 
 ### Examples
 

--- a/website/versioned_docs/version-2.0/fdc3-charter.md
+++ b/website/versioned_docs/version-2.0/fdc3-charter.md
@@ -18,7 +18,9 @@ This Standard is focused specifically on the desktop.  Activities of the desktop
 * Interoperability between mobile apps
 * Interoperability via REST or other client to server communication
 
-Note: While these areas are out of scope, compatibility with Mobile and/or REST are still valid points of consideration for FDC3.
+:::note
+While these areas are out of scope, compatibility with Mobile and/or REST are still valid points of consideration for FDC3.
+:::
 
 ### Success Criteria
 * Commitment from major banks and application vendors to support the standards set out by the FDC3

--- a/website/versioned_docs/version-2.0/intents/ref/ViewContact.md
+++ b/website/versioned_docs/version-2.0/intents/ref/ViewContact.md
@@ -5,7 +5,9 @@ hide_title: true
 original_id: ViewContact
 ---
 # `ViewContact`
-> **Note:** ViewContact has been deprecated in FDC3 2.0 in favour of the more general [ViewProfile](ViewProfile) intent.
+:::caution
+ViewContact has been deprecated in FDC3 2.0 in favour of the more general [ViewProfile](ViewProfile) intent.
+:::
 
 
 View details for a contact.

--- a/website/versioned_docs/version-2.0/intents/spec.md
+++ b/website/versioned_docs/version-2.0/intents/spec.md
@@ -19,7 +19,9 @@ Naming of Intents SHOULD follow the below guidelines:
 * ‘.’ will be used to namespace the intent (see below).
 * Intent names should be in UpperCamelCase.
 
-> **Note:** The naming guidelines should be adhered to when creating future Intents.  This is to ensure they meet the criteria for addition to the FDC3 standard and to provide a consistent user experience.
+:::note
+The naming guidelines should be adhered to when creating future Intents.  This is to ensure they meet the criteria for addition to the FDC3 standard and to provide a consistent user experience.
+:::
 
 ### Characteristics
 


### PR DESCRIPTION
Part of the #921 umbrella

In the current docs, notes might be called out like this:
![image](https://user-images.githubusercontent.com/74684272/231542448-c7307d0f-3ef9-4521-b9fe-d671d819e75b.png)
![image](https://user-images.githubusercontent.com/74684272/231542773-c82317d1-8e43-4bc9-9282-274aa7c2a720.png)
![image](https://user-images.githubusercontent.com/74684272/231542955-196e4e42-073f-4a3b-b75a-c72240f73022.png)
![image](https://user-images.githubusercontent.com/74684272/231543030-6f88d901-a9f8-42d7-99a0-f019c7a72f17.png)

I updated these examples to use docusaurus's included support for admonitions. This has the benefit of stylistic consistency and visually breaking up the page where they're used.

Here are some updated examples:
![image](https://user-images.githubusercontent.com/74684272/231543392-9988a665-0598-4b75-85da-79272376c18b.png)
![image](https://user-images.githubusercontent.com/74684272/231543586-0f4d6cf6-9161-4e2b-8824-598b89fe9a90.png)
![image](https://user-images.githubusercontent.com/74684272/231543657-f27b2eb3-c30c-4902-b331-78f5e1a2d8f9.png)
![image](https://user-images.githubusercontent.com/74684272/231543721-aa6a5733-4f54-4e31-a52a-0b244a7d7a23.png)
