### PR TITLE
Remove vestigial twitter badge from FINOS footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -177,9 +177,6 @@ module.exports={
               "html": "<a href=\"https://github.com/finos/FDC3\"><img src=\"https://img.shields.io/github/stars/finos/FDC3?label=FDC3&style=social\" /></a>"
             },
             {
-              "html": "<a href=\"https://twitter.com/FDC3_\"><img src=\"https://img.shields.io/twitter/follow/FDC3_?style=social\" ></a>"
-            },
-            {
               "label": "Users",
               "to": "/users"
             },


### PR DESCRIPTION
From @kriswest in #950 :
>  I don't believe the maintainers have access to this twitter account and theres next to nothing on it. It needs to go.

So, here's a quick PR to just remove it from the footer while we're talking about it.

Before PR:
![image](https://user-images.githubusercontent.com/74684272/231805843-eea34914-c38b-4737-b955-a2f5dc3ba409.png)

After PR:
![image](https://user-images.githubusercontent.com/74684272/231805900-2c5b38b0-79be-4b37-9395-b545ce1239b0.png)
