### PR TITLE
Add netlify.toml file to customize preview builds and CORS headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../{toolbox,docs,src,website}/"
+
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Adding a netlify.toml file that customizes when previews are built (not sure why that was removed...) and to set permissive CORS headers to allow schema file retrievals by JSON schema tools.

resolves #956