### PR TITLE
Make grid blocks images/labels clickable

### DIFF
--- a/website/data/features/api.mdx
+++ b/website/data/features/api.mdx
@@ -1,5 +1,8 @@
-<img alt="" src="/img/feature-api.svg" />
+<a href="/docs/api/spec">
+    <div>
+        <img alt="" src="/img/feature-api.svg" />
+        <div className="blockTitle">API</div>
+    </div>
+</a>
 
-## API
-
-Create a consistent developer experience by adhering to the [API](/docs/api/spec) standard
+Create a consistent developer experience by adhering to the API standard

--- a/website/data/features/app-directory.mdx
+++ b/website/data/features/app-directory.mdx
@@ -1,5 +1,8 @@
-<img alt="" src="/img/feature-appd.svg" />
+<a href="/docs/app-directory/overview">
+    <div>
+        <img alt="" src="/img/feature-appd.svg" />
+        <div className="blockTitle">App Directory</div>
+    </div>
+</a>
 
-## App Directory
-
-Discover trusted apps that can take part in a FDC3 workflow using an [App directory](/docs/app-directory/overview)
+Discover trusted apps that can take part in a FDC3 workflow using an App directory

--- a/website/data/features/context-data.mdx
+++ b/website/data/features/context-data.mdx
@@ -1,5 +1,8 @@
-<img alt="" src="/img/feature-context.svg" />
+<a href="/docs/context/spec">
+    <div>
+        <img alt="" src="/img/feature-context.svg" />
+        <div className="blockTitle">Context Data</div>
+    </div>
+</a>
 
-## Context Data
-
-Share [context](/docs/context/spec) between apps to eliminate re-keying and streamline workflow
+Share context between apps to eliminate re-keying and streamline workflow

--- a/website/data/features/intents.mdx
+++ b/website/data/features/intents.mdx
@@ -1,5 +1,8 @@
-<img alt="" src="/img/feature-intents.svg" />
+<a href="/docs/intents/spec">
+    <div>
+        <img alt="" src="/img/feature-intents.svg" />
+        <div className="blockTitle">Intents</div>
+    </div>
+</a>
 
-## Intents
-
-Use [standardized verbs](/docs/intents/spec) to instruct other apps to take an action
+Use standardized verbs to instruct other apps to take an action

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -204,9 +204,16 @@ header.postHeader:empty + article h1 {
 .blockContent {
   margin: 40px 20px;
 }
-.blockContent h2{
+ 
+.blockTitle {
   color:  #0086bf;  /* DO NOT CHANGE - THIS IS THE TITLE UNDER THE ICONS IN THE 3RD BLOCK - SHOULD STAY FINOS BLUE */
   text-align: center;
+  font-size: var(--ifm-h2-font-size);
+  font-family: var(--ifm-heading-font-family);
+  font-weight: var(--ifm-heading-font-weight);
+  line-height: var(--ifm-heading-line-height);
+  margin: var(--ifm-heading-margin-top) 0 0 0;
+  padding-bottom: var(--ifm-heading-margin-bottom);
 }
 
 


### PR DESCRIPTION
Part of #943 

In this PR, I:
- [x] Removed the H2 tags from the "API", "Intents", "Context Data", and "App Directory" blocks.
- [x] Made the images and labels into one large clickable block
- [x] Remove the links from the descriptions (since the images+labels are now links)

Before:
![image](https://user-images.githubusercontent.com/74684272/232569215-cbad584a-e9c2-4c60-975e-71404372c9a6.png)

After:
![image](https://user-images.githubusercontent.com/74684272/232569330-7f705fe6-2bb6-44e5-95c4-e0d1ec6e5461.png)


This is what a new block looks like with a focus indicator:
![image](https://user-images.githubusercontent.com/74684272/232569857-04b3502e-41f6-4f37-acac-6c44a580211f.png)

(The focus indicator is only visible if you use keyboard navigation to tab to the element on the page. If a mouse user simply clicks on the image/label, you'll see an underline under the text)