### PR TITLE
docs: Address all console errors on the front page

### DIFF
--- a/website/src/components/ConformanceShowcase/index.js
+++ b/website/src/components/ConformanceShowcase/index.js
@@ -15,19 +15,19 @@ export default ({ badge }) => {
             });
     });
 
-    return <div class={styles.conformanceShowcase}>
+    return <div className={styles.conformanceShowcase}>
         {
-            relevant.map(c => {
+            relevant.map((c, key) => {
                 return (
-                    <div className={styles.conformanceShowcaseItem}>
-                        <div class={styles.conformanceImage}>
+                    <div className={styles.conformanceShowcaseItem} key={key}>
+                        <div className={styles.conformanceImage}>
                             <img src={c.conf.image} alt={c.conf.title} title={c.conf.title} />
                         </div>
-                        <div class={styles.conformanceText}>
+                        <div className={styles.conformanceText}>
                             <a href={c.conf.infoLink}><h3>{c.conf.title}</h3></a><ul>
                                 {
-                                    c.badge.items.map(item => {
-                                        return (<li class={styles.conformanceItem}>
+                                    c.badge.items.map((item, key2) => {
+                                        return (<li className={styles.conformanceItem} key={key2}>
                                             <p>{item.text} {  (item.link) ? <em><a href={item.link}>More Details</a></em> :"" }</p>
                                         </li>)
                                     })

--- a/website/src/components/GridBlock/index.js
+++ b/website/src/components/GridBlock/index.js
@@ -5,8 +5,8 @@ export default ({items}) => {
     return (
       <div className="gridBlock">
         {
-          items.map(sl =>
-            <div className="blockElement fourByGridBlock">
+          items.map((sl, key) =>
+            <div className="blockElement fourByGridBlock" key={key}>
               <div className="blockContent">
                 {sl}
               </div>


### PR DESCRIPTION
If you launch the FDC3 website in dev mode, you get webpack/react warnings like this:
![Warning: Each child in a list should have a unique "key" prop](https://user-images.githubusercontent.com/74684272/232781554-a749cfee-4b6f-4f21-b82d-66d91fd146d6.png)

There were 2 cases where a `key` prop being needed, and a couple of cases of `class` being used instead of `className`.

Now, there are no errors/warnings on the home page (in dev mode).