### PR TITLE
Fixing minor syntax error in PrivateChannel docs

### DIFF
--- a/docs/api/ref/PrivateChannel.md
+++ b/docs/api/ref/PrivateChannel.md
@@ -102,7 +102,7 @@ try {
 } catch (resolverError) {
     console.error(`Error: Intent was not resolved: ${resolverError}`);
 }
-
+```
 
 ## Methods
 

--- a/website/versioned_docs/version-2.0/api/ref/PrivateChannel.md
+++ b/website/versioned_docs/version-2.0/api/ref/PrivateChannel.md
@@ -97,7 +97,7 @@ try {
 } catch (resolverError) {
     console.error(`Error: Intent was not resolved: ${resolverError}`);
 }
-
+```
 
 ## Methods
 


### PR DESCRIPTION
WHile working on the bridging proposal I noticed a code fence with a missing close that is breaking the formatting of the PrivateChannel docs