### PR TITLE
980 Correcting appd interop.appChannels to use id instead of name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Updated definition of the `Instrument` context type to include optional market identifiers ([#819](https://github.com/finos/FDC3/pull/819))
 * Corrected API functions and object types to always use `string` instead of `String` ([#924](https://github.com/finos/FDC3/pull/924))
+* Corrected the appD `interop.appChannels` metadata to use an `id` field to identify channels, rather than `name` ([#981](https://github.com/finos/FDC3/pull/981))
 
 ### Deprecated
 

--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -714,11 +714,13 @@ components:
           items:
             type: object
             required:
-              - name
+              - id
             properties:
-              name:
+              id:
                 type: string
-                description: The name of the App Channel.
+                description: >
+                  The id of the App Channel. 
+                  N.b. in FDC3 2.0 this field was incorrectly  called `name`.
               description:
                 type: string
                 description: A description of how the channel is used.
@@ -894,7 +896,7 @@ components:
         tooltip: FDC3 Workbench
         lang: en-US
         icons:
-          - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+          - src: https://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
         screenshots:
           - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png
             label: FDC3 logo
@@ -1064,7 +1066,7 @@ components:
               - fdc3.instrument
               - fdc3.organization
           appChannels: 
-            - name: myApp.quotes,
+            - id: myApp.quotes,
               description: >-
                 Used to share a stream of quotes for currently displayed instrument and may be used to change the currently displayed symbol,
               broadcasts: 
@@ -1179,7 +1181,7 @@ components:
                   - fdc3.instrument
                   - fdc3.organization
               appChannels: 
-                - name: myApp.quotes,
+                - id: myApp.quotes,
                   description: >-
                     Used to share a stream of quotes for currently displayed instrument and may be used to change the currently displayed symbol,
                   broadcasts:
@@ -1199,7 +1201,7 @@ components:
             tooltip: FDC3 Workbench
             lang: en-US
             icons:
-              - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+              - src: https://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
             screenshots:
               - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
                 label: FDC3 logo

--- a/website/static/schemas/next/app-directory.yaml
+++ b/website/static/schemas/next/app-directory.yaml
@@ -714,11 +714,13 @@ components:
           items:
             type: object
             required:
-              - name
+              - id
             properties:
-              name:
+              id:
                 type: string
-                description: The name of the App Channel.
+                description: >
+                  The id of the App Channel. 
+                  N.b. in FDC3 2.0 this field was incorrectly  called `name`.
               description:
                 type: string
                 description: A description of how the channel is used.
@@ -894,7 +896,7 @@ components:
         tooltip: FDC3 Workbench
         lang: en-US
         icons:
-          - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+          - src: https://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
         screenshots:
           - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png
             label: FDC3 logo
@@ -1064,7 +1066,7 @@ components:
               - fdc3.instrument
               - fdc3.organization
           appChannels: 
-            - name: myApp.quotes,
+            - id: myApp.quotes,
               description: >-
                 Used to share a stream of quotes for currently displayed instrument and may be used to change the currently displayed symbol,
               broadcasts: 
@@ -1179,7 +1181,7 @@ components:
                   - fdc3.instrument
                   - fdc3.organization
               appChannels: 
-                - name: myApp.quotes,
+                - id: myApp.quotes,
                   description: >-
                     Used to share a stream of quotes for currently displayed instrument and may be used to change the currently displayed symbol,
                   broadcasts:
@@ -1199,7 +1201,7 @@ components:
             tooltip: FDC3 Workbench
             lang: en-US
             icons:
-              - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
+              - src: https://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
             screenshots:
               - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
                 label: FDC3 logo


### PR DESCRIPTION
resolves #980 

Swaps out `interop.appChannels.name` for `interop.appChannels.id` - use of `name` was inadvertent and confusing (as channels have an `id` and an optional `displayMetadata.name`)