### PR TITLE
Add a body background color declaration to website light theme

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -49,6 +49,10 @@ html[data-theme='light'] .footer-copyright {
   font-size: smaller;
 }
 
+html[data-theme='light'] body {
+  background-color: #fff;
+}
+
 .dropdown__menu {
   background-color:  #009ADC;
 }


### PR DESCRIPTION
I noticed the website's light theme is missing body background color declaration and is relying on the window background being white, which it isn't always: dark mode extension, containers that set dark background (which is most of them AFAIK)