### PR TITLE
Don't use deprecated functions in 2.0 version of workbench

### DIFF
--- a/toolbox/fdc3-workbench/src/store/ChannelStore.ts
+++ b/toolbox/fdc3-workbench/src/store/ChannelStore.ts
@@ -49,7 +49,7 @@ class ChannelStore {
 			.fdc3Ready(5000)
 			.then(async () => {
 				try {
-					const userChannels = await fdc3.getSystemChannels();
+					const userChannels = await fdc3.getUserChannels();
 					const currentUserChannel = await fdc3.getCurrentChannel();
 
 					runInAction(() => {
@@ -81,7 +81,7 @@ class ChannelStore {
 
 	async joinUserChannel(channelId: string) {
 		try {
-			await fdc3.joinChannel(channelId);
+			await fdc3.joinUserChannel(channelId);
 			const currentUserChannel = await fdc3.getCurrentChannel();
 			const isSuccess = currentUserChannel !== null;
 

--- a/toolbox/fdc3-workbench/src/utility/Fdc3Api.ts
+++ b/toolbox/fdc3-workbench/src/utility/Fdc3Api.ts
@@ -118,12 +118,20 @@ class Fdc3Api {
 		}
 	}
 
-	getSystemChannels() {
-		return this.fdc3Methods.getSystemChannels();
+	getUserChannels() {
+		if (window.fdc3Version === "2.0") {
+			return this.fdc3Methods.getUserChannels();
+		} else {
+			return this.fdc3Methods.getSystemChannels();
+		}
 	}
 
-	joinChannel(channelId: string) {
-		return this.fdc3Methods.joinChannel(channelId);
+	joinUserChannel(channelId: string) {
+		if (window.fdc3Version === "2.0") {
+			return this.fdc3Methods.joinUserChannel(channelId);
+		} else {
+			return this.fdc3Methods.joinChannel(channelId);
+		}
 	}
 
 	leaveCurrentChannel() {


### PR DESCRIPTION
@bingenito spotted that the FDC3-workbench was still using deprecated functions (`getSystemChannels` and `joinChannel`) in its 2.0 version. This works if they are implemented, but they don't have to be. Hence, use the modern versions of the functions in 2.0 and only use the deprecated versions in the 1.2 version.