### PR TITLE
Applying readonly flags to ImplementationMetadata.optionalFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * Further clarified the difference between the behavior of User channels and other channel types on joinUserChannel/addContextListener. ([#971](https://github.com/finos/FDC3/pull/971))
+
+## [npm v2.0.3] - 2023-05-31
+
+### Changed
+
+* Applied missing `readonly` tags to `ImplementationMetadata.optionalFeatures` sub-properties. ([#XXXX](https://github.com/finos/FDC3/pull/XXX))
+
 ## [npm v2.0.2] - 2023-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-* Applied missing `readonly` tags to `ImplementationMetadata.optionalFeatures` sub-properties. ([#XXXX](https://github.com/finos/FDC3/pull/XXX))
+* Applied missing `readonly` tags to `ImplementationMetadata.optionalFeatures` sub-properties. ([#1008](https://github.com/finos/FDC3/pull/1008))
 
 ## [npm v2.0.2] - 2023-05-24
 

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -274,11 +274,11 @@ interface ImplementationMetadata {
   readonly optionalFeatures: {
     /** Used to indicate whether the exposure of 'origninating app metadata' for
      *  context and intent messages is supported by the Desktop Agent.*/
-    "OriginatingAppMetadata": boolean;
+    readonly OriginatingAppMetadata: boolean;
     /** Used to indicate whether the optional `fdc3.joinUserChannel`,
      *  `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
      *  the Desktop Agent.*/
-    "UserChannelMembershipAPIs": boolean;
+    readonly UserChannelMembershipAPIs: boolean;
   };
 
   /** The calling application instance's own metadata, according to the 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/src/api/ImplementationMetadata.ts
+++ b/src/api/ImplementationMetadata.ts
@@ -24,13 +24,13 @@ export interface ImplementationMetadata {
    *  the Desktop Agent API.
    */
   readonly optionalFeatures: {
-    /** Used to indicate whether the exposure of 'origninating app metadata' for
+    /** Used to indicate whether the exposure of 'originating app metadata' for
      *  context and intent messages is supported by the Desktop Agent.*/
-    OriginatingAppMetadata: boolean;
+    readonly OriginatingAppMetadata: boolean;
     /** Used to indicate whether the optional `fdc3.joinUserChannel`,
      *  `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
      *  the Desktop Agent.*/
-    UserChannelMembershipAPIs: boolean;
+    readonly UserChannelMembershipAPIs: boolean;
   };
 
   /** The calling application instance's own metadata, according to the Desktop Agent (MUST include at least the `appId` and `instanceId`). */


### PR DESCRIPTION
@rikoe noticed that the sub-properties of `ImplementationMetadata.optionalFeatures` had not been marked `readonly` in the docs and were quoted unnecessarily. This PR corrects that and re-releases the NPM module with the fix