### PR TITLE
Correct issue in appd details field's schema, error in example and improve test

### DIFF
--- a/src/app-directory/specification/appd.yaml
+++ b/src/app-directory/specification/appd.yaml
@@ -542,7 +542,7 @@ components:
         The type specific launch details of the application. These details are intended to be 
         vendor-agnostic and MAY be duplicated or overridden by details provided in the hostManifests 
         object for a specific host.
-      oneOf:
+      anyOf:
         - $ref: '#/components/schemas/WebAppDetails'
         - $ref: '#/components/schemas/NativeAppDetails'
         - $ref: '#/components/schemas/CitrixAppDetails'
@@ -1209,8 +1209,8 @@ components:
             screenshots:
               - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
                 label: FDC3 logo
-            contactEmail: fdc3@finos.org,
-            supportEmail: fdc3-maintainers@finos.org,
+            contactEmail: fdc3@finos.org
+            supportEmail: fdc3-maintainers@finos.org
             publisher: FDC3,
             type: web
             details:

--- a/src/app-directory/specification/examples/application/fdc3-workbench.json
+++ b/src/app-directory/specification/examples/application/fdc3-workbench.json
@@ -3,32 +3,28 @@
   "name": "fdc3-workbench",
   "title": "FDC3 Workbench",
   "description": "Development and test tool for FDC3 desktop agents and apps",
+  "categories": [
+    "developer tools",
+    "training"
+  ],
   "version": "1.0.0",
   "tooltip": "FDC3 Workbench",
+  "lang": "en-US",
   "icons": [
     {
       "src": "http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png"
     }
   ],
-  "images": [
+  "screenshots": [
     {
-      "url": "https://fdc3.finos.org/docs/assets/fdc3-logo.png",
-      "tooltip": "FDC3 logo"
+      "src": "https://fdc3.finos.org/docs/assets/fdc3-logo.png",
+      "label": "FDC3 logo"
     }
   ],
   "contactEmail": "fdc3@finos.org",
   "supportEmail": "fdc3-maintainers@finos.org",
-  "publisher": "FDC3",
-  "intents": [
-    {
-      "name": "ViewChart",
-      "displayName": "View Chart",
-      "contexts": [
-        "fdc3.instrument"
-      ]
-    }
-  ],
-  "type": "browser",
+  "publisher": "FDC3,",
+  "type": "web",
   "details": {
     "url": "https://fdc3.finos.org/toolbox/fdc3-workbench/"
   },
@@ -81,5 +77,11 @@
       }
     },
     "Web App Manifest": "https://example.com/fdc3-workbench.json"
+  },
+  "localizedVersions": {
+    "fr-FR": {
+      "title": "FDC3 Table de travail",
+      "description": "Outil de développement et de test pour les desktop agents et applications FDC3"
+    }
   }
 }

--- a/src/app-directory/specification/examples/application/myApplication.json
+++ b/src/app-directory/specification/examples/application/myApplication.json
@@ -1,0 +1,145 @@
+{
+	"appId": "my-application",
+	"name": "my-application",
+	"title": "My Application",
+	"description": "An example application that uses FDC3 and fully describes itself in an AppD record.",
+	"categories": [
+	  "market data",
+	  "research",
+	  "news"
+	],
+	"version": "1.0.0",
+	"tooltip": "My example application definition",
+	"lang": "en-US",
+	"icons": [
+	  {
+		"src": "http://example.domain.com/assets/my-app-icon.png",
+		"size": "256x256",
+		"type": "image/png"
+	  }
+	],
+	"screenshots": [
+	  {
+		"src": "http://example.domain.com/assets/my-app-screenshot-1.png",
+		"label": "The first screenshot of my example app",
+		"type": "image/png",
+		"size": "800x600"
+	  },
+	  {
+		"src": "http://example.domain.com/assets/my-app-screenshot-2.png",
+		"label": "The second screenshot of my example app",
+		"type": "image/png",
+		"size": "800x600"
+	  }
+	],
+	"contactEmail": "fdc3@finos.org",
+	"supportEmail": "fdc3-maintainers@finos.org",
+	"moreInfo": "http://example.domain.com/",
+	"publisher": "Example App, Inc.",
+	"type": "web",
+	"details": {
+	  "url": "http://example.domain.com/app.html"
+	},
+	"hostManifests": {
+	  "Finsemble": {
+		"window": {
+		  "left": 120,
+		  "top": 120,
+		  "width": 600,
+		  "height": 800,
+		  "options": {
+			"minWidth": 75
+		  }
+		},
+		"foreign": {
+		  "components": {
+			"App Launcher": {
+			  "launchableByUser": true
+			},
+			"Window Manager": {
+			  "FSBLHeader": true,
+			  "persistWindowState": true
+			}
+		  }
+		},
+		"interop": {
+		  "autoConnect": true
+		}
+	  },
+	  "Glue42": {
+		"type": "window",
+		"details": {
+		  "height": 800,
+		  "width": 600,
+		  "left": 120,
+		  "top": 120,
+		  "mode": "tab",
+		  "allowChannels": true,
+		  "loader": {
+			"enabled": true,
+			"hideOnLoad": true
+		  }
+		},
+		"customProperties": {
+		  "folder": "FDC3 Toolbox"
+		}
+	  },
+	  "Web App Manifest": "http://example.domain.com/my-app.json"
+	},
+	"interop": {
+	  "intents": {
+		"listensFor": {
+		  "ViewChart": {
+			"displayName": "View Chart",
+			"contexts": [
+			  "fdc3.instrument"
+			]
+		  },
+		  "myApp.GetPrice": {
+			"displayName": "Get Price",
+			"contexts": [
+			  "fdc3.instrument"
+			],
+			"resultType": "myApp.quote"
+		  }
+		},
+		"raises": {
+		  "ViewOrders": [
+			"fdc3.instrument",
+			"fdc3.organization"
+		  ],
+		  "StartEmail": [
+			"fdc3.email"
+		  ]
+		}
+	  },
+	  "userChannels": {
+		"broadcasts": [
+		  "fdc3.instrument",
+		  "fdc3.organization"
+		],
+		"listensFor": [
+		  "fdc3.instrument",
+		  "fdc3.organization"
+		]
+	  },
+	  "appChannels": [
+		{
+		  "id": "myApp.quotes,",
+		  "description": "Used to share a stream of quotes for currently displayed instrument and may be used to change the currently displayed symbol,",
+		  "broadcasts": [
+			"myApp.quote"
+		  ],
+		  "listensFor": [
+			"fdc3.instrument"
+		  ]
+		}
+	  ]
+	},
+	"localizedVersions": {
+	  "fr-FR": {
+		"title": "Mon application,",
+		"description": "Un exemple d'application qui utilise FDC3 et se décrit entièrement dans un enregistrement AppD."
+	  }
+	}
+  }

--- a/src/app-directory/specification/test/index.js
+++ b/src/app-directory/specification/test/index.js
@@ -1,7 +1,8 @@
 const SwaggerParser = require('@apidevtools/swagger-parser');
 const { Validator } = require('jsonschema');
 const assert = require('assert');
-const exampleApplication = require('../examples/application/fdc3-workbench.json');
+const exampleApplication1 = require('../examples/application/myApplication.json');
+const exampleApplication2 = require('../examples/application/fdc3-workbench.json');
 
 (async () => {
   try {
@@ -11,16 +12,30 @@ const exampleApplication = require('../examples/application/fdc3-workbench.json'
 
     const applicationSchema = api.components.schemas.Application;
 
+    console.log("Setting up the validator...");
     const v = new Validator();
 
-    const validatorResult = v.validate(exampleApplication, applicationSchema);
+
+    console.log("\nValidating the first example: myApplication.json");
+    const validatorResult1 = v.validate(exampleApplication1, applicationSchema);
 
     assert(
-      validatorResult.valid,
-      `The example application definition does not comply with the Application schema: ${validatorResult.errors}`
+      validatorResult1.valid,
+      `The example application definition does not comply with the Application schema: ${validatorResult1.errors}`
     );
 
-    console.log('Successfully validated the specification and the example application definition!');
+    console.log('Successfully validated the specification and the first example application definition!');
+
+    console.log("\nValidating the second example: fdc3-workbench.json");
+    const validatorResult2 = v.validate(exampleApplication2, applicationSchema);
+
+    assert(
+      validatorResult2.valid,
+      `The example application definition does not comply with the Application schema: ${validatorResult2.errors}`
+    );
+
+    console.log('Successfully validated the specification and the second example application definition!');
+
   } catch (error) {
     console.log(error.message || error);
   }

--- a/src/app-directory/specification/test/package-lock.json
+++ b/src/app-directory/specification/test/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apidevtools/swagger-parser": "^10.0.2",
+        "@apidevtools/swagger-parser": "^10.0.3",
         "jsonschema": "^1.4.0"
       },
       "engines": {
@@ -17,14 +17,13 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^3.13.1"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -41,16 +40,17 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+      "integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "9.0.6",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.1"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -61,37 +61,80 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
     },
     "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "node_modules/call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/jsonschema": {
       "version": "1.4.0",
@@ -101,60 +144,51 @@
         "node": "*"
       }
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
     "node_modules/openapi-types": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-9.1.0.tgz",
       "integrity": "sha512-mhXh8QN8sbErlxfxBeZ/pzgvmDn443p8CXlxwGSi2bWANZAFvjLPI0PoGjqHW+JdBbXg6uvmvM81WXaweh/SVA==",
       "peer": true
     },
-    "node_modules/validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=6"
       }
     },
-    "node_modules/z-schema": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
-      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
-      "dependencies": {
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.6.0"
-      },
-      "bin": {
-        "z-schema": "bin/z-schema"
-      },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
-        "node": ">=6.0.0"
-      },
-      "optionalDependencies": {
-        "commander": "^2.7.1"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     }
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
+      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
         "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^3.13.1"
       }
     },
     "@apidevtools/openapi-schemas": {
@@ -168,16 +202,17 @@
       "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
     },
     "@apidevtools/swagger-parser": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
-      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.0.tgz",
+      "integrity": "sha512-9Kt7EuS/7WbMAUv2gSziqjvxwDbFSg3Xeyfuj5laUODX8o/k/CpsAKiQ8W7/R88eXFTMbJYg6+7uAmOWNKmwnw==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/json-schema-ref-parser": "9.0.6",
+        "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "z-schema": "^4.2.3"
+        "ajv": "^8.6.3",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.1"
       }
     },
     "@jsdevtools/ono": {
@@ -185,49 +220,64 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
-    "@types/json-schema": {
-      "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg=="
+    "ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "requires": {}
     },
     "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "jsonschema": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
       "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "openapi-types": {
       "version": "9.1.0",
@@ -235,20 +285,27 @@
       "integrity": "sha512-mhXh8QN8sbErlxfxBeZ/pzgvmDn443p8CXlxwGSi2bWANZAFvjLPI0PoGjqHW+JdBbXg6uvmvM81WXaweh/SVA==",
       "peer": true
     },
-    "validator": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
-      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
-    "z-schema": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
-      "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.4.2",
-        "lodash.isequal": "^4.5.0",
-        "validator": "^13.6.0"
+        "punycode": "^2.1.0"
       }
     }
   }

--- a/src/app-directory/specification/test/package.json
+++ b/src/app-directory/specification/test/package.json
@@ -23,7 +23,7 @@
     "test": "node index.js"
   },
   "dependencies": {
-    "@apidevtools/swagger-parser": "^10.0.2",
+    "@apidevtools/swagger-parser": "^10.0.3",
     "jsonschema": "^1.4.0"
   }
 }

--- a/website/static/schemas/2.0/app-directory.yaml
+++ b/website/static/schemas/2.0/app-directory.yaml
@@ -520,7 +520,7 @@ components:
         The type specific launch details of the application. These details are intended to be 
         vendor-agnostic and MAY be duplicated or overridden by details provided in the hostManifests 
         object for a specific host.
-      oneOf:
+      anyOf:
         - $ref: '#/components/schemas/WebAppDetails'
         - $ref: '#/components/schemas/NativeAppDetails'
         - $ref: '#/components/schemas/CitrixAppDetails'
@@ -1187,10 +1187,10 @@ components:
             icons:
               - src: http://fdc3.finos.org/toolbox/fdc3-workbench/fdc3-icon-256.png
             screenshots:
-              - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png,
+              - src: https://fdc3.finos.org/docs/assets/fdc3-logo.png
                 label: FDC3 logo
-            contactEmail: fdc3@finos.org,
-            supportEmail: fdc3-maintainers@finos.org,
+            contactEmail: fdc3@finos.org
+            supportEmail: fdc3-maintainers@finos.org
             publisher: FDC3,
             type: web
             details:


### PR DESCRIPTION
resolves #1033 

- the details field of the appD schema is using `oneOf` to combine subschemas
  - However, this requires them to be distinct and non-overlapping, they are not (both web and online native have a `url` property). 
  - `anyOf` should be used in this situation instead as `oneOf` returns validation errors when the element conforms to multiple subschemas.
- commas were removed from email fields in the fdc3-workbench example as these fail validation (just a syntax error in the YAML file)
- The test was improved by adding multiple examples and providing better console output from it.