### PR TITLE
Adjusting package.json to roll docusaurus version numbers

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -29,9 +29,9 @@
     "replace-in-files-cli": "2.0.0",
     "replace-json-property": "1.8.0",
     "rimraf": "5.0.0",
-    "@docusaurus/core": "^2.4.0",
-    "@docusaurus/preset-classic": "^2.4.0",
-    "@docusaurus/theme-mermaid": "^2.4.0",
+    "@docusaurus/core": "~2.4.1",
+    "@docusaurus/preset-classic": "~2.4.1",
+    "@docusaurus/theme-mermaid": "~2.4.1",
     "clsx": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
The package-lock.json file is gitignored so dependencies are being re-resolved on build. This is causing issues as, for some reason, the them-mermaid resolved to a later version that docusaurus, causing the website to crash on pages with mermaid diagrams.

From the last production deployment:
![image](https://github.com/finos/FDC3/assets/1701764/b665cec3-9a53-4633-96c0-b874dc84eab3)

which causes (I believe):
![image](https://github.com/finos/FDC3/assets/1701764/87030d62-8ba0-4317-94aa-59908f26e1c8)
