### PR TITLE
Correcting an error in privateChannel bridging schemas vs. documentation

### DIFF
--- a/docs/agent-bridging/ref/PrivateChannel.broadcast.md
+++ b/docs/agent-bridging/ref/PrivateChannel.broadcast.md
@@ -69,7 +69,7 @@ Hence, the broadcast message should be repeated once for each subscriber, and mo
 {
     "type": "PrivateChannel.broadcast", //modified type for PrivateChannel broadcasts
     "payload": {
-        "channel": "private-channel-ABC123",
+        "channelId": "private-channel-ABC123",
         "context": { /*contextObj*/}
     },
     "meta": {

--- a/docs/agent-bridging/ref/PrivateChannel.eventListenerAdded.md
+++ b/docs/agent-bridging/ref/PrivateChannel.eventListenerAdded.md
@@ -50,7 +50,7 @@ sequenceDiagram
 {
     "type": "PrivateChannel.eventListenerAdded",
     "payload": {
-        "channel": "private-channel-ABC123",
+        "channelId": "private-channel-ABC123",
         "listenerType": "onAddContextListener"
     },
     "meta": {

--- a/docs/agent-bridging/ref/PrivateChannel.eventListenerRemoved.md
+++ b/docs/agent-bridging/ref/PrivateChannel.eventListenerRemoved.md
@@ -53,7 +53,7 @@ sequenceDiagram
 {
     "type": "PrivateChannel.eventListenerRemoved",
     "payload": {
-        "channel": "private-channel-ABC123",
+        "channelId": "private-channel-ABC123",
         "listenerType": "onAddContextListener"
     },
     "meta": {

--- a/docs/agent-bridging/ref/PrivateChannel.onAddContextListener.md
+++ b/docs/agent-bridging/ref/PrivateChannel.onAddContextListener.md
@@ -48,7 +48,7 @@ sequenceDiagram
 {
     "type": "PrivateChannel.onAddContextListener",
     "payload": {
-        "channel": "private-channel-ABC123",
+        "channelId": "private-channel-ABC123",
         "contextType": "fdc3.instrument"
     },
     "meta": {

--- a/docs/agent-bridging/ref/PrivateChannel.onDisconnect.md
+++ b/docs/agent-bridging/ref/PrivateChannel.onDisconnect.md
@@ -48,7 +48,7 @@ sequenceDiagram
 {
     "type": "PrivateChannel.onDisconnect",
     "payload": {
-        "channel": "private-channel-ABC123"
+        "channelId": "private-channel-ABC123"
     },
     "meta": {
         "requestUuid": "<requestUuid>",

--- a/docs/agent-bridging/ref/PrivateChannel.onUnsubscribe.md
+++ b/docs/agent-bridging/ref/PrivateChannel.onUnsubscribe.md
@@ -51,7 +51,7 @@ sequenceDiagram
 {
     "type": "PrivateChannel.onUnsubscribe",
     "payload": {
-        "channel": "private-channel-ABC123",
+        "channelId": "private-channel-ABC123",
         "contextType": "fdc3.instrument"
     },
     "meta": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/schemas/bridging/broadcastAgentRequest.schema.json
+++ b/schemas/bridging/broadcastAgentRequest.schema.json
@@ -28,7 +28,7 @@
             "channelId": {
               "type": "string",
               "title": "Channel Id",
-              "description": "The Id of the PrivateChannel that the broadcast was sent on"
+              "description": "The Id of the Channel that the broadcast was sent on"
             },
             "context": {
               "$ref": "../context/context.schema.json",

--- a/schemas/bridging/common.schema.json
+++ b/schemas/bridging/common.schema.json
@@ -110,6 +110,15 @@
         "$ref": "#/$defs/ErrorMessages"
       },
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
+    },
+    "PrivateChannelEventListenerTypes": {
+      "title": "",
+      "type": "string",
+      "enum": [
+        "onAddContextListener",
+        "onUnsubscribe",
+        "onDisconnect"
+      ]
     }
   }
 }

--- a/schemas/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelBroadcast Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string",
               "title": "Channel Id",
               "description": "The Id of the PrivateChannel that the broadcast was sent on"
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channelId", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",

--- a/schemas/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channelId", "context"]
+          "required": ["channel", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",

--- a/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -28,12 +28,12 @@
             "channel": {
               "type": "string"
             },
-            "context": {
-              "type": "string"
+            "listenerType": {
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channel", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerAdded Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerRemoved Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerRemoved Request Metadata",

--- a/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -29,7 +29,7 @@
               "type": "string"
             },
             "listenerType": {
-              "type": "string"
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,

--- a/schemas/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnAddContextListener Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnAddContextListener Request Metadata",

--- a/schemas/bridging/privateChannelOnDisconnectAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnDisconnectAgentRequest.schema.json
@@ -25,12 +25,12 @@
           "title": "PrivateChannelOnDisconnect Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             }
           },
           "additionalProperties": false,
-          "required": ["channel"]
+          "required": ["channelId"]
         },
         "meta": {
           "title": "PrivateChannelOnDisconnect Request Metadata",

--- a/schemas/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnUnsubscribe Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnUnsubscribe Request Metadata",

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -637,7 +637,7 @@ export interface SourceObject {
  */
 export interface BroadcastAgentRequestPayload {
   /**
-   * The Id of the PrivateChannel that the broadcast was sent on
+   * The Id of the Channel that the broadcast was sent on
    */
   channelId: string;
   /**
@@ -808,7 +808,7 @@ export interface MetaSource {
  */
 export interface BroadcastBridgeRequestPayload {
   /**
-   * The Id of the PrivateChannel that the broadcast was sent on
+   * The Id of the Channel that the broadcast was sent on
    */
   channelId: string;
   /**
@@ -2885,7 +2885,7 @@ export interface PrivateChannelBroadcastAgentRequestPayload {
   /**
    * The Id of the PrivateChannel that the broadcast was sent on
    */
-  channel: string;
+  channelId: string;
   /**
    * The context object that was the payload of a broadcast message.
    */
@@ -2937,7 +2937,7 @@ export interface PrivateChannelBroadcastBridgeRequestPayload {
   /**
    * The Id of the PrivateChannel that the broadcast was sent on
    */
-  channel: string;
+  channelId: string;
   /**
    * The context object that was the payload of a broadcast message.
    */
@@ -2985,7 +2985,7 @@ export interface PrivateChannelEventListenerAddedAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerAddedAgentRequestPayload {
-  channel: string;
+  channelId: string;
   listenerType: Empty;
 }
 
@@ -3037,7 +3037,7 @@ export interface PrivateChannelEventListenerAddedBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerAddedBridgeRequestPayload {
-  channel: string;
+  channelId: string;
   listenerType: Empty;
 }
 
@@ -3082,7 +3082,7 @@ export interface PrivateChannelEventListenerRemovedAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
-  channel: string;
+  channelId: string;
   listenerType: Empty;
 }
 
@@ -3128,7 +3128,7 @@ export interface PrivateChannelEventListenerRemovedBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerRemovedBridgeRequestPayload {
-  channel: string;
+  channelId: string;
   listenerType: Empty;
 }
 
@@ -3173,7 +3173,7 @@ export interface PrivateChannelOnAddContextListenerAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnAddContextListenerAgentRequestPayload {
-  channel: string;
+  channelId: string;
   contextType: string;
 }
 
@@ -3219,7 +3219,7 @@ export interface PrivateChannelOnAddContextListenerBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnAddContextListenerBridgeRequestPayload {
-  channel: string;
+  channelId: string;
   contextType: string;
 }
 
@@ -3264,7 +3264,7 @@ export interface PrivateChannelOnDisconnectAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnDisconnectAgentRequestPayload {
-  channel: string;
+  channelId: string;
 }
 
 /**
@@ -3309,7 +3309,7 @@ export interface PrivateChannelOnDisconnectBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnDisconnectBridgeRequestPayload {
-  channel: string;
+  channelId: string;
 }
 
 /**
@@ -3353,7 +3353,7 @@ export interface PrivateChannelOnUnsubscribeAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnUnsubscribeAgentRequestPayload {
-  channel: string;
+  channelId: string;
   contextType: string;
 }
 
@@ -3399,7 +3399,7 @@ export interface ERequestMetadata {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnUnsubscribeBridgeRequestPayload {
-  channel: string;
+  channelId: string;
   contextType: string;
 }
 
@@ -5745,7 +5745,7 @@ const typeMap: any = {
   ),
   PrivateChannelBroadcastAgentRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
@@ -5769,7 +5769,7 @@ const typeMap: any = {
   ),
   PrivateChannelBroadcastBridgeRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
@@ -5793,7 +5793,7 @@ const typeMap: any = {
   ),
   PrivateChannelEventListenerAddedAgentRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
@@ -5817,7 +5817,7 @@ const typeMap: any = {
   ),
   PrivateChannelEventListenerAddedBridgeRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
@@ -5841,7 +5841,7 @@ const typeMap: any = {
   ),
   PrivateChannelEventListenerRemovedAgentRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
@@ -5865,7 +5865,7 @@ const typeMap: any = {
   ),
   PrivateChannelEventListenerRemovedBridgeRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
@@ -5889,7 +5889,7 @@ const typeMap: any = {
   ),
   PrivateChannelOnAddContextListenerAgentRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'contextType', js: 'contextType', typ: '' },
     ],
     false
@@ -5913,7 +5913,7 @@ const typeMap: any = {
   ),
   PrivateChannelOnAddContextListenerBridgeRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'contextType', js: 'contextType', typ: '' },
     ],
     false
@@ -5935,7 +5935,7 @@ const typeMap: any = {
     ],
     false
   ),
-  PrivateChannelOnDisconnectAgentRequestPayload: o([{ json: 'channel', js: 'channel', typ: '' }], false),
+  PrivateChannelOnDisconnectAgentRequestPayload: o([{ json: 'channelId', js: 'channelId', typ: '' }], false),
   PrivateChannelOnDisconnectBridgeRequest: o(
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnDisconnectBridgeRequestMeta') },
@@ -5953,7 +5953,7 @@ const typeMap: any = {
     ],
     false
   ),
-  PrivateChannelOnDisconnectBridgeRequestPayload: o([{ json: 'channel', js: 'channel', typ: '' }], false),
+  PrivateChannelOnDisconnectBridgeRequestPayload: o([{ json: 'channelId', js: 'channelId', typ: '' }], false),
   PrivateChannelOnUnsubscribeAgentRequest: o(
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnUnsubscribeAgentRequestMeta') },
@@ -5973,7 +5973,7 @@ const typeMap: any = {
   ),
   PrivateChannelOnUnsubscribeAgentRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'contextType', js: 'contextType', typ: '' },
     ],
     false
@@ -5997,7 +5997,7 @@ const typeMap: any = {
   ),
   PrivateChannelOnUnsubscribeBridgeRequestPayload: o(
     [
-      { json: 'channel', js: 'channel', typ: '' },
+      { json: 'channelId', js: 'channelId', typ: '' },
       { json: 'contextType', js: 'contextType', typ: '' },
     ],
     false

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -2885,7 +2885,7 @@ export interface PrivateChannelBroadcastAgentRequestPayload {
   /**
    * The Id of the PrivateChannel that the broadcast was sent on
    */
-  channelId: string;
+  channel: string;
   /**
    * The context object that was the payload of a broadcast message.
    */
@@ -2937,7 +2937,7 @@ export interface PrivateChannelBroadcastBridgeRequestPayload {
   /**
    * The Id of the PrivateChannel that the broadcast was sent on
    */
-  channelId: string;
+  channel: string;
   /**
    * The context object that was the payload of a broadcast message.
    */
@@ -2986,7 +2986,13 @@ export interface PrivateChannelEventListenerAddedAgentRequestMeta {
  */
 export interface PrivateChannelEventListenerAddedAgentRequestPayload {
   channel: string;
-  context: string;
+  listenerType: Empty;
+}
+
+export enum Empty {
+  OnAddContextListener = 'onAddContextListener',
+  OnDisconnect = 'onDisconnect',
+  OnUnsubscribe = 'onUnsubscribe',
 }
 
 /**
@@ -3032,7 +3038,7 @@ export interface PrivateChannelEventListenerAddedBridgeRequestMeta {
  */
 export interface PrivateChannelEventListenerAddedBridgeRequestPayload {
   channel: string;
-  context: string;
+  listenerType: Empty;
 }
 
 /**
@@ -3077,7 +3083,7 @@ export interface PrivateChannelEventListenerRemovedAgentRequestMeta {
  */
 export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
   channel: string;
-  listenerType: string;
+  listenerType: Empty;
 }
 
 /**
@@ -3123,7 +3129,7 @@ export interface PrivateChannelEventListenerRemovedBridgeRequestMeta {
  */
 export interface PrivateChannelEventListenerRemovedBridgeRequestPayload {
   channel: string;
-  listenerType: string;
+  listenerType: Empty;
 }
 
 /**
@@ -5739,7 +5745,7 @@ const typeMap: any = {
   ),
   PrivateChannelBroadcastAgentRequestPayload: o(
     [
-      { json: 'channelId', js: 'channelId', typ: '' },
+      { json: 'channel', js: 'channel', typ: '' },
       { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
@@ -5763,7 +5769,7 @@ const typeMap: any = {
   ),
   PrivateChannelBroadcastBridgeRequestPayload: o(
     [
-      { json: 'channelId', js: 'channelId', typ: '' },
+      { json: 'channel', js: 'channel', typ: '' },
       { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
@@ -5788,7 +5794,7 @@ const typeMap: any = {
   PrivateChannelEventListenerAddedAgentRequestPayload: o(
     [
       { json: 'channel', js: 'channel', typ: '' },
-      { json: 'context', js: 'context', typ: '' },
+      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
   ),
@@ -5812,7 +5818,7 @@ const typeMap: any = {
   PrivateChannelEventListenerAddedBridgeRequestPayload: o(
     [
       { json: 'channel', js: 'channel', typ: '' },
-      { json: 'context', js: 'context', typ: '' },
+      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
   ),
@@ -5836,7 +5842,7 @@ const typeMap: any = {
   PrivateChannelEventListenerRemovedAgentRequestPayload: o(
     [
       { json: 'channel', js: 'channel', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: '' },
+      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
   ),
@@ -5860,7 +5866,7 @@ const typeMap: any = {
   PrivateChannelEventListenerRemovedBridgeRequestPayload: o(
     [
       { json: 'channel', js: 'channel', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: '' },
+      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
     ],
     false
   ),
@@ -6323,6 +6329,7 @@ const typeMap: any = {
     'ResolverUnavailable',
     'ResponseToBridgeTimedOut',
   ],
+  Empty: ['onAddContextListener', 'onDisconnect', 'onUnsubscribe'],
   RaiseIntentResultErrorMessage: [
     'AgentDisconnected',
     'IntentHandlerRejected',

--- a/website/static/schemas/2.1/bridging/broadcastAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/broadcastAgentRequest.schema.json
@@ -28,7 +28,7 @@
             "channelId": {
               "type": "string",
               "title": "Channel Id",
-              "description": "The Id of the PrivateChannel that the broadcast was sent on"
+              "description": "The Id of the Channel that the broadcast was sent on"
             },
             "context": {
               "$ref": "../context/context.schema.json",

--- a/website/static/schemas/2.1/bridging/common.schema.json
+++ b/website/static/schemas/2.1/bridging/common.schema.json
@@ -110,6 +110,15 @@
         "$ref": "#/$defs/ErrorMessages"
       },
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
+    },
+    "PrivateChannelEventListenerTypes": {
+      "title": "",
+      "type": "string",
+      "enum": [
+        "onAddContextListener",
+        "onUnsubscribe",
+        "onDisconnect"
+      ]
     }
   }
 }

--- a/website/static/schemas/2.1/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channelId", "context"]
+          "required": ["channel", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",
@@ -59,3 +59,4 @@
     }
   }
 }
+

--- a/website/static/schemas/2.1/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channelId", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -28,12 +28,12 @@
             "channel": {
               "type": "string"
             },
-            "context": {
-              "type": "string"
+            "listenerType": {
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channel", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerAdded Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerRemoved Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerRemoved Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -29,7 +29,7 @@
               "type": "string"
             },
             "listenerType": {
-              "type": "string"
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,

--- a/website/static/schemas/2.1/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnAddContextListener Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnAddContextListener Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelOnDisconnectAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelOnDisconnectAgentRequest.schema.json
@@ -25,12 +25,12 @@
           "title": "PrivateChannelOnDisconnect Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             }
           },
           "additionalProperties": false,
-          "required": ["channel"]
+          "required": ["channelId"]
         },
         "meta": {
           "title": "PrivateChannelOnDisconnect Request Metadata",

--- a/website/static/schemas/2.1/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnUnsubscribe Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnUnsubscribe Request Metadata",

--- a/website/static/schemas/next/bridging/broadcastAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/broadcastAgentRequest.schema.json
@@ -28,7 +28,7 @@
             "channelId": {
               "type": "string",
               "title": "Channel Id",
-              "description": "The Id of the PrivateChannel that the broadcast was sent on"
+              "description": "The Id of the Channel that the broadcast was sent on"
             },
             "context": {
               "$ref": "../context/context.schema.json",

--- a/website/static/schemas/next/bridging/common.schema.json
+++ b/website/static/schemas/next/bridging/common.schema.json
@@ -110,6 +110,15 @@
         "$ref": "#/$defs/ErrorMessages"
       },
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
+    },
+    "PrivateChannelEventListenerTypes": {
+      "title": "",
+      "type": "string",
+      "enum": [
+        "onAddContextListener",
+        "onUnsubscribe",
+        "onDisconnect"
+      ]
     }
   }
 }

--- a/website/static/schemas/next/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelBroadcast Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string",
               "title": "Channel Id",
               "description": "The Id of the PrivateChannel that the broadcast was sent on"
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channelId", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelBroadcastAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelBroadcastAgentRequest.schema.json
@@ -37,7 +37,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channelId", "context"]
+          "required": ["channel", "context"]
         },
         "meta": {
           "title": "PrivateChannelBroadcast Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -28,12 +28,12 @@
             "channel": {
               "type": "string"
             },
-            "context": {
-              "type": "string"
+            "listenerType": {
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "context"]
+          "required": ["channel", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerAdded Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerAdded Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelEventListenerRemoved Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "listenerType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "listenerType"]
+          "required": ["channelId", "listenerType"]
         },
         "meta": {
           "title": "PrivateChannelEventListenerRemoved Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -29,7 +29,7 @@
               "type": "string"
             },
             "listenerType": {
-              "type": "string"
+              "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
             }
           },
           "additionalProperties": false,

--- a/website/static/schemas/next/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnAddContextListener Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnAddContextListener Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelOnDisconnectAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelOnDisconnectAgentRequest.schema.json
@@ -25,12 +25,12 @@
           "title": "PrivateChannelOnDisconnect Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             }
           },
           "additionalProperties": false,
-          "required": ["channel"]
+          "required": ["channelId"]
         },
         "meta": {
           "title": "PrivateChannelOnDisconnect Request Metadata",

--- a/website/static/schemas/next/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
+++ b/website/static/schemas/next/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
@@ -25,7 +25,7 @@
           "title": "PrivateChannelOnUnsubscribe Request Payload",
           "type": "object",
           "properties": {
-            "channel": {
+            "channelId": {
               "type": "string"
             },
             "contextType": {
@@ -33,7 +33,7 @@
             }
           },
           "additionalProperties": false,
-          "required": ["channel", "contextType"]
+          "required": ["channelId", "contextType"]
         },
         "meta": {
           "title": "PrivateChannelOnUnsubscribe Request Metadata",


### PR DESCRIPTION
We spotted a couple of copy/paste errors in the private channel bridging schemas that did not agree with the documentation, and one docs typo which is fixed in this PR.