### PR TITLE
Upgrade quicktype and correct a schema error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.0.3",
+  "version": "2.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/fdc3",
-      "version": "2.0.3",
+      "version": "2.1.0-beta.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "husky": "^4.3.0",
         "jest-mock-extended": "^1.0.13",
-        "quicktype": "^23.0.49",
+        "quicktype": "23.0.75",
         "tsdx": "^0.14.1",
         "tslib": "^2.0.1",
         "typescript": "^4.0.3"
@@ -2186,9 +2186,9 @@
       }
     },
     "node_modules/@mark.probst/typescript-json-schema/node_modules/@types/node": {
-      "version": "16.18.38",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.38.tgz",
-      "integrity": "sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==",
+      "version": "16.18.54",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.54.tgz",
+      "integrity": "sha512-oTmGy68gxZZ21FhTJVVvZBYpQHEBZxHKTsGshobMqm9qWpbqdZsA5jvsuPZcHu0KwpmLrOHWPdEfg7XDpNT9UA==",
       "dev": true
     },
     "node_modules/@mark.probst/typescript-json-schema/node_modules/cliui": {
@@ -2550,9 +2550,9 @@
       "dev": true
     },
     "node_modules/@types/urijs": {
-      "version": "1.19.19",
-      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.19.tgz",
-      "integrity": "sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==",
+      "version": "1.19.20",
+      "resolved": "https://registry.npmjs.org/@types/urijs/-/urijs-1.19.20.tgz",
+      "integrity": "sha512-77Mq/2BeHU894J364dUv9tSwxxyCLtcX228Pc8TwZpP5bvOoMns+gZoftp3LYl3FBH8vChpWbuagKGiMki2c1A==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -4087,9 +4087,9 @@
       "dev": true
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
@@ -8489,9 +8489,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -9473,9 +9473,9 @@
       }
     },
     "node_modules/quicktype": {
-      "version": "23.0.49",
-      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-23.0.49.tgz",
-      "integrity": "sha512-SWF3MRBiW1JuIhQPFwN8cY6xHo6SogEF/9Y6m6XNunqaJrT7Lbp9gERpNR5wrkMyJb0KYYDOLo49HXWzi4jGCA==",
+      "version": "23.0.75",
+      "resolved": "https://registry.npmjs.org/quicktype/-/quicktype-23.0.75.tgz",
+      "integrity": "sha512-5afrJWTiVJjvkOD7MP7QaErCw9k0pgyijmYakSeRykkGhfn1KOSE6FTh2+eOLhn3rVCofT1h9/FADnPhV/qcog==",
       "dev": true,
       "dependencies": {
         "@glideapps/ts-necessities": "^2.1.3",
@@ -9483,15 +9483,15 @@
         "collection-utils": "^1.0.1",
         "command-line-args": "^5.2.1",
         "command-line-usage": "^7.0.1",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "graphql": "^0.11.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
-        "quicktype-core": "23.0.49",
-        "quicktype-graphql-input": "23.0.49",
-        "quicktype-typescript-input": "23.0.49",
-        "readable-stream": "^4.3.0",
-        "stream-json": "1.7.5",
+        "quicktype-core": "23.0.75",
+        "quicktype-graphql-input": "23.0.75",
+        "quicktype-typescript-input": "23.0.75",
+        "readable-stream": "^4.4.2",
+        "stream-json": "1.8.0",
         "string-to-stream": "^3.0.1",
         "typescript": "4.9.5"
       },
@@ -9503,71 +9503,56 @@
       }
     },
     "node_modules/quicktype-core": {
-      "version": "23.0.49",
-      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.49.tgz",
-      "integrity": "sha512-lzPhHqqrqCvelt1+Hb/vsxyQtnv4nObcRCAItB3kOVQGYBYIfS8DQMG2t8FfC/fLW5o8xkhl6PF7CdHcejsFmg==",
+      "version": "23.0.75",
+      "resolved": "https://registry.npmjs.org/quicktype-core/-/quicktype-core-23.0.75.tgz",
+      "integrity": "sha512-aVXb5MpCdWCyrWUqw906+dBU7C3wFWwSax1ySu/0wk4QNGnpg1DPJDDUdOXXMNKmLlAeA9+3Cs1kPHWNXxovBQ==",
       "dev": true,
       "dependencies": {
         "@glideapps/ts-necessities": "2.1.3",
         "@types/urijs": "^1.19.19",
         "browser-or-node": "^2.1.1",
         "collection-utils": "^1.0.1",
-        "cross-fetch": "^3.1.5",
+        "cross-fetch": "^4.0.0",
         "is-url": "^1.2.4",
         "js-base64": "^3.7.5",
         "lodash": "^4.17.21",
         "pako": "^1.0.6",
         "pluralize": "^8.0.0",
-        "readable-stream": "4.3.0",
+        "readable-stream": "4.4.2",
         "unicode-properties": "^1.4.1",
         "urijs": "^1.19.1",
         "wordwrap": "^1.0.0",
-        "yaml": "^2.2.2"
-      }
-    },
-    "node_modules/quicktype-core/node_modules/readable-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
-      "dev": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "yaml": "^2.3.1"
       }
     },
     "node_modules/quicktype-core/node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/quicktype-graphql-input": {
-      "version": "23.0.49",
-      "resolved": "https://registry.npmjs.org/quicktype-graphql-input/-/quicktype-graphql-input-23.0.49.tgz",
-      "integrity": "sha512-3KtF6wOV8K7SSl1v5LG/CzgxzUNuslpibtKtzfUFiMwxfdQiG9vDhsiewdkoetCB+13HOiNCKysXfSgELPPMzg==",
+      "version": "23.0.75",
+      "resolved": "https://registry.npmjs.org/quicktype-graphql-input/-/quicktype-graphql-input-23.0.75.tgz",
+      "integrity": "sha512-dSLNFXRSiaQbvCduSWSpr+q5F/hUbo+SODqI3mFLy5lkcJgTJq0sIWAxYbX4n43AJscyMqy7KTuLMe9D8tJrsA==",
       "dev": true,
       "dependencies": {
         "collection-utils": "^1.0.1",
         "graphql": "^0.11.7",
-        "quicktype-core": "23.0.49"
+        "quicktype-core": "23.0.75"
       }
     },
     "node_modules/quicktype-typescript-input": {
-      "version": "23.0.49",
-      "resolved": "https://registry.npmjs.org/quicktype-typescript-input/-/quicktype-typescript-input-23.0.49.tgz",
-      "integrity": "sha512-/hSUpeharpOxhls+S7KBKw0d9ig8Pm662OZ5a20eROtUl/qS5s/hSshxt+pW+R3RjD5fZw2SiyaWDY5L+LgfVQ==",
+      "version": "23.0.75",
+      "resolved": "https://registry.npmjs.org/quicktype-typescript-input/-/quicktype-typescript-input-23.0.75.tgz",
+      "integrity": "sha512-XNgIP+XU0ardG4nelrn7FfXGkpcv77JOYpMAr9IfDX5mH/fUNYUaBEMytN+Vb2VCPbKjmsnDt6OxLd4trEJ7ow==",
       "dev": true,
       "dependencies": {
         "@mark.probst/typescript-json-schema": "0.55.0",
-        "quicktype-core": "23.0.49",
+        "quicktype-core": "23.0.75",
         "typescript": "4.9.5"
       }
     },
@@ -11283,9 +11268,9 @@
       "dev": true
     },
     "node_modules/stream-json": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.7.5.tgz",
-      "integrity": "sha512-NSkoVduGakxZ8a+pTPUlcGEeAGQpWL9rKJhOFCV+J/QtdQUEU5vtBgVg6eJXn8JB8RZvpbJWZGvXkhz70MLWoA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.8.0.tgz",
+      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
       "dev": true,
       "dependencies": {
         "stream-chain": "^2.2.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "preprepare": "npm run typegen && npm run typegen-bridging",
     "prepare": "tsdx build",
     "typegen": "node s2tQuicktypeUtil.js schemas/context src/context/ContextTypes.ts && tsdx lint src/context/ --fix",
-    "typegen-bridging": "node s2tQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingTypes.ts && tsdx lint src/bridging/ --fix"
+    "typegen-bridging": "node s2tQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingTypes.ts && tsdx lint src/bridging/ --fix",
+    "typegen-bridging-zod": "node s2zodQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingZodSchemas.ts"
   },
   "peerDependencies": {},
   "husky": {
@@ -48,7 +49,7 @@
   "devDependencies": {
     "husky": "^4.3.0",
     "jest-mock-extended": "^1.0.13",
-    "quicktype": "^23.0.49",
+    "quicktype": "23.0.75",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.1",
     "typescript": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "preprepare": "npm run typegen && npm run typegen-bridging",
     "prepare": "tsdx build",
     "typegen": "node s2tQuicktypeUtil.js schemas/context src/context/ContextTypes.ts && tsdx lint src/context/ --fix",
-    "typegen-bridging": "node s2tQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingTypes.ts && tsdx lint src/bridging/ --fix",
-    "typegen-bridging-zod": "node s2zodQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingZodSchemas.ts"
+    "typegen-bridging": "node s2tQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingTypes.ts && tsdx lint src/bridging/ --fix"
   },
   "peerDependencies": {},
   "husky": {

--- a/schemas/api/api.schema.json
+++ b/schemas/api/api.schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://fdc3.finos.org/schemas/next/api/api.schema.json",
+    "title": "FDC3 Desktop Agent API Schema",
     "definitions": {
         "AppIdentifier": {
             "description": "Identifies an application, or instance of an application, and is used to target FDC3 API calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application instances.\n\nWill always include at least an `appId` field, which uniquely identifies a specific app.\n\nIf the `instanceId` field is set then the `AppMetadata` object represents a specific instance of the application that may be addressed using that Id.",

--- a/schemas/bridging/agentRequest.schema.json
+++ b/schemas/bridging/agentRequest.schema.json
@@ -17,6 +17,7 @@
         "openRequest",
         "PrivateChannel.broadcast",
         "PrivateChannel.eventListenerAdded",
+        "PrivateChannel.eventListenerRemoved",
         "PrivateChannel.onAddContextListener",
         "PrivateChannel.onDisconnect",
         "PrivateChannel.onUnsubscribe",

--- a/schemas/bridging/common.schema.json
+++ b/schemas/bridging/common.schema.json
@@ -112,7 +112,8 @@
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
     },
     "PrivateChannelEventListenerTypes": {
-      "title": "",
+      "title": "Private Channel Event Listener Types",
+      "description": "Event listener type names for Private Channel events",
       "type": "string",
       "enum": [
         "onAddContextListener",

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -2,7 +2,7 @@
 //
 //   import { Convert, BaseImplementationMetadata, AgentErrorResponseMessage, AgentRequestMessage, AgentResponseMessage, BridgeErrorResponseMessage, BridgeRequestMessage, BridgeResponseMessage, BroadcastAgentRequest, BroadcastBridgeRequest, ConnectionStepMessage, ConnectionStep2Hello, ConnectionStep3Handshake, ConnectionStep4AuthenticationFailed, ConnectionStep6ConnectedAgentsUpdate, FindInstancesAgentErrorResponse, FindInstancesAgentRequest, FindInstancesAgentResponse, FindInstancesBridgeErrorResponse, FindInstancesBridgeRequest, FindInstancesBridgeResponse, FindIntentAgentErrorResponse, FindIntentAgentRequest, FindIntentAgentResponse, FindIntentBridgeErrorResponse, FindIntentBridgeRequest, FindIntentBridgeResponse, FindIntentsByContextAgentErrorResponse, FindIntentsByContextAgentRequest, FindIntentsByContextAgentResponse, FindIntentsByContextBridgeErrorResponse, FindIntentsByContextBridgeRequest, FindIntentsByContextBridgeResponse, GetAppMetadataAgentErrorResponse, GetAppMetadataAgentRequest, GetAppMetadataAgentResponse, GetAppMetadataBridgeErrorResponse, GetAppMetadataBridgeRequest, GetAppMetadataBridgeResponse, OpenAgentErrorResponse, OpenAgentRequest, OpenAgentResponse, OpenBridgeErrorResponse, OpenBridgeRequest, OpenBridgeResponse, PrivateChannelBroadcastAgentRequest, PrivateChannelBroadcastBridgeRequest, PrivateChannelEventListenerAddedAgentRequest, PrivateChannelEventListenerAddedBridgeRequest, PrivateChannelEventListenerRemovedAgentRequest, PrivateChannelEventListenerRemovedBridgeRequest, PrivateChannelOnAddContextListenerAgentRequest, PrivateChannelOnAddContextListenerBridgeRequest, PrivateChannelOnDisconnectAgentRequest, PrivateChannelOnDisconnectBridgeRequest, PrivateChannelOnUnsubscribeAgentRequest, PrivateChannelOnUnsubscribeBridgeRequest, RaiseIntentAgentErrorResponse, RaiseIntentAgentRequest, RaiseIntentAgentResponse, RaiseIntentBridgeErrorResponse, RaiseIntentBridgeRequest, RaiseIntentBridgeResponse, RaiseIntentResultAgentErrorResponse, RaiseIntentResultAgentResponse, RaiseIntentResultBridgeErrorResponse, RaiseIntentResultBridgeResponse, Context } from "./file";
 //
-//   const schemasAPIAPISchema = Convert.toSchemasAPIAPISchema(json);
+//   const fDC3DesktopAgentAPISchema = Convert.toFDC3DesktopAgentAPISchema(json);
 //   const baseImplementationMetadata = Convert.toBaseImplementationMetadata(json);
 //   const agentErrorResponseMessage = Convert.toAgentErrorResponseMessage(json);
 //   const agentRequestMessage = Convert.toAgentRequestMessage(json);
@@ -74,54 +74,6 @@
 //
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
-
-/**
- * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
- */
-export interface BaseImplementationMetadata {
-  /**
-   * The version number of the FDC3 specification that the implementation provides.
-   * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
-   */
-  fdc3Version: string;
-  /**
-   * Metadata indicating whether the Desktop Agent implements optional features of
-   * the Desktop Agent API.
-   */
-  optionalFeatures: BaseImplementationMetadataOptionalFeatures;
-  /**
-   * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
-   * OpenFin etc.).
-   */
-  provider: string;
-  /**
-   * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
-   */
-  providerVersion?: string;
-}
-
-/**
- * Metadata indicating whether the Desktop Agent implements optional features of
- * the Desktop Agent API.
- */
-export interface BaseImplementationMetadataOptionalFeatures {
-  /**
-   * Used to indicate whether the experimental Desktop Agent Bridging
-   * feature is implemented by the Desktop Agent.
-   */
-  DesktopAgentBridging: boolean;
-  /**
-   * Used to indicate whether the exposure of 'originating app metadata' for
-   * context and intent messages is supported by the Desktop Agent.
-   */
-  OriginatingAppMetadata: boolean;
-  /**
-   * Used to indicate whether the optional `fdc3.joinUserChannel`,
-   * `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
-   * the Desktop Agent.
-   */
-  UserChannelMembershipAPIs: boolean;
-}
 
 /**
  * A response message from a Desktop Agent to the Bridge containing an error, to be used in
@@ -387,6 +339,7 @@ export enum RequestMessageType {
   OpenRequest = 'openRequest',
   PrivateChannelBroadcast = 'PrivateChannel.broadcast',
   PrivateChannelEventListenerAdded = 'PrivateChannel.eventListenerAdded',
+  PrivateChannelEventListenerRemoved = 'PrivateChannel.eventListenerRemoved',
   PrivateChannelOnAddContextListener = 'PrivateChannel.onAddContextListener',
   PrivateChannelOnDisconnect = 'PrivateChannel.onDisconnect',
   PrivateChannelOnUnsubscribe = 'PrivateChannel.onUnsubscribe',
@@ -554,7 +507,7 @@ export interface BroadcastAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: BroadcastRequestMessageType;
 }
 
 /**
@@ -643,7 +596,7 @@ export interface BroadcastAgentRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: ContextElement;
+  context: Context;
 }
 
 /**
@@ -661,7 +614,7 @@ export interface BroadcastAgentRequestPayload {
  * data object of a particular type can be expected to have, but this can always be extended
  * with custom fields as appropriate.
  */
-export interface ContextElement {
+export interface Context {
   /**
    * Context data objects may include a set of equivalent key-value pairs that can be used to
    * help applications identify and look up the context type they receive in their own domain.
@@ -702,6 +655,18 @@ export interface ContextElement {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum BroadcastRequestMessageType {
+  BroadcastRequest = 'broadcastRequest',
+}
+
+/**
  * A request to broadcast context on a channel.
  *
  * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
@@ -716,7 +681,7 @@ export interface BroadcastBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: BroadcastRequestMessageType;
 }
 
 /**
@@ -814,7 +779,7 @@ export interface BroadcastBridgeRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: ContextElement;
+  context: Context;
 }
 
 /**
@@ -868,7 +833,7 @@ export interface ConnectionStep2Hello {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStepMessageType;
+  type: ConnectionStep2HelloType;
 }
 
 /**
@@ -902,6 +867,13 @@ export interface ConnectionStep2HelloPayload {
 }
 
 /**
+ * Identifies the type of the connection step message.
+ */
+export enum ConnectionStep2HelloType {
+  Hello = 'hello',
+}
+
+/**
  * Handshake message sent by the Desktop Agent to the Bridge (including requested name,
  * channel state and authentication data)
  *
@@ -917,7 +889,7 @@ export interface ConnectionStep3Handshake {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStepMessageType;
+  type: ConnectionStep3HandshakeType;
 }
 
 /**
@@ -937,11 +909,11 @@ export interface ConnectionStep3HandshakePayload {
    * The current state of the Desktop Agent's channels, excluding any private channels, as a
    * mapping of channel id to an array of Context objects, most recent first.
    */
-  channelsState: { [key: string]: ContextElement[] };
+  channelsState: { [key: string]: Context[] };
   /**
    * Desktop Agent ImplementationMetadata trying to connect to the bridge.
    */
-  implementationMetadata: ImplementationMetadataElement;
+  implementationMetadata: BaseImplementationMetadata;
   /**
    * The requested Desktop Agent name
    */
@@ -949,11 +921,11 @@ export interface ConnectionStep3HandshakePayload {
 }
 
 /**
- * Desktop Agent ImplementationMetadata trying to connect to the bridge.
- *
  * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
+ *
+ * Desktop Agent ImplementationMetadata trying to connect to the bridge.
  */
-export interface ImplementationMetadataElement {
+export interface BaseImplementationMetadata {
   /**
    * The version number of the FDC3 specification that the implementation provides.
    * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
@@ -963,7 +935,7 @@ export interface ImplementationMetadataElement {
    * Metadata indicating whether the Desktop Agent implements optional features of
    * the Desktop Agent API.
    */
-  optionalFeatures: ImplementationMetadataOptionalFeatures;
+  optionalFeatures: OptionalFeatures;
   /**
    * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
    * OpenFin etc.).
@@ -979,7 +951,7 @@ export interface ImplementationMetadataElement {
  * Metadata indicating whether the Desktop Agent implements optional features of
  * the Desktop Agent API.
  */
-export interface ImplementationMetadataOptionalFeatures {
+export interface OptionalFeatures {
   /**
    * Used to indicate whether the experimental Desktop Agent Bridging
    * feature is implemented by the Desktop Agent.
@@ -999,6 +971,13 @@ export interface ImplementationMetadataOptionalFeatures {
 }
 
 /**
+ * Identifies the type of the connection step message.
+ */
+export enum ConnectionStep3HandshakeType {
+  Handshake = 'handshake',
+}
+
+/**
  * Message sent by Bridge to Desktop Agent if their authentication fails.
  *
  * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
@@ -1013,7 +992,7 @@ export interface ConnectionStep4AuthenticationFailed {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStepMessageType;
+  type: ConnectionStep4AuthenticationFailedType;
 }
 
 /**
@@ -1033,6 +1012,13 @@ export interface ConnectionStep4AuthenticationFailedPayload {
 }
 
 /**
+ * Identifies the type of the connection step message.
+ */
+export enum ConnectionStep4AuthenticationFailedType {
+  AuthenticationFailed = 'authenticationFailed',
+}
+
+/**
  * Message sent by Bridge to all Desktop Agent when an agent joins or leaves the bridge,
  * includes the details of all agents, the change made and the expected channel state for
  * all agents.
@@ -1049,7 +1035,7 @@ export interface ConnectionStep6ConnectedAgentsUpdate {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStepMessageType;
+  type: ConnectionStep6ConnectedAgentsUpdateType;
 }
 
 /**
@@ -1072,17 +1058,24 @@ export interface ConnectionStep6ConnectedAgentsUpdatePayload {
   /**
    * Desktop Agent Bridge implementation metadata of all connected agents.
    */
-  allAgents: ImplementationMetadataElement[];
+  allAgents: BaseImplementationMetadata[];
   /**
    * The updated state of channels that should be adopted by the agents. Should only be set
    * when an agent is connecting to the bridge.
    */
-  channelsState?: { [key: string]: ContextElement[] };
+  channelsState?: { [key: string]: Context[] };
   /**
    * Should be set when an agent disconnects from the bridge and provide the name that no
    * longer is assigned.
    */
   removeAgent?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+export enum ConnectionStep6ConnectedAgentsUpdateType {
+  ConnectedAgentsUpdate = 'connectedAgentsUpdate',
 }
 
 /**
@@ -1101,7 +1094,7 @@ export interface FindInstancesAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindInstancesResponseMessageType;
 }
 
 /**
@@ -1149,6 +1142,18 @@ export enum ErrorMessage {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindInstancesResponseMessageType {
+  FindInstancesResponse = 'findInstancesResponse',
+}
+
+/**
  * A request for details of instances of a particular app
  *
  * A request message from a Desktop Agent to the Bridge.
@@ -1163,7 +1168,7 @@ export interface FindInstancesAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: FindInstancesRequestMessageType;
 }
 
 /**
@@ -1299,6 +1304,18 @@ export interface AppIdentifier {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindInstancesRequestMessageType {
+  FindInstancesRequest = 'findInstancesRequest',
+}
+
+/**
  * A response to a findInstances request.
  *
  * A response message from a Desktop Agent to the Bridge.
@@ -1313,7 +1330,7 @@ export interface FindInstancesAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindInstancesResponseMessageType;
 }
 
 /**
@@ -1466,7 +1483,7 @@ export interface FindInstancesBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindInstancesResponseMessageType;
 }
 
 /**
@@ -1503,7 +1520,7 @@ export interface FindInstancesBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: FindInstancesRequestMessageType;
 }
 
 /**
@@ -1625,7 +1642,7 @@ export interface FindInstancesBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindInstancesResponseMessageType;
 }
 
 /**
@@ -1663,7 +1680,7 @@ export interface FindIntentAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindIntentResponseMessageType;
 }
 
 /**
@@ -1683,6 +1700,18 @@ export interface FindIntentAgentErrorResponsePayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindIntentResponseMessageType {
+  FindIntentResponse = 'findIntentResponse',
+}
+
+/**
  * A request for details of apps available to resolve a particular intent and context pair.
  *
  * A request message from a Desktop Agent to the Bridge.
@@ -1697,7 +1726,7 @@ export interface FindIntentAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: FindIntentRequestMessageType;
 }
 
 /**
@@ -1723,8 +1752,20 @@ export interface FindIntentAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentAgentRequestPayload {
-  context?: ContextElement;
+  context?: Context;
   intent: string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindIntentRequestMessageType {
+  FindIntentRequest = 'findIntentRequest',
 }
 
 /**
@@ -1742,7 +1783,7 @@ export interface FindIntentAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindIntentResponseMessageType;
 }
 
 /**
@@ -1808,7 +1849,7 @@ export interface FindIntentBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindIntentResponseMessageType;
 }
 
 /**
@@ -1845,7 +1886,7 @@ export interface FindIntentBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: FindIntentRequestMessageType;
 }
 
 /**
@@ -1872,7 +1913,7 @@ export interface FindIntentBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentBridgeRequestPayload {
-  context?: ContextElement;
+  context?: Context;
   intent: string;
 }
 
@@ -1892,7 +1933,7 @@ export interface FindIntentBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindIntentResponseMessageType;
 }
 
 /**
@@ -1930,7 +1971,7 @@ export interface FindIntentsByContextAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindIntentsByContextResponseMessageType;
 }
 
 /**
@@ -1950,6 +1991,18 @@ export interface FindIntentsByContextAgentErrorResponsePayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindIntentsByContextResponseMessageType {
+  FindIntentsByContextResponse = 'findIntentsByContextResponse',
+}
+
+/**
  * A request for details of intents and apps available to resolve them for a particular
  * context.
  *
@@ -1965,7 +2018,7 @@ export interface FindIntentsByContextAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: FindIntentsByContextRequestMessageType;
 }
 
 /**
@@ -1991,7 +2044,19 @@ export interface FindIntentsByContextAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentsByContextAgentRequestPayload {
-  context: ContextElement;
+  context: Context;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum FindIntentsByContextRequestMessageType {
+  FindIntentsByContextRequest = 'findIntentsByContextRequest',
 }
 
 /**
@@ -2009,7 +2074,7 @@ export interface FindIntentsByContextAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: FindIntentsByContextResponseMessageType;
 }
 
 /**
@@ -2045,7 +2110,7 @@ export interface FindIntentsByContextBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindIntentsByContextResponseMessageType;
 }
 
 /**
@@ -2083,7 +2148,7 @@ export interface FindIntentsByContextBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: FindIntentsByContextRequestMessageType;
 }
 
 /**
@@ -2110,7 +2175,7 @@ export interface FindIntentsByContextBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentsByContextBridgeRequestPayload {
-  context: ContextElement;
+  context: Context;
 }
 
 /**
@@ -2129,7 +2194,7 @@ export interface FindIntentsByContextBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: FindIntentsByContextResponseMessageType;
 }
 
 /**
@@ -2167,7 +2232,7 @@ export interface GetAppMetadataAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: GetAppMetadataResponseMessageType;
 }
 
 /**
@@ -2187,6 +2252,18 @@ export interface GetAppMetadataAgentErrorResponsePayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum GetAppMetadataResponseMessageType {
+  GetAppMetadataResponse = 'getAppMetadataResponse',
+}
+
+/**
  * A request for metadata about an app
  *
  * A request message from a Desktop Agent to the Bridge.
@@ -2201,7 +2278,7 @@ export interface GetAppMetadataAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: GetAppMetadataRequestMessageType;
 }
 
 /**
@@ -2290,6 +2367,18 @@ export interface AppDestinationIdentifier {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum GetAppMetadataRequestMessageType {
+  GetAppMetadataRequest = 'getAppMetadataRequest',
+}
+
+/**
  * A response to a getAppMetadata request.
  *
  * A response message from a Desktop Agent to the Bridge.
@@ -2304,7 +2393,7 @@ export interface GetAppMetadataAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: GetAppMetadataResponseMessageType;
 }
 
 /**
@@ -2340,7 +2429,7 @@ export interface GetAppMetadataBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: GetAppMetadataResponseMessageType;
 }
 
 /**
@@ -2377,7 +2466,7 @@ export interface GetAppMetadataBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: GetAppMetadataRequestMessageType;
 }
 
 /**
@@ -2423,7 +2512,7 @@ export interface GetAppMetadataBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: GetAppMetadataResponseMessageType;
 }
 
 /**
@@ -2461,7 +2550,7 @@ export interface OpenAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: OpenResponseMessageType;
 }
 
 /**
@@ -2506,6 +2595,18 @@ export enum OpenErrorMessage {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum OpenResponseMessageType {
+  OpenResponse = 'openResponse',
+}
+
+/**
  * A request to open an application
  *
  * A request message from a Desktop Agent to the Bridge.
@@ -2520,7 +2621,7 @@ export interface OpenAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: OpenRequestMessageType;
 }
 
 /**
@@ -2550,7 +2651,7 @@ export interface OpenAgentRequestPayload {
    * The application to open on the specified Desktop Agent
    */
   app: AppToOpen;
-  context?: ContextElement;
+  context?: Context;
 }
 
 /**
@@ -2612,6 +2713,18 @@ export interface AppToOpen {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum OpenRequestMessageType {
+  OpenRequest = 'openRequest',
+}
+
+/**
  * A response to an open request
  *
  * A response message from a Desktop Agent to the Bridge.
@@ -2626,7 +2739,7 @@ export interface OpenAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: OpenResponseMessageType;
 }
 
 /**
@@ -2662,7 +2775,7 @@ export interface OpenBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: OpenResponseMessageType;
 }
 
 /**
@@ -2699,7 +2812,7 @@ export interface OpenBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: OpenRequestMessageType;
 }
 
 /**
@@ -2730,7 +2843,7 @@ export interface OpenBridgeRequestPayload {
    * The application to open on the specified Desktop Agent
    */
   app: AppToOpen;
-  context?: ContextElement;
+  context?: Context;
 }
 
 /**
@@ -2749,7 +2862,7 @@ export interface OpenBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: OpenResponseMessageType;
 }
 
 /**
@@ -2786,7 +2899,7 @@ export interface PrivateChannelBroadcastAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelBroadcastMessageType;
 }
 
 /**
@@ -2889,7 +3002,19 @@ export interface PrivateChannelBroadcastAgentRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: ContextElement;
+  context: Context;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelBroadcastMessageType {
+  PrivateChannelBroadcast = 'PrivateChannel.broadcast',
 }
 
 /**
@@ -2907,7 +3032,7 @@ export interface PrivateChannelBroadcastBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelBroadcastMessageType;
 }
 
 /**
@@ -2941,7 +3066,7 @@ export interface PrivateChannelBroadcastBridgeRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: ContextElement;
+  context: Context;
 }
 
 /**
@@ -2959,7 +3084,7 @@ export interface PrivateChannelEventListenerAddedAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelEventListenerAddedMessageType;
 }
 
 /**
@@ -2986,13 +3111,28 @@ export interface PrivateChannelEventListenerAddedAgentRequestMeta {
  */
 export interface PrivateChannelEventListenerAddedAgentRequestPayload {
   channelId: string;
-  listenerType: Empty;
+  listenerType: PrivateChannelEventListenerTypes;
 }
 
-export enum Empty {
+/**
+ * Event listener type names for Private Channel events
+ */
+export enum PrivateChannelEventListenerTypes {
   OnAddContextListener = 'onAddContextListener',
   OnDisconnect = 'onDisconnect',
   OnUnsubscribe = 'onUnsubscribe',
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelEventListenerAddedMessageType {
+  PrivateChannelEventListenerAdded = 'PrivateChannel.eventListenerAdded',
 }
 
 /**
@@ -3010,7 +3150,7 @@ export interface PrivateChannelEventListenerAddedBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelEventListenerAddedMessageType;
 }
 
 /**
@@ -3038,7 +3178,7 @@ export interface PrivateChannelEventListenerAddedBridgeRequestMeta {
  */
 export interface PrivateChannelEventListenerAddedBridgeRequestPayload {
   channelId: string;
-  listenerType: Empty;
+  listenerType: PrivateChannelEventListenerTypes;
 }
 
 /**
@@ -3056,7 +3196,7 @@ export interface PrivateChannelEventListenerRemovedAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelEventListenerRemovedMessageType;
 }
 
 /**
@@ -3083,7 +3223,19 @@ export interface PrivateChannelEventListenerRemovedAgentRequestMeta {
  */
 export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
   channelId: string;
-  listenerType: Empty;
+  listenerType: PrivateChannelEventListenerTypes;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelEventListenerRemovedMessageType {
+  PrivateChannelEventListenerRemoved = 'PrivateChannel.eventListenerRemoved',
 }
 
 /**
@@ -3101,7 +3253,7 @@ export interface PrivateChannelEventListenerRemovedBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelEventListenerRemovedMessageType;
 }
 
 /**
@@ -3129,7 +3281,7 @@ export interface PrivateChannelEventListenerRemovedBridgeRequestMeta {
  */
 export interface PrivateChannelEventListenerRemovedBridgeRequestPayload {
   channelId: string;
-  listenerType: Empty;
+  listenerType: PrivateChannelEventListenerTypes;
 }
 
 /**
@@ -3147,7 +3299,7 @@ export interface PrivateChannelOnAddContextListenerAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelOnAddContextListenerMessageType;
 }
 
 /**
@@ -3178,6 +3330,18 @@ export interface PrivateChannelOnAddContextListenerAgentRequestPayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelOnAddContextListenerMessageType {
+  PrivateChannelOnAddContextListener = 'PrivateChannel.onAddContextListener',
+}
+
+/**
  * A request to forward on an AddContextListener event, relating to a PrivateChannel
  *
  * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
@@ -3192,7 +3356,7 @@ export interface PrivateChannelOnAddContextListenerBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelOnAddContextListenerMessageType;
 }
 
 /**
@@ -3238,7 +3402,7 @@ export interface PrivateChannelOnDisconnectAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelOnDisconnectMessageType;
 }
 
 /**
@@ -3268,6 +3432,18 @@ export interface PrivateChannelOnDisconnectAgentRequestPayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelOnDisconnectMessageType {
+  PrivateChannelOnDisconnect = 'PrivateChannel.onDisconnect',
+}
+
+/**
  * A request to forward on a Disconnect event, relating to a PrivateChannel
  *
  * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
@@ -3282,7 +3458,7 @@ export interface PrivateChannelOnDisconnectBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelOnDisconnectMessageType;
 }
 
 /**
@@ -3327,7 +3503,7 @@ export interface PrivateChannelOnUnsubscribeAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: PrivateChannelOnUnsubscribeMessageType;
 }
 
 /**
@@ -3358,6 +3534,18 @@ export interface PrivateChannelOnUnsubscribeAgentRequestPayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum PrivateChannelOnUnsubscribeMessageType {
+  PrivateChannelOnUnsubscribe = 'PrivateChannel.onUnsubscribe',
+}
+
+/**
  * A request to forward on an Unsubscribe event, relating to a PrivateChannel
  *
  * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
@@ -3372,7 +3560,7 @@ export interface PrivateChannelOnUnsubscribeBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: PrivateChannelOnUnsubscribeMessageType;
 }
 
 /**
@@ -3419,7 +3607,7 @@ export interface RaiseIntentAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: RaiseIntentResponseMessageType;
 }
 
 /**
@@ -3439,6 +3627,18 @@ export interface RaiseIntentAgentErrorResponsePayload {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum RaiseIntentResponseMessageType {
+  RaiseIntentResponse = 'raiseIntentResponse',
+}
+
+/**
  * A request to raise an intent.
  *
  * A request message from a Desktop Agent to the Bridge.
@@ -3453,7 +3653,7 @@ export interface RaiseIntentAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RequestMessageType;
+  type: RaiseIntentRequestMessageType;
 }
 
 /**
@@ -3480,8 +3680,20 @@ export interface RaiseIntentAgentRequestMeta {
  */
 export interface RaiseIntentAgentRequestPayload {
   app: AppDestinationIdentifier;
-  context: ContextElement;
+  context: Context;
   intent: string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum RaiseIntentRequestMessageType {
+  RaiseIntentRequest = 'raiseIntentRequest',
 }
 
 /**
@@ -3499,7 +3711,7 @@ export interface RaiseIntentAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: RaiseIntentResponseMessageType;
 }
 
 /**
@@ -3579,7 +3791,7 @@ export interface RaiseIntentBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: RaiseIntentResponseMessageType;
 }
 
 /**
@@ -3616,7 +3828,7 @@ export interface RaiseIntentBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: string;
+  type: RaiseIntentRequestMessageType;
 }
 
 /**
@@ -3644,7 +3856,7 @@ export interface RaiseIntentBridgeRequestMeta {
  */
 export interface RaiseIntentBridgeRequestPayload {
   app: AppDestinationIdentifier;
-  context: ContextElement;
+  context: Context;
   intent: string;
 }
 
@@ -3664,7 +3876,7 @@ export interface RaiseIntentBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: RaiseIntentResponseMessageType;
 }
 
 /**
@@ -3703,7 +3915,7 @@ export interface RaiseIntentResultAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: RaiseIntentResultResponseMessageType;
 }
 
 /**
@@ -3744,6 +3956,18 @@ export enum RaiseIntentResultErrorMessage {
 }
 
 /**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * UUID for the request
+ *
+ * UUID for this specific response message.
+ */
+export enum RaiseIntentResultResponseMessageType {
+  RaiseIntentResultResponse = 'raiseIntentResultResponse',
+}
+
+/**
  * A secondary response to a request to raise an intent used to deliver the intent result
  *
  * A response message from a Desktop Agent to the Bridge.
@@ -3758,7 +3982,7 @@ export interface RaiseIntentResultAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: ResponseMessageType;
+  type: RaiseIntentResultResponseMessageType;
 }
 
 /**
@@ -3778,7 +4002,7 @@ export interface RaiseIntentResultAgentResponsePayload {
 }
 
 export interface IntentResult {
-  context?: ContextElement;
+  context?: Context;
   channel?: Channel;
 }
 
@@ -3869,7 +4093,7 @@ export interface RaiseIntentResultBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: RaiseIntentResultResponseMessageType;
 }
 
 /**
@@ -3907,7 +4131,7 @@ export interface RaiseIntentResultBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: string;
+  type: RaiseIntentResultResponseMessageType;
 }
 
 /**
@@ -3929,67 +4153,14 @@ export interface RaiseIntentResultBridgeResponsePayload {
   intentResult: IntentResult;
 }
 
-/**
- * The `fdc3.context` type defines the basic contract or "shape" for all data exchanged by
- * FDC3 operations. As such, it is not really meant to be used on its own, but is imported
- * by more specific type definitions (standardized or custom) to provide the structure and
- * properties shared by all FDC3 context data types.
- *
- * The key element of FDC3 context types is their mandatory `type` property, which is used
- * to identify what type of data the object represents, and what shape it has.
- *
- * The FDC3 context type, and all derived types, define the minimum set of fields a context
- * data object of a particular type can be expected to have, but this can always be extended
- * with custom fields as appropriate.
- */
-export interface Context {
-  /**
-   * Context data objects may include a set of equivalent key-value pairs that can be used to
-   * help applications identify and look up the context type they receive in their own domain.
-   * The idea behind this design is that applications can provide as many equivalent
-   * identifiers to a target application as possible, e.g. an instrument may be represented by
-   * an ISIN, CUSIP or Bloomberg identifier.
-   *
-   * Identifiers do not make sense for all types of data, so the `id` property is therefore
-   * optional, but some derived types may choose to require at least one identifier.
-   */
-  id?: { [key: string]: any };
-  /**
-   * Context data objects may include a name property that can be used for more information,
-   * or display purposes. Some derived types may require the name object as mandatory,
-   * depending on use case.
-   */
-  name?: string;
-  /**
-   * The type property is the only _required_ part of the FDC3 context data schema. The FDC3
-   * [API](https://fdc3.finos.org/docs/api/spec) relies on the `type` property being present
-   * to route shared context data appropriately.
-   *
-   * FDC3 [Intents](https://fdc3.finos.org/docs/intents/spec) also register the context data
-   * types they support in an FDC3 [App
-   * Directory](https://fdc3.finos.org/docs/app-directory/overview), used for intent discovery
-   * and routing.
-   *
-   * Standardized FDC3 context types have well-known `type` properties prefixed with the
-   * `fdc3` namespace, e.g. `fdc3.instrument`. For non-standard types, e.g. those defined and
-   * used by a particular organization, the convention is to prefix them with an
-   * organization-specific namespace, e.g. `blackrock.fund`.
-   *
-   * See the [Context Data Specification](https://fdc3.finos.org/docs/context/spec) for more
-   * information about context data types.
-   */
-  type: string;
-  [property: string]: any;
-}
-
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-  public static toSchemasAPIAPISchema(json: string): any {
+  public static toFDC3DesktopAgentAPISchema(json: string): any {
     return cast(JSON.parse(json), 'any');
   }
 
-  public static schemasAPIAPISchemaToJson(value: any): string {
+  public static fDC3DesktopAgentAPISchemaToJson(value: any): string {
     return JSON.stringify(uncast(value, 'any'), null, 2);
   }
 
@@ -4731,23 +4902,6 @@ function r(name: string) {
 }
 
 const typeMap: any = {
-  BaseImplementationMetadata: o(
-    [
-      { json: 'fdc3Version', js: 'fdc3Version', typ: '' },
-      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('BaseImplementationMetadataOptionalFeatures') },
-      { json: 'provider', js: 'provider', typ: '' },
-      { json: 'providerVersion', js: 'providerVersion', typ: u(undefined, '') },
-    ],
-    false
-  ),
-  BaseImplementationMetadataOptionalFeatures: o(
-    [
-      { json: 'DesktopAgentBridging', js: 'DesktopAgentBridging', typ: true },
-      { json: 'OriginatingAppMetadata', js: 'OriginatingAppMetadata', typ: true },
-      { json: 'UserChannelMembershipAPIs', js: 'UserChannelMembershipAPIs', typ: true },
-    ],
-    false
-  ),
   AgentErrorResponseMessage: o(
     [
       { json: 'meta', js: 'meta', typ: r('AgentResponseMetadata') },
@@ -4866,7 +5020,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('BroadcastAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('BroadcastAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('BroadcastRequestMessageType') },
     ],
     false
   ),
@@ -4889,11 +5043,11 @@ const typeMap: any = {
   BroadcastAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
     ],
     false
   ),
-  ContextElement: o(
+  Context: o(
     [
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
@@ -4905,7 +5059,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('BroadcastBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('BroadcastBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('BroadcastRequestMessageType') },
     ],
     false
   ),
@@ -4928,7 +5082,7 @@ const typeMap: any = {
   BroadcastBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
     ],
     false
   ),
@@ -4952,7 +5106,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ConnectionStep2HelloMeta') },
       { json: 'payload', js: 'payload', typ: r('ConnectionStep2HelloPayload') },
-      { json: 'type', js: 'type', typ: r('ConnectionStepMessageType') },
+      { json: 'type', js: 'type', typ: r('ConnectionStep2HelloType') },
     ],
     false
   ),
@@ -4970,7 +5124,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ConnectionStep3HandshakeMeta') },
       { json: 'payload', js: 'payload', typ: r('ConnectionStep3HandshakePayload') },
-      { json: 'type', js: 'type', typ: r('ConnectionStepMessageType') },
+      { json: 'type', js: 'type', typ: r('ConnectionStep3HandshakeType') },
     ],
     false
   ),
@@ -4984,22 +5138,22 @@ const typeMap: any = {
   ConnectionStep3HandshakePayload: o(
     [
       { json: 'authToken', js: 'authToken', typ: u(undefined, '') },
-      { json: 'channelsState', js: 'channelsState', typ: m(a(r('ContextElement'))) },
-      { json: 'implementationMetadata', js: 'implementationMetadata', typ: r('ImplementationMetadataElement') },
+      { json: 'channelsState', js: 'channelsState', typ: m(a(r('Context'))) },
+      { json: 'implementationMetadata', js: 'implementationMetadata', typ: r('BaseImplementationMetadata') },
       { json: 'requestedName', js: 'requestedName', typ: '' },
     ],
     false
   ),
-  ImplementationMetadataElement: o(
+  BaseImplementationMetadata: o(
     [
       { json: 'fdc3Version', js: 'fdc3Version', typ: '' },
-      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('ImplementationMetadataOptionalFeatures') },
+      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('OptionalFeatures') },
       { json: 'provider', js: 'provider', typ: '' },
       { json: 'providerVersion', js: 'providerVersion', typ: u(undefined, '') },
     ],
     false
   ),
-  ImplementationMetadataOptionalFeatures: o(
+  OptionalFeatures: o(
     [
       { json: 'DesktopAgentBridging', js: 'DesktopAgentBridging', typ: true },
       { json: 'OriginatingAppMetadata', js: 'OriginatingAppMetadata', typ: true },
@@ -5011,7 +5165,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ConnectionStep4AuthenticationFailedMeta') },
       { json: 'payload', js: 'payload', typ: r('ConnectionStep4AuthenticationFailedPayload') },
-      { json: 'type', js: 'type', typ: r('ConnectionStepMessageType') },
+      { json: 'type', js: 'type', typ: r('ConnectionStep4AuthenticationFailedType') },
     ],
     false
   ),
@@ -5028,7 +5182,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ConnectionStep6ConnectedAgentsUpdateMeta') },
       { json: 'payload', js: 'payload', typ: r('ConnectionStep6ConnectedAgentsUpdatePayload') },
-      { json: 'type', js: 'type', typ: r('ConnectionStepMessageType') },
+      { json: 'type', js: 'type', typ: r('ConnectionStep6ConnectedAgentsUpdateType') },
     ],
     false
   ),
@@ -5043,8 +5197,8 @@ const typeMap: any = {
   ConnectionStep6ConnectedAgentsUpdatePayload: o(
     [
       { json: 'addAgent', js: 'addAgent', typ: u(undefined, '') },
-      { json: 'allAgents', js: 'allAgents', typ: a(r('ImplementationMetadataElement')) },
-      { json: 'channelsState', js: 'channelsState', typ: u(undefined, m(a(r('ContextElement')))) },
+      { json: 'allAgents', js: 'allAgents', typ: a(r('BaseImplementationMetadata')) },
+      { json: 'channelsState', js: 'channelsState', typ: u(undefined, m(a(r('Context')))) },
       { json: 'removeAgent', js: 'removeAgent', typ: u(undefined, '') },
     ],
     false
@@ -5053,7 +5207,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
     ],
     false
   ),
@@ -5070,7 +5224,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesRequestMessageType') },
     ],
     false
   ),
@@ -5104,7 +5258,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
     ],
     false
   ),
@@ -5158,7 +5312,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
     ],
     false
   ),
@@ -5177,7 +5331,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindInstancesRequestMessageType') },
     ],
     false
   ),
@@ -5203,7 +5357,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
     ],
     false
   ),
@@ -5226,7 +5380,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
     ],
     false
   ),
@@ -5243,7 +5397,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentRequestMessageType') },
     ],
     false
   ),
@@ -5258,7 +5412,7 @@ const typeMap: any = {
   ),
   FindIntentAgentRequestPayload: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -5267,7 +5421,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
     ],
     false
   ),
@@ -5298,7 +5452,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
     ],
     false
   ),
@@ -5317,7 +5471,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentRequestMessageType') },
     ],
     false
   ),
@@ -5332,7 +5486,7 @@ const typeMap: any = {
   ),
   FindIntentBridgeRequestPayload: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -5341,7 +5495,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
     ],
     false
   ),
@@ -5361,7 +5515,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
     ],
     false
   ),
@@ -5378,7 +5532,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextRequestMessageType') },
     ],
     false
   ),
@@ -5391,12 +5545,12 @@ const typeMap: any = {
     ],
     false
   ),
-  FindIntentsByContextAgentRequestPayload: o([{ json: 'context', js: 'context', typ: r('ContextElement') }], false),
+  FindIntentsByContextAgentRequestPayload: o([{ json: 'context', js: 'context', typ: r('Context') }], false),
   FindIntentsByContextAgentResponse: o(
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
     ],
     false
   ),
@@ -5416,7 +5570,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
     ],
     false
   ),
@@ -5435,7 +5589,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextRequestMessageType') },
     ],
     false
   ),
@@ -5448,12 +5602,12 @@ const typeMap: any = {
     ],
     false
   ),
-  FindIntentsByContextBridgeRequestPayload: o([{ json: 'context', js: 'context', typ: r('ContextElement') }], false),
+  FindIntentsByContextBridgeRequestPayload: o([{ json: 'context', js: 'context', typ: r('Context') }], false),
   FindIntentsByContextBridgeResponse: o(
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
     ],
     false
   ),
@@ -5476,7 +5630,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
     ],
     false
   ),
@@ -5493,7 +5647,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataRequestMessageType') },
     ],
     false
   ),
@@ -5519,7 +5673,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
     ],
     false
   ),
@@ -5536,7 +5690,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
     ],
     false
   ),
@@ -5555,7 +5709,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataRequestMessageType') },
     ],
     false
   ),
@@ -5573,7 +5727,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
     ],
     false
   ),
@@ -5593,7 +5747,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
     ],
     false
   ),
@@ -5610,7 +5764,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenRequestMessageType') },
     ],
     false
   ),
@@ -5626,7 +5780,7 @@ const typeMap: any = {
   OpenAgentRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppToOpen') },
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
     ],
     false
   ),
@@ -5642,7 +5796,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
     ],
     false
   ),
@@ -5659,7 +5813,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
     ],
     false
   ),
@@ -5678,7 +5832,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('OpenRequestMessageType') },
     ],
     false
   ),
@@ -5694,7 +5848,7 @@ const typeMap: any = {
   OpenBridgeRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppToOpen') },
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
     ],
     false
   ),
@@ -5702,7 +5856,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
     ],
     false
   ),
@@ -5722,7 +5876,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelBroadcastAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelBroadcastAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastMessageType') },
     ],
     false
   ),
@@ -5746,7 +5900,7 @@ const typeMap: any = {
   PrivateChannelBroadcastAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
     ],
     false
   ),
@@ -5754,7 +5908,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelBroadcastBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelBroadcastBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastMessageType') },
     ],
     false
   ),
@@ -5770,7 +5924,7 @@ const typeMap: any = {
   PrivateChannelBroadcastBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
     ],
     false
   ),
@@ -5778,7 +5932,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerAddedAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerAddedAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedMessageType') },
     ],
     false
   ),
@@ -5794,7 +5948,7 @@ const typeMap: any = {
   PrivateChannelEventListenerAddedAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
+      { json: 'listenerType', js: 'listenerType', typ: r('PrivateChannelEventListenerTypes') },
     ],
     false
   ),
@@ -5802,7 +5956,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerAddedBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerAddedBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedMessageType') },
     ],
     false
   ),
@@ -5818,7 +5972,7 @@ const typeMap: any = {
   PrivateChannelEventListenerAddedBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
+      { json: 'listenerType', js: 'listenerType', typ: r('PrivateChannelEventListenerTypes') },
     ],
     false
   ),
@@ -5826,7 +5980,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerRemovedAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerRemovedAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedMessageType') },
     ],
     false
   ),
@@ -5842,7 +5996,7 @@ const typeMap: any = {
   PrivateChannelEventListenerRemovedAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
+      { json: 'listenerType', js: 'listenerType', typ: r('PrivateChannelEventListenerTypes') },
     ],
     false
   ),
@@ -5850,7 +6004,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerRemovedBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerRemovedBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedMessageType') },
     ],
     false
   ),
@@ -5866,7 +6020,7 @@ const typeMap: any = {
   PrivateChannelEventListenerRemovedBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'listenerType', js: 'listenerType', typ: r('Empty') },
+      { json: 'listenerType', js: 'listenerType', typ: r('PrivateChannelEventListenerTypes') },
     ],
     false
   ),
@@ -5874,7 +6028,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnAddContextListenerAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnAddContextListenerAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerMessageType') },
     ],
     false
   ),
@@ -5898,7 +6052,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnAddContextListenerBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnAddContextListenerBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerMessageType') },
     ],
     false
   ),
@@ -5922,7 +6076,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnDisconnectAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnDisconnectAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectMessageType') },
     ],
     false
   ),
@@ -5940,7 +6094,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnDisconnectBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnDisconnectBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectMessageType') },
     ],
     false
   ),
@@ -5958,7 +6112,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnUnsubscribeAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnUnsubscribeAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeMessageType') },
     ],
     false
   ),
@@ -5982,7 +6136,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ERequestMetadata') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnUnsubscribeBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeMessageType') },
     ],
     false
   ),
@@ -6006,7 +6160,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
     ],
     false
   ),
@@ -6023,7 +6177,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RequestMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentRequestMessageType') },
     ],
     false
   ),
@@ -6039,7 +6193,7 @@ const typeMap: any = {
   RaiseIntentAgentRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppDestinationIdentifier') },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -6048,7 +6202,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
     ],
     false
   ),
@@ -6076,7 +6230,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
     ],
     false
   ),
@@ -6095,7 +6249,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('RaiseIntentRequestMessageType') },
     ],
     false
   ),
@@ -6111,7 +6265,7 @@ const typeMap: any = {
   RaiseIntentBridgeRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppDestinationIdentifier') },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -6120,7 +6274,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
     ],
     false
   ),
@@ -6143,7 +6297,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
     ],
     false
   ),
@@ -6163,7 +6317,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('ResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
     ],
     false
   ),
@@ -6181,7 +6335,7 @@ const typeMap: any = {
   ),
   IntentResult: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
       { json: 'channel', js: 'channel', typ: u(undefined, r('Channel')) },
     ],
     false
@@ -6206,7 +6360,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
     ],
     false
   ),
@@ -6228,7 +6382,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
     ],
     false
   ),
@@ -6246,14 +6400,6 @@ const typeMap: any = {
   RaiseIntentResultBridgeResponsePayload: o(
     [{ json: 'intentResult', js: 'intentResult', typ: r('IntentResult') }],
     false
-  ),
-  Context: o(
-    [
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
-    ],
-    'any'
   ),
   ResponseErrorDetail: [
     'AccessDenied',
@@ -6296,12 +6442,18 @@ const typeMap: any = {
     'openRequest',
     'PrivateChannel.broadcast',
     'PrivateChannel.eventListenerAdded',
+    'PrivateChannel.eventListenerRemoved',
     'PrivateChannel.onAddContextListener',
     'PrivateChannel.onDisconnect',
     'PrivateChannel.onUnsubscribe',
     'raiseIntentRequest',
   ],
+  BroadcastRequestMessageType: ['broadcastRequest'],
   ConnectionStepMessageType: ['authenticationFailed', 'connectedAgentsUpdate', 'handshake', 'hello'],
+  ConnectionStep2HelloType: ['hello'],
+  ConnectionStep3HandshakeType: ['handshake'],
+  ConnectionStep4AuthenticationFailedType: ['authenticationFailed'],
+  ConnectionStep6ConnectedAgentsUpdateType: ['connectedAgentsUpdate'],
   ErrorMessage: [
     'AgentDisconnected',
     'DesktopAgentNotFound',
@@ -6317,6 +6469,14 @@ const typeMap: any = {
     'TargetInstanceUnavailable',
     'UserCancelledResolution',
   ],
+  FindInstancesResponseMessageType: ['findInstancesResponse'],
+  FindInstancesRequestMessageType: ['findInstancesRequest'],
+  FindIntentResponseMessageType: ['findIntentResponse'],
+  FindIntentRequestMessageType: ['findIntentRequest'],
+  FindIntentsByContextResponseMessageType: ['findIntentsByContextResponse'],
+  FindIntentsByContextRequestMessageType: ['findIntentsByContextRequest'],
+  GetAppMetadataResponseMessageType: ['getAppMetadataResponse'],
+  GetAppMetadataRequestMessageType: ['getAppMetadataRequest'],
   OpenErrorMessage: [
     'AgentDisconnected',
     'AppNotFound',
@@ -6329,7 +6489,17 @@ const typeMap: any = {
     'ResolverUnavailable',
     'ResponseToBridgeTimedOut',
   ],
-  Empty: ['onAddContextListener', 'onDisconnect', 'onUnsubscribe'],
+  OpenResponseMessageType: ['openResponse'],
+  OpenRequestMessageType: ['openRequest'],
+  PrivateChannelBroadcastMessageType: ['PrivateChannel.broadcast'],
+  PrivateChannelEventListenerTypes: ['onAddContextListener', 'onDisconnect', 'onUnsubscribe'],
+  PrivateChannelEventListenerAddedMessageType: ['PrivateChannel.eventListenerAdded'],
+  PrivateChannelEventListenerRemovedMessageType: ['PrivateChannel.eventListenerRemoved'],
+  PrivateChannelOnAddContextListenerMessageType: ['PrivateChannel.onAddContextListener'],
+  PrivateChannelOnDisconnectMessageType: ['PrivateChannel.onDisconnect'],
+  PrivateChannelOnUnsubscribeMessageType: ['PrivateChannel.onUnsubscribe'],
+  RaiseIntentResponseMessageType: ['raiseIntentResponse'],
+  RaiseIntentRequestMessageType: ['raiseIntentRequest'],
   RaiseIntentResultErrorMessage: [
     'AgentDisconnected',
     'IntentHandlerRejected',
@@ -6338,5 +6508,6 @@ const typeMap: any = {
     'NotConnectedToBridge',
     'ResponseToBridgeTimedOut',
   ],
+  RaiseIntentResultResponseMessageType: ['raiseIntentResultResponse'],
   Type: ['app', 'private', 'user'],
 };

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -1,7 +1,3 @@
-/**
- * SPDX-License-Identifier: Apache-2.0
- * Copyright FINOS FDC3 contributors - see NOTICE file
- */
 // To parse this data:
 //
 //   import { Convert, Action, Chart, ChatInitSettings, ChatMessage, ChatRoom, ChatSearchCriteria, Contact, ContactList, Context, Country, Currency, Email, Instrument, InstrumentList, Interaction, Message, Nothing, Order, OrderList, Organization, Portfolio, Position, Product, TimeRange, Trade, TradeList, TransactionResult, Valuation } from "./file";
@@ -57,7 +53,7 @@ export interface Action {
   /**
    * A context object with which the action will be performed
    */
-  context: ContextElement;
+  context: Context;
   /**
    * Optional Intent to raise to perform the actions. Should reference an intent type name,
    * such as those defined in the FDC3 Standard. If intent is not set then
@@ -69,7 +65,7 @@ export interface Action {
    * A human readable display name for the action
    */
   title: string;
-  type: string;
+  type: ActionType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -123,7 +119,7 @@ export interface ActionTargetApp {
  * data object of a particular type can be expected to have, but this can always be extended
  * with custom fields as appropriate.
  */
-export interface ContextElement {
+export interface Context {
   /**
    * Context data objects may include a set of equivalent key-value pairs that can be used to
    * help applications identify and look up the context type they receive in their own domain.
@@ -164,6 +160,16 @@ export interface ContextElement {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ActionType {
+  Fdc3Action = 'fdc3.action',
+}
+
+/**
  * A context type representing details of a Chart, which may be used to request plotting of
  * a particular chart or to otherwise share details of its composition, such as:
  *
@@ -181,22 +187,22 @@ export interface Chart {
   /**
    * An array of instrument contexts whose data should be plotted.
    */
-  instruments: InstrumentElement[];
+  instruments: Instrument[];
   /**
    * It is common for charts to support other configuration, such as indicators, annotations
    * etc., which do not have standardized formats, but may be included in the `otherConfig`
    * array as context objects.
    */
-  otherConfig?: ContextElement[];
+  otherConfig?: Context[];
   /**
    * The time range that should be plotted
    */
-  range?: TimeRangeObject;
+  range?: TimeRange;
   /**
    * The type of chart that should be plotted
    */
   style?: ChartStyle;
-  type: string;
+  type: ChartType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -209,7 +215,7 @@ export interface Chart {
  *
  * A financial instrument from any asset class.
  */
-export interface InstrumentElement {
+export interface Instrument {
   /**
    * Any combination of instrument identifiers can be used together to resolve ambiguity, or
    * for a better match. Not all applications will use the same instrument identifiers, which
@@ -225,14 +231,14 @@ export interface InstrumentElement {
    * fields, define a property that makes it clear what the value represents. Doing so will
    * make interpretation easier for the developers of target applications.
    */
-  id: PurpleInstrumentIdentifiers;
+  id: InstrumentIdentifiers;
   /**
    * The `market` map can be used to further specify the instrument and help achieve
    * interoperability between disparate data sources. This is especially useful when using an
    * `id` field that is not globally unique.
    */
-  market?: OrganizationMarket;
-  type: string;
+  market?: Market;
+  type: PurpleInteractionType;
   name?: string;
   [property: string]: any;
 }
@@ -252,7 +258,7 @@ export interface InstrumentElement {
  * fields, define a property that makes it clear what the value represents. Doing so will
  * make interpretation easier for the developers of target applications.
  */
-export interface PurpleInstrumentIdentifiers {
+export interface InstrumentIdentifiers {
   /**
    * <https://www.bloomberg.com/>
    */
@@ -297,7 +303,7 @@ export interface PurpleInstrumentIdentifiers {
  * interoperability between disparate data sources. This is especially useful when using an
  * `id` field that is not globally unique.
  */
-export interface OrganizationMarket {
+export interface Market {
   /**
    * <https://www.bloomberg.com/>
    */
@@ -315,6 +321,16 @@ export interface OrganizationMarket {
    */
   name?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum PurpleInteractionType {
+  Fdc3Instrument = 'fdc3.instrument',
 }
 
 /**
@@ -353,7 +369,7 @@ export interface OrganizationMarket {
  * `"2022-05-12T16:18:03+01:00"`
  * - Times MAY be specified with millisecond precision, e.g. `"2022-05-12T15:18:03.349Z"`
  */
-export interface TimeRangeObject {
+export interface TimeRange {
   /**
    * The end time of the range, encoded according to [ISO
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
@@ -364,10 +380,20 @@ export interface TimeRangeObject {
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
    */
   startTime?: Date;
-  type: string;
+  type: TimeRangeType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum TimeRangeType {
+  Fdc3Timerange = 'fdc3.timerange',
 }
 
 /**
@@ -387,6 +413,16 @@ export enum ChartStyle {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ChartType {
+  Fdc3Chart = 'fdc3.chart',
+}
+
+/**
  * A collection of settings to start a new chat conversation
  */
 export interface ChatInitSettings {
@@ -397,16 +433,16 @@ export interface ChatInitSettings {
   /**
    * Contacts to add to the chat
    */
-  members?: ContactListObject;
+  members?: ContactList;
   /**
    * An initial message to post in the chat when created.
    */
-  message?: MessageObject | string;
+  message?: Message | string;
   /**
    * Option settings that affect the creation of the chat
    */
   options?: ChatOptions;
-  type: string;
+  type: ChatInitSettingsType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -423,12 +459,12 @@ export interface ChatInitSettings {
  * there is not a common standard for such identifiers. Applications can, however, populate
  * this part of the contract with custom identifiers if so desired.
  */
-export interface ContactListObject {
+export interface ContactList {
   /**
    * An array of contact contexts that forms the list.
    */
-  contacts: ContactElement[];
-  type: string;
+  contacts: Contact[];
+  type: ContactListType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -439,12 +475,12 @@ export interface ContactListObject {
  *
  * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface ContactElement {
+export interface Contact {
   /**
    * Identifiers that relate to the Contact represented by this context
    */
-  id: PurpleContactIdentifiers;
-  type: string;
+  id: ContactID;
+  type: FluffyInteractionType;
   name?: string;
   [property: string]: any;
 }
@@ -452,7 +488,7 @@ export interface ContactElement {
 /**
  * Identifiers that relate to the Contact represented by this context
  */
-export interface PurpleContactIdentifiers {
+export interface ContactID {
   /**
    * The email address for the contact
    */
@@ -465,22 +501,42 @@ export interface PurpleContactIdentifiers {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum FluffyInteractionType {
+  Fdc3Contact = 'fdc3.contact',
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ContactListType {
+  Fdc3ContactList = 'fdc3.contactList',
+}
+
+/**
  * A chat message to be sent through an instant messaging application. Can contain one or
  * several text bodies (organized by mime-type, plaintext or markdown), as well as attached
  * entities (either arbitrary file attachments or FDC3 actions to be embedded in the
  * message). To be put inside a ChatInitSettings object.
  */
-export interface MessageObject {
+export interface Message {
   /**
    * A map of string IDs to entities that should be attached to the message, such as an action
    * to perform, a file attachment, or other FDC3 context object.
    */
-  entities?: { [key: string]: PurpleAction };
+  entities?: { [key: string]: EntityValue };
   /**
    * A map of string mime-type to string content
    */
-  text?: PurpleMessageText;
-  type: string;
+  text?: MessageText;
+  type: MessageType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -499,7 +555,7 @@ export interface MessageObject {
  *
  * A File attachment encoded in the form of a data URI
  */
-export interface PurpleAction {
+export interface EntityValue {
   /**
    * An optional target application identifier that should perform the action
    */
@@ -507,7 +563,7 @@ export interface PurpleAction {
   /**
    * A context object with which the action will be performed
    */
-  context?: ContextElement;
+  context?: Context;
   /**
    * Optional Intent to raise to perform the actions. Should reference an intent type name,
    * such as those defined in the FDC3 Standard. If intent is not set then
@@ -519,14 +575,14 @@ export interface PurpleAction {
    * A human readable display name for the action
    */
   title?: string;
-  type: any;
+  type: EntityType;
   id?: { [key: string]: any };
   name?: string;
-  data?: PurpleData;
+  data?: Data;
   [property: string]: any;
 }
 
-export interface PurpleData {
+export interface Data {
   /**
    * A data URI encoding the content of the file to be attached
    */
@@ -539,9 +595,20 @@ export interface PurpleData {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum EntityType {
+  Fdc3Action = 'fdc3.action',
+  Fdc3EntityFileAttachment = 'fdc3.entity.fileAttachment',
+}
+
+/**
  * A map of string mime-type to string content
  */
-export interface PurpleMessageText {
+export interface MessageText {
   /**
    * Markdown encoded content
    */
@@ -551,6 +618,16 @@ export interface PurpleMessageText {
    */
   'text/plain'?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum MessageType {
+  Fdc3Message = 'fdc3.message',
 }
 
 /**
@@ -581,43 +658,28 @@ export interface ChatOptions {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ChatInitSettingsType {
+  Fdc3ChatInitSettings = 'fdc3.chat.initSettings',
+}
+
+/**
  * A context representing a chat message. Typically used to send the message or to
  * pre-populate a message for sending.
  */
 export interface ChatMessage {
-  chatRoom: ChatRoomObject;
+  chatRoom: ChatRoom;
   /**
    * The content of the message to post in the chat when created.
    */
-  message: MessageObject | string;
-  type: string;
+  message: Message | string;
+  type: ChatMessageType;
   id?: { [key: string]: any };
   name?: string;
-  [property: string]: any;
-}
-
-/**
- * Reference to the chat room which could be used to send a message to the room
- */
-export interface ChatRoomObject {
-  /**
-   * Identifier(s) for the chat - currently unstandardized
-   */
-  id: { [key: string]: any };
-  /**
-   * Display name for the chat room
-   */
-  name?: string;
-  /**
-   * The name of the service that hosts the chat
-   */
-  providerName: string;
-  type: string;
-  /**
-   * Universal url to access to the room. It could be opened from a browser, a mobile app,
-   * etc...
-   */
-  url?: string;
   [property: string]: any;
 }
 
@@ -637,13 +699,33 @@ export interface ChatRoom {
    * The name of the service that hosts the chat
    */
   providerName: string;
-  type: string;
+  type: ChatRoomType;
   /**
    * Universal url to access to the room. It could be opened from a browser, a mobile app,
    * etc...
    */
   url?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ChatRoomType {
+  Fdc3ChatRoom = 'fdc3.chat.room',
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ChatMessageType {
+  Fdc3ChatMessage = 'fdc3.chat.message',
 }
 
 /**
@@ -660,8 +742,8 @@ export interface ChatSearchCriteria {
    *
    * Empty search criteria can be supported to allow resetting of filters.
    */
-  criteria: Array<OrganizationObject | string>;
-  type: string;
+  criteria: Array<InstrumentObject | string>;
+  type: ChatSearchCriteriaType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -684,7 +766,7 @@ export interface ChatSearchCriteria {
  *
  * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface OrganizationObject {
+export interface InstrumentObject {
   /**
    * Any combination of instrument identifiers can be used together to resolve ambiguity, or
    * for a better match. Not all applications will use the same instrument identifiers, which
@@ -710,8 +792,8 @@ export interface OrganizationObject {
    * interoperability between disparate data sources. This is especially useful when using an
    * `id` field that is not globally unique.
    */
-  market?: OrganizationMarket;
-  type: string;
+  market?: Market;
+  type: TentacledInteractionType;
   name?: string;
   [property: string]: any;
 }
@@ -793,102 +875,25 @@ export interface Identifiers {
 }
 
 /**
- * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface Contact {
-  /**
-   * Identifiers that relate to the Contact represented by this context
-   */
-  id: FluffyContactIdentifiers;
-  type: string;
-  name?: string;
-  [property: string]: any;
+export enum TentacledInteractionType {
+  Fdc3Contact = 'fdc3.contact',
+  Fdc3Instrument = 'fdc3.instrument',
+  Fdc3Organization = 'fdc3.organization',
 }
 
 /**
- * Identifiers that relate to the Contact represented by this context
- */
-export interface FluffyContactIdentifiers {
-  /**
-   * The email address for the contact
-   */
-  email?: string;
-  /**
-   * FactSet Permanent Identifier representing the contact
-   */
-  FDS_ID?: string;
-  [property: string]: any;
-}
-
-/**
- * A collection of contacts, e.g. for chatting to or calling multiple contacts.
+ * Free text to be used for a keyword search
  *
- * The contact list schema does not explicitly include identifiers in the `id` section, as
- * there is not a common standard for such identifiers. Applications can, however, populate
- * this part of the contract with custom identifiers if so desired.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface ContactList {
-  /**
-   * An array of contact contexts that forms the list.
-   */
-  contacts: ContactElement[];
-  type: string;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
-}
-
-/**
- * The `fdc3.context` type defines the basic contract or "shape" for all data exchanged by
- * FDC3 operations. As such, it is not really meant to be used on its own, but is imported
- * by more specific type definitions (standardized or custom) to provide the structure and
- * properties shared by all FDC3 context data types.
- *
- * The key element of FDC3 context types is their mandatory `type` property, which is used
- * to identify what type of data the object represents, and what shape it has.
- *
- * The FDC3 context type, and all derived types, define the minimum set of fields a context
- * data object of a particular type can be expected to have, but this can always be extended
- * with custom fields as appropriate.
- */
-export interface Context {
-  /**
-   * Context data objects may include a set of equivalent key-value pairs that can be used to
-   * help applications identify and look up the context type they receive in their own domain.
-   * The idea behind this design is that applications can provide as many equivalent
-   * identifiers to a target application as possible, e.g. an instrument may be represented by
-   * an ISIN, CUSIP or Bloomberg identifier.
-   *
-   * Identifiers do not make sense for all types of data, so the `id` property is therefore
-   * optional, but some derived types may choose to require at least one identifier.
-   */
-  id?: { [key: string]: any };
-  /**
-   * Context data objects may include a name property that can be used for more information,
-   * or display purposes. Some derived types may require the name object as mandatory,
-   * depending on use case.
-   */
-  name?: string;
-  /**
-   * The type property is the only _required_ part of the FDC3 context data schema. The FDC3
-   * [API](https://fdc3.finos.org/docs/api/spec) relies on the `type` property being present
-   * to route shared context data appropriately.
-   *
-   * FDC3 [Intents](https://fdc3.finos.org/docs/intents/spec) also register the context data
-   * types they support in an FDC3 [App
-   * Directory](https://fdc3.finos.org/docs/app-directory/overview), used for intent discovery
-   * and routing.
-   *
-   * Standardized FDC3 context types have well-known `type` properties prefixed with the
-   * `fdc3` namespace, e.g. `fdc3.instrument`. For non-standard types, e.g. those defined and
-   * used by a particular organization, the convention is to prefix them with an
-   * organization-specific namespace, e.g. `blackrock.fund`.
-   *
-   * See the [Context Data Specification](https://fdc3.finos.org/docs/context/spec) for more
-   * information about context data types.
-   */
-  type: string;
-  [property: string]: any;
+export enum ChatSearchCriteriaType {
+  Fdc3ChatSearchCriteria = 'fdc3.chat.searchCriteria',
 }
 
 /**
@@ -910,7 +915,7 @@ export interface Context {
  */
 export interface Country {
   id: CountryID;
-  type: string;
+  type: CountryType;
   name?: string;
   [property: string]: any;
 }
@@ -938,6 +943,16 @@ export interface CountryID {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum CountryType {
+  Fdc3Country = 'fdc3.country',
+}
+
+/**
  * A context representing an individual Currency.
  */
 export interface Currency {
@@ -946,7 +961,7 @@ export interface Currency {
    * The name of the currency for display purposes
    */
   name?: string;
-  type: string;
+  type: CurrencyType;
   [property: string]: any;
 }
 
@@ -957,6 +972,16 @@ export interface CurrencyID {
    */
   CURRENCY_ISOCODE?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum CurrencyType {
+  Fdc3Currency = 'fdc3.currency',
 }
 
 /**
@@ -975,7 +1000,7 @@ export interface Email {
    * Body content for the email.
    */
   textBody?: string;
-  type: string;
+  type: EmailType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1003,12 +1028,12 @@ export interface EmailRecipients {
    * Identifiers that relate to the Contact represented by this context
    */
   id?: EmailRecipientsID;
-  type: string;
+  type: EmailRecipientsType;
   name?: string;
   /**
    * An array of contact contexts that forms the list.
    */
-  contacts?: ContactElement[];
+  contacts?: Contact[];
   [property: string]: any;
 }
 
@@ -1028,114 +1053,24 @@ export interface EmailRecipientsID {
 }
 
 /**
- * A financial instrument from any asset class.
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface Instrument {
-  /**
-   * Any combination of instrument identifiers can be used together to resolve ambiguity, or
-   * for a better match. Not all applications will use the same instrument identifiers, which
-   * is why FDC3 allows for multiple to be specified. In general, the more identifiers an
-   * application can provide, the easier it will be to achieve interoperability.
-   *
-   * It is valid to include extra properties and metadata as part of the instrument payload,
-   * but the minimum requirement is for at least one instrument identifier to be provided.
-   *
-   * Try to only use instrument identifiers as intended. E.g. the `ticker` property is meant
-   * for tickers as used by an exchange.
-   * If the identifier you want to share is not a ticker or one of the other standardized
-   * fields, define a property that makes it clear what the value represents. Doing so will
-   * make interpretation easier for the developers of target applications.
-   */
-  id: FluffyInstrumentIdentifiers;
-  /**
-   * The `market` map can be used to further specify the instrument and help achieve
-   * interoperability between disparate data sources. This is especially useful when using an
-   * `id` field that is not globally unique.
-   */
-  market?: PurpleMarket;
-  type: string;
-  name?: string;
-  [property: string]: any;
+export enum EmailRecipientsType {
+  Fdc3Contact = 'fdc3.contact',
+  Fdc3ContactList = 'fdc3.contactList',
 }
 
 /**
- * Any combination of instrument identifiers can be used together to resolve ambiguity, or
- * for a better match. Not all applications will use the same instrument identifiers, which
- * is why FDC3 allows for multiple to be specified. In general, the more identifiers an
- * application can provide, the easier it will be to achieve interoperability.
+ * Free text to be used for a keyword search
  *
- * It is valid to include extra properties and metadata as part of the instrument payload,
- * but the minimum requirement is for at least one instrument identifier to be provided.
- *
- * Try to only use instrument identifiers as intended. E.g. the `ticker` property is meant
- * for tickers as used by an exchange.
- * If the identifier you want to share is not a ticker or one of the other standardized
- * fields, define a property that makes it clear what the value represents. Doing so will
- * make interpretation easier for the developers of target applications.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface FluffyInstrumentIdentifiers {
-  /**
-   * <https://www.bloomberg.com/>
-   */
-  BBG?: string;
-  /**
-   * <https://www.cusip.com/>
-   */
-  CUSIP?: string;
-  /**
-   * <https://www.factset.com/>
-   */
-  FDS_ID?: string;
-  /**
-   * <https://www.openfigi.com/>
-   */
-  FIGI?: string;
-  /**
-   * <https://www.isin.org/>
-   */
-  ISIN?: string;
-  /**
-   * <https://permid.org/>
-   */
-  PERMID?: string;
-  /**
-   * <https://www.refinitiv.com/>
-   */
-  RIC?: string;
-  /**
-   * <https://www.lseg.com/sedol>
-   */
-  SEDOL?: string;
-  /**
-   * Unstandardized stock tickers
-   */
-  ticker?: string;
-  [property: string]: any;
-}
-
-/**
- * The `market` map can be used to further specify the instrument and help achieve
- * interoperability between disparate data sources. This is especially useful when using an
- * `id` field that is not globally unique.
- */
-export interface PurpleMarket {
-  /**
-   * <https://www.bloomberg.com/>
-   */
-  BBG?: string;
-  /**
-   * <https://www.iso.org/iso-3166-country-codes.html>
-   */
-  COUNTRY_ISOALPHA2?: string;
-  /**
-   * <https://en.wikipedia.org/wiki/Market_Identifier_Code>
-   */
-  MIC?: string;
-  /**
-   * Human readable market name
-   */
-  name?: string;
-  [property: string]: any;
+export enum EmailType {
+  Fdc3Email = 'fdc3.email',
 }
 
 /**
@@ -1152,11 +1087,21 @@ export interface InstrumentList {
   /**
    * An array of instrument contexts that forms the list.
    */
-  instruments: InstrumentElement[];
-  type: string;
+  instruments: Instrument[];
+  type: InstrumentListType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum InstrumentListType {
+  Fdc3InstrumentList = 'fdc3.instrumentList',
 }
 
 /**
@@ -1181,7 +1126,7 @@ export interface Interaction {
   /**
    * The contact that initiated the interaction
    */
-  initiator?: ContactElement;
+  initiator?: Contact;
   /**
    * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
    * `'Meeting'` although other string values are permitted.
@@ -1195,12 +1140,12 @@ export interface Interaction {
   /**
    * A list of contacts involved in the interaction
    */
-  participants: ContactListObject;
+  participants: ContactList;
   /**
    * The time range over which the interaction occurred
    */
-  timeRange: TimeRangeObject;
-  type: string;
+  timeRange: TimeRange;
+  type: InteractionType;
   name?: string;
   [property: string]: any;
 }
@@ -1231,92 +1176,13 @@ export interface InteractionID {
 }
 
 /**
- * A chat message to be sent through an instant messaging application. Can contain one or
- * several text bodies (organized by mime-type, plaintext or markdown), as well as attached
- * entities (either arbitrary file attachments or FDC3 actions to be embedded in the
- * message). To be put inside a ChatInitSettings object.
- */
-export interface Message {
-  /**
-   * A map of string IDs to entities that should be attached to the message, such as an action
-   * to perform, a file attachment, or other FDC3 context object.
-   */
-  entities?: { [key: string]: FluffyAction };
-  /**
-   * A map of string mime-type to string content
-   */
-  text?: FluffyMessageText;
-  type: string;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
-}
-
-/**
- * A representation of an FDC3 Action (specified via a Context or Context & Intent) that can
- * be inserted inside another object, for example a chat message.
+ * Free text to be used for a keyword search
  *
- * The action may be completed by calling `fdc3.raiseIntent()` with the specified Intent and
- * Context, or, if only a context is specified, by calling `fdc3.raiseIntentForContext()`
- * (which the Desktop Agent will resolve by presenting the user with a list of available
- * Intents for the Context).
- *
- * Accepts an optional `app` parameter in order to specify a specific app.
- *
- * A File attachment encoded in the form of a data URI
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface FluffyAction {
-  /**
-   * An optional target application identifier that should perform the action
-   */
-  app?: ActionTargetApp;
-  /**
-   * A context object with which the action will be performed
-   */
-  context?: ContextElement;
-  /**
-   * Optional Intent to raise to perform the actions. Should reference an intent type name,
-   * such as those defined in the FDC3 Standard. If intent is not set then
-   * `fdc3.raiseIntentForContext` should be used to perform the action as this will usually
-   * allow the user to choose the intent to raise.
-   */
-  intent?: string;
-  /**
-   * A human readable display name for the action
-   */
-  title?: string;
-  type: any;
-  id?: { [key: string]: any };
-  name?: string;
-  data?: FluffyData;
-  [property: string]: any;
-}
-
-export interface FluffyData {
-  /**
-   * A data URI encoding the content of the file to be attached
-   */
-  dataUri: string;
-  /**
-   * The name of the attached file
-   */
-  name: string;
-  [property: string]: any;
-}
-
-/**
- * A map of string mime-type to string content
- */
-export interface FluffyMessageText {
-  /**
-   * Markdown encoded content
-   */
-  'text/markdown'?: string;
-  /**
-   * Plain text encoded content.
-   */
-  'text/plain'?: string;
-  [property: string]: any;
+export enum InteractionType {
+  Fdc3Interaction = 'fdc3.interaction',
 }
 
 /**
@@ -1334,7 +1200,36 @@ export interface FluffyMessageText {
  * for a lack of context, for example in their intent metadata in an app directory.
  */
 export interface Nothing {
-  type: string;
+  type: NothingType;
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum NothingType {
+  Fdc3Nothing = 'fdc3.nothing',
+}
+
+/**
+ * @experimental A list of orders. Use this type for use cases that require not just a
+ * single order, but multiple.
+ *
+ * The OrderList schema does not explicitly include identifiers in the id section, as there
+ * is not a common standard for such identifiers. Applications can, however, populate this
+ * part of the contract with custom identifiers if so desired.
+ */
+export interface OrderList {
+  /**
+   * An array of order contexts that forms the list.
+   */
+  orders: Order[];
+  type: OrderListType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1356,7 +1251,7 @@ export interface Order {
    * Optional additional details about the order, which may include a product element that is
    * an, as yet undefined but extensible, Context
    */
-  details?: PurpleOrderDetails;
+  details?: OrderDetails;
   /**
    * One or more identifiers that refer to the order in an OMS, EMS or related system.
    * Specific key names for systems are expected to be standardized in future.
@@ -1366,7 +1261,7 @@ export interface Order {
    * An optional human-readable summary of the order.
    */
   name?: string;
-  type: string;
+  type: OrderType;
   [property: string]: any;
 }
 
@@ -1374,8 +1269,8 @@ export interface Order {
  * Optional additional details about the order, which may include a product element that is
  * an, as yet undefined but extensible, Context
  */
-export interface PurpleOrderDetails {
-  product?: ProductObject;
+export interface OrderDetails {
+  product?: Product;
   [property: string]: any;
 }
 
@@ -1392,7 +1287,7 @@ export interface PurpleOrderDetails {
  * not a common standard for such identifiers. Applications can, however, populate this part
  * of the contract with custom identifiers if so desired.
  */
-export interface ProductObject {
+export interface Product {
   /**
    * One or more identifiers that refer to the product. Specific key names for systems are
    * expected to be standardized in future.
@@ -1401,71 +1296,43 @@ export interface ProductObject {
   /**
    * financial instrument that relates to the definition of this product
    */
-  instrument?: InstrumentElement;
+  instrument?: Instrument;
   /**
    * A human-readable summary of the product.
    */
   name?: string;
-  type: string;
+  type: ProductType;
   [property: string]: any;
 }
 
 /**
- * @experimental A list of orders. Use this type for use cases that require not just a
- * single order, but multiple.
+ * Free text to be used for a keyword search
  *
- * The OrderList schema does not explicitly include identifiers in the id section, as there
- * is not a common standard for such identifiers. Applications can, however, populate this
- * part of the contract with custom identifiers if so desired.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface OrderList {
-  /**
-   * An array of order contexts that forms the list.
-   */
-  orders: OrderElement[];
-  type: string;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
+export enum ProductType {
+  Fdc3Product = 'fdc3.product',
 }
 
 /**
- * @experimental context type representing an order. To be used with OMS and EMS systems.
+ * Free text to be used for a keyword search
  *
- * This type currently only defines a required `id` field, which should provide a reference
- * to the order in one or more systems, an optional human readable `name` field to be used
- * to summarize the order and an optional `details` field that may be used to provide
- * additional detail about the order, including a context representing a `product`, which
- * may be extended with arbitrary properties. The `details.product` field is currently typed
- * as a unspecified Context type, but both `details` and `details.product` are expected to
- * be standardized in future.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface OrderElement {
-  /**
-   * Optional additional details about the order, which may include a product element that is
-   * an, as yet undefined but extensible, Context
-   */
-  details?: FluffyOrderDetails;
-  /**
-   * One or more identifiers that refer to the order in an OMS, EMS or related system.
-   * Specific key names for systems are expected to be standardized in future.
-   */
-  id: { [key: string]: string };
-  /**
-   * An optional human-readable summary of the order.
-   */
-  name?: string;
-  type: string;
-  [property: string]: any;
+export enum OrderType {
+  Fdc3Order = 'fdc3.order',
 }
 
 /**
- * Optional additional details about the order, which may include a product element that is
- * an, as yet undefined but extensible, Context
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface FluffyOrderDetails {
-  product?: ProductObject;
-  [property: string]: any;
+export enum OrderListType {
+  Fdc3OrderList = 'fdc3.orderList',
 }
 
 /**
@@ -1480,7 +1347,7 @@ export interface Organization {
    * Identifiers for the organization, at least one must be provided.
    */
   id: OrganizationIdentifiers;
-  type: string;
+  type: StickyInteractionType;
   name?: string;
   [property: string]: any;
 }
@@ -1508,6 +1375,16 @@ export interface OrganizationIdentifiers {
 }
 
 /**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum StickyInteractionType {
+  Fdc3Organization = 'fdc3.organization',
+}
+
+/**
  * A financial portfolio made up of multiple positions (holdings) in several instruments.
  * Contrast this with e.g. the [InstrumentList](InstrumentList) type, which is just a list
  * of instruments.
@@ -1526,34 +1403,8 @@ export interface Portfolio {
   /**
    * The List of Positions which make up the Portfolio
    */
-  positions: PositionElement[];
-  type: string;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
-}
-
-/**
- * A financial position made up of an instrument and a holding in that instrument. This type
- * is a good example of how new context types can be composed from existing types.
- *
- * In this case, the instrument and the holding amount for that instrument are required
- * values.
- *
- * The [Position](Position) type goes hand-in-hand with the [Portfolio](Portfolio) type,
- * which represents multiple holdings in a combination of instruments.
- *
- * The position schema does not explicitly include identifiers in the `id` section, as there
- * is not a common standard for such identifiers. Applications can, however, populate this
- * part of the contract with custom identifiers if so desired.
- */
-export interface PositionElement {
-  /**
-   * The amount of the holding, e.g. a number of shares
-   */
-  holding: number;
-  instrument: InstrumentElement;
-  type: string;
+  positions: Position[];
+  type: PortfolioType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1578,86 +1429,47 @@ export interface Position {
    * The amount of the holding, e.g. a number of shares
    */
   holding: number;
-  instrument: InstrumentElement;
-  type: string;
+  instrument: Instrument;
+  type: PositionType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
 }
 
 /**
- * @experimental context type representing a tradable product. To be used with OMS and EMS
- * systems.
+ * Free text to be used for a keyword search
  *
- * This type is currently only loosely defined as an extensible context object, with an
- * optional instrument field.
- *
- * The Product schema does not explicitly include identifiers in the id section, as there is
- * not a common standard for such identifiers. Applications can, however, populate this part
- * of the contract with custom identifiers if so desired.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface Product {
-  /**
-   * One or more identifiers that refer to the product. Specific key names for systems are
-   * expected to be standardized in future.
-   */
-  id: { [key: string]: string };
-  /**
-   * financial instrument that relates to the definition of this product
-   */
-  instrument?: InstrumentElement;
-  /**
-   * A human-readable summary of the product.
-   */
-  name?: string;
-  type: string;
-  [property: string]: any;
+export enum PositionType {
+  Fdc3Position = 'fdc3.position',
 }
 
 /**
- * A context representing a period of time. Any user interfaces that represent or visualize
- * events or activity over time can be filtered or focused on a particular time period,
- * e.g.:
+ * Free text to be used for a keyword search
  *
- * - A pricing chart
- * - A trade blotter
- * - A record of client contact/activity in a CRM
- *
- * Example use cases:
- *
- * - User may want to view pricing/trades/customer activity for a security over a particular
- * time period, the time range might be specified as the context for the `ViewChart` intent
- * OR it might be embedded in another context (e.g. a context representing a chart to plot).
- * - User filters a visualization (e.g. a pricing chart) to show a particular period, the
- * `TimeRange` is broadcast and other visualizations (e.g. a heatmap of activity by
- * instrument, or industry sector etc.) receive it and filter themselves to show data over
- * the same range.
- *
- * Notes:
- *
- * - A `TimeRange` may be closed (i.e. `startTime` and `endTime` are both known) or open
- * (i.e. only one of `startTime` or `endTime` is known).
- * - Ranges corresponding to dates (e.g. `2022-05-12` to `2022-05-19`) should be specified
- * using times as this prevents issues with timezone conversions and inclusive/exclusive
- * date ranges.
- * - String fields representing times are encoded according to [ISO
- * 8601-1:2019](https://www.iso.org/standard/70907.html).
- * - A timezone indicator should be specified, e.g. `"2022-05-12T15:18:03Z"` or
- * `"2022-05-12T16:18:03+01:00"`
- * - Times MAY be specified with millisecond precision, e.g. `"2022-05-12T15:18:03.349Z"`
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface TimeRange {
+export enum PortfolioType {
+  Fdc3Portfolio = 'fdc3.portfolio',
+}
+
+/**
+ * @experimental A list of trades. Use this type for use cases that require not just a
+ * single trade, but multiple.
+ *
+ * The TradeList schema does not explicitly include identifiers in the id section, as there
+ * is not a common standard for such identifiers. Applications can, however, populate this
+ * part of the contract with custom identifiers if so desired.
+ */
+export interface TradeList {
   /**
-   * The end time of the range, encoded according to [ISO
-   * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
+   * An array of trade contexts that forms the list.
    */
-  endTime?: Date;
-  /**
-   * The start time of the range, encoded according to [ISO
-   * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
-   */
-  startTime?: Date;
-  type: string;
+  trades: Trade[];
+  type: TradeListType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1689,59 +1501,29 @@ export interface Trade {
   /**
    * A product that is the subject of th trade.
    */
-  product: ProductObject;
-  type: string;
+  product: Product;
+  type: TradeType;
   [property: string]: any;
 }
 
 /**
- * @experimental A list of trades. Use this type for use cases that require not just a
- * single trade, but multiple.
+ * Free text to be used for a keyword search
  *
- * The TradeList schema does not explicitly include identifiers in the id section, as there
- * is not a common standard for such identifiers. Applications can, however, populate this
- * part of the contract with custom identifiers if so desired.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface TradeList {
-  /**
-   * An array of trade contexts that forms the list.
-   */
-  trades: TradeElement[];
-  type: string;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
+export enum TradeType {
+  Fdc3Trade = 'fdc3.trade',
 }
 
 /**
- * @experimental context type representing a trade. To be used with execution systems.
+ * Free text to be used for a keyword search
  *
- * This type currently only defines a required `id` field, which should provide a reference
- * to the trade in one or more systems, an optional human readable `name` field to be used
- * to summarize the trade and a required `product` field that may be used to provide
- * additional detail about the trade, which is currently typed as a unspecified Context
- * type, but `product` is expected to be standardized in future.
- *
- * The Trade schema does not explicitly include identifiers in the id section, as there is
- * not a common standard for such identifiers. Applications can, however, populate this part
- * of the contract with custom identifiers if so desired.
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
  */
-export interface TradeElement {
-  /**
-   * One or more identifiers that refer to the trade in an OMS, EMS or related system.
-   * Specific key names for systems are expected to be standardized in future.
-   */
-  id: { [key: string]: string };
-  /**
-   * A human-readable summary of the trade.
-   */
-  name?: string;
-  /**
-   * A product that is the subject of th trade.
-   */
-  product: ProductObject;
-  type: string;
-  [property: string]: any;
+export enum TradeListType {
+  Fdc3TradeList = 'fdc3.tradeList',
 }
 
 /**
@@ -1754,12 +1536,12 @@ export interface TransactionResult {
   /**
    * A context object returned by the transaction, possibly with updated data.
    */
-  context?: ContextElement;
+  context?: Context;
   /**
    * The status of the transaction being reported.
    */
   status: TransactionStatus;
-  type: string;
+  type: TransactionResultType;
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1773,6 +1555,16 @@ export enum TransactionStatus {
   Deleted = 'Deleted',
   Failed = 'Failed',
   Updated = 'Updated',
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum TransactionResultType {
+  Fdc3TransactionResult = 'fdc3.transactionResult',
 }
 
 /**
@@ -1793,7 +1585,7 @@ export interface Valuation {
    * The price per unit the the valuation is based on.
    */
   price?: number;
-  type: string;
+  type: ValuationType;
   /**
    * The time at which the valuation was performed, encoded according to [ISO
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator included.
@@ -1806,6 +1598,16 @@ export interface Valuation {
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+export enum ValuationType {
+  Fdc3Valuation = 'fdc3.valuation',
 }
 
 // Converts JSON strings to/from your types
@@ -2206,10 +2008,10 @@ const typeMap: any = {
   Action: o(
     [
       { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
-      { json: 'context', js: 'context', typ: r('ContextElement') },
+      { json: 'context', js: 'context', typ: r('Context') },
       { json: 'intent', js: 'intent', typ: u(undefined, '') },
       { json: 'title', js: 'title', typ: '' },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ActionType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2223,7 +2025,7 @@ const typeMap: any = {
     ],
     'any'
   ),
-  ContextElement: o(
+  Context: o(
     [
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
@@ -2233,26 +2035,26 @@ const typeMap: any = {
   ),
   Chart: o(
     [
-      { json: 'instruments', js: 'instruments', typ: a(r('InstrumentElement')) },
-      { json: 'otherConfig', js: 'otherConfig', typ: u(undefined, a(r('ContextElement'))) },
-      { json: 'range', js: 'range', typ: u(undefined, r('TimeRangeObject')) },
+      { json: 'instruments', js: 'instruments', typ: a(r('Instrument')) },
+      { json: 'otherConfig', js: 'otherConfig', typ: u(undefined, a(r('Context'))) },
+      { json: 'range', js: 'range', typ: u(undefined, r('TimeRange')) },
       { json: 'style', js: 'style', typ: u(undefined, r('ChartStyle')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ChartType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  InstrumentElement: o(
+  Instrument: o(
     [
-      { json: 'id', js: 'id', typ: r('PurpleInstrumentIdentifiers') },
-      { json: 'market', js: 'market', typ: u(undefined, r('OrganizationMarket')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'id', js: 'id', typ: r('InstrumentIdentifiers') },
+      { json: 'market', js: 'market', typ: u(undefined, r('Market')) },
+      { json: 'type', js: 'type', typ: r('PurpleInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  PurpleInstrumentIdentifiers: o(
+  InstrumentIdentifiers: o(
     [
       { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
       { json: 'CUSIP', js: 'CUSIP', typ: u(undefined, '') },
@@ -2266,7 +2068,7 @@ const typeMap: any = {
     ],
     'any'
   ),
-  OrganizationMarket: o(
+  Market: o(
     [
       { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
       { json: 'COUNTRY_ISOALPHA2', js: 'COUNTRY_ISOALPHA2', typ: u(undefined, '') },
@@ -2275,11 +2077,11 @@ const typeMap: any = {
     ],
     'any'
   ),
-  TimeRangeObject: o(
+  TimeRange: o(
     [
       { json: 'endTime', js: 'endTime', typ: u(undefined, Date) },
       { json: 'startTime', js: 'startTime', typ: u(undefined, Date) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('TimeRangeType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2288,70 +2090,70 @@ const typeMap: any = {
   ChatInitSettings: o(
     [
       { json: 'chatName', js: 'chatName', typ: u(undefined, '') },
-      { json: 'members', js: 'members', typ: u(undefined, r('ContactListObject')) },
-      { json: 'message', js: 'message', typ: u(undefined, u(r('MessageObject'), '')) },
+      { json: 'members', js: 'members', typ: u(undefined, r('ContactList')) },
+      { json: 'message', js: 'message', typ: u(undefined, u(r('Message'), '')) },
       { json: 'options', js: 'options', typ: u(undefined, r('ChatOptions')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ChatInitSettingsType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  ContactListObject: o(
+  ContactList: o(
     [
-      { json: 'contacts', js: 'contacts', typ: a(r('ContactElement')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'contacts', js: 'contacts', typ: a(r('Contact')) },
+      { json: 'type', js: 'type', typ: r('ContactListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  ContactElement: o(
+  Contact: o(
     [
-      { json: 'id', js: 'id', typ: r('PurpleContactIdentifiers') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'id', js: 'id', typ: r('ContactID') },
+      { json: 'type', js: 'type', typ: r('FluffyInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  PurpleContactIdentifiers: o(
+  ContactID: o(
     [
       { json: 'email', js: 'email', typ: u(undefined, '') },
       { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
     ],
     'any'
   ),
-  MessageObject: o(
+  Message: o(
     [
-      { json: 'entities', js: 'entities', typ: u(undefined, m(r('PurpleAction'))) },
-      { json: 'text', js: 'text', typ: u(undefined, r('PurpleMessageText')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'entities', js: 'entities', typ: u(undefined, m(r('EntityValue'))) },
+      { json: 'text', js: 'text', typ: u(undefined, r('MessageText')) },
+      { json: 'type', js: 'type', typ: r('MessageType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  PurpleAction: o(
+  EntityValue: o(
     [
       { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
       { json: 'intent', js: 'intent', typ: u(undefined, '') },
       { json: 'title', js: 'title', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: 'any' },
+      { json: 'type', js: 'type', typ: r('EntityType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'data', js: 'data', typ: u(undefined, r('PurpleData')) },
+      { json: 'data', js: 'data', typ: u(undefined, r('Data')) },
     ],
     'any'
   ),
-  PurpleData: o(
+  Data: o(
     [
       { json: 'dataUri', js: 'dataUri', typ: '' },
       { json: 'name', js: 'name', typ: '' },
     ],
     'any'
   ),
-  PurpleMessageText: o(
+  MessageText: o(
     [
       { json: 'text/markdown', js: 'text/markdown', typ: u(undefined, '') },
       { json: 'text/plain', js: 'text/plain', typ: u(undefined, '') },
@@ -2370,21 +2172,11 @@ const typeMap: any = {
   ),
   ChatMessage: o(
     [
-      { json: 'chatRoom', js: 'chatRoom', typ: r('ChatRoomObject') },
-      { json: 'message', js: 'message', typ: u(r('MessageObject'), '') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'chatRoom', js: 'chatRoom', typ: r('ChatRoom') },
+      { json: 'message', js: 'message', typ: u(r('Message'), '') },
+      { json: 'type', js: 'type', typ: r('ChatMessageType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  ChatRoomObject: o(
-    [
-      { json: 'id', js: 'id', typ: m('any') },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'providerName', js: 'providerName', typ: '' },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'url', js: 'url', typ: u(undefined, '') },
     ],
     'any'
   ),
@@ -2393,25 +2185,25 @@ const typeMap: any = {
       { json: 'id', js: 'id', typ: m('any') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
       { json: 'providerName', js: 'providerName', typ: '' },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ChatRoomType') },
       { json: 'url', js: 'url', typ: u(undefined, '') },
     ],
     'any'
   ),
   ChatSearchCriteria: o(
     [
-      { json: 'criteria', js: 'criteria', typ: a(u(r('OrganizationObject'), '')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'criteria', js: 'criteria', typ: a(u(r('InstrumentObject'), '')) },
+      { json: 'type', js: 'type', typ: r('ChatSearchCriteriaType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  OrganizationObject: o(
+  InstrumentObject: o(
     [
       { json: 'id', js: 'id', typ: r('Identifiers') },
-      { json: 'market', js: 'market', typ: u(undefined, r('OrganizationMarket')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'market', js: 'market', typ: u(undefined, r('Market')) },
+      { json: 'type', js: 'type', typ: r('TentacledInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
@@ -2432,42 +2224,10 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Contact: o(
-    [
-      { json: 'id', js: 'id', typ: r('FluffyContactIdentifiers') },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  FluffyContactIdentifiers: o(
-    [
-      { json: 'email', js: 'email', typ: u(undefined, '') },
-      { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  ContactList: o(
-    [
-      { json: 'contacts', js: 'contacts', typ: a(r('ContactElement')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  Context: o(
-    [
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
-    ],
-    'any'
-  ),
   Country: o(
     [
       { json: 'id', js: 'id', typ: r('CountryID') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('CountryType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
@@ -2485,7 +2245,7 @@ const typeMap: any = {
     [
       { json: 'id', js: 'id', typ: r('CurrencyID') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('CurrencyType') },
     ],
     'any'
   ),
@@ -2495,7 +2255,7 @@ const typeMap: any = {
       { json: 'recipients', js: 'recipients', typ: r('EmailRecipients') },
       { json: 'subject', js: 'subject', typ: u(undefined, '') },
       { json: 'textBody', js: 'textBody', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('EmailType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2504,9 +2264,9 @@ const typeMap: any = {
   EmailRecipients: o(
     [
       { json: 'id', js: 'id', typ: u(undefined, r('EmailRecipientsID')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('EmailRecipientsType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'contacts', js: 'contacts', typ: u(undefined, a(r('ContactElement'))) },
+      { json: 'contacts', js: 'contacts', typ: u(undefined, a(r('Contact'))) },
     ],
     'any'
   ),
@@ -2517,42 +2277,10 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Instrument: o(
-    [
-      { json: 'id', js: 'id', typ: r('FluffyInstrumentIdentifiers') },
-      { json: 'market', js: 'market', typ: u(undefined, r('PurpleMarket')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  FluffyInstrumentIdentifiers: o(
-    [
-      { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
-      { json: 'CUSIP', js: 'CUSIP', typ: u(undefined, '') },
-      { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
-      { json: 'FIGI', js: 'FIGI', typ: u(undefined, '') },
-      { json: 'ISIN', js: 'ISIN', typ: u(undefined, '') },
-      { json: 'PERMID', js: 'PERMID', typ: u(undefined, '') },
-      { json: 'RIC', js: 'RIC', typ: u(undefined, '') },
-      { json: 'SEDOL', js: 'SEDOL', typ: u(undefined, '') },
-      { json: 'ticker', js: 'ticker', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  PurpleMarket: o(
-    [
-      { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
-      { json: 'COUNTRY_ISOALPHA2', js: 'COUNTRY_ISOALPHA2', typ: u(undefined, '') },
-      { json: 'MIC', js: 'MIC', typ: u(undefined, '') },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
   InstrumentList: o(
     [
-      { json: 'instruments', js: 'instruments', typ: a(r('InstrumentElement')) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'instruments', js: 'instruments', typ: a(r('Instrument')) },
+      { json: 'type', js: 'type', typ: r('InstrumentListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2562,12 +2290,12 @@ const typeMap: any = {
     [
       { json: 'description', js: 'description', typ: '' },
       { json: 'id', js: 'id', typ: u(undefined, r('InteractionID')) },
-      { json: 'initiator', js: 'initiator', typ: u(undefined, r('ContactElement')) },
+      { json: 'initiator', js: 'initiator', typ: u(undefined, r('Contact')) },
       { json: 'interactionType', js: 'interactionType', typ: '' },
       { json: 'origin', js: 'origin', typ: u(undefined, '') },
-      { json: 'participants', js: 'participants', typ: r('ContactListObject') },
-      { json: 'timeRange', js: 'timeRange', typ: r('TimeRangeObject') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'participants', js: 'participants', typ: r('ContactList') },
+      { json: 'timeRange', js: 'timeRange', typ: r('TimeRange') },
+      { json: 'type', js: 'type', typ: r('InteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
@@ -2580,46 +2308,18 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Message: o(
-    [
-      { json: 'entities', js: 'entities', typ: u(undefined, m(r('FluffyAction'))) },
-      { json: 'text', js: 'text', typ: u(undefined, r('FluffyMessageText')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  FluffyAction: o(
-    [
-      { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
-      { json: 'intent', js: 'intent', typ: u(undefined, '') },
-      { json: 'title', js: 'title', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: 'any' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'data', js: 'data', typ: u(undefined, r('FluffyData')) },
-    ],
-    'any'
-  ),
-  FluffyData: o(
-    [
-      { json: 'dataUri', js: 'dataUri', typ: '' },
-      { json: 'name', js: 'name', typ: '' },
-    ],
-    'any'
-  ),
-  FluffyMessageText: o(
-    [
-      { json: 'text/markdown', js: 'text/markdown', typ: u(undefined, '') },
-      { json: 'text/plain', js: 'text/plain', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
   Nothing: o(
     [
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('NothingType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  OrderList: o(
+    [
+      { json: 'orders', js: 'orders', typ: a(r('Order')) },
+      { json: 'type', js: 'type', typ: r('OrderListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2627,46 +2327,27 @@ const typeMap: any = {
   ),
   Order: o(
     [
-      { json: 'details', js: 'details', typ: u(undefined, r('PurpleOrderDetails')) },
+      { json: 'details', js: 'details', typ: u(undefined, r('OrderDetails')) },
       { json: 'id', js: 'id', typ: m('') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('OrderType') },
     ],
     'any'
   ),
-  PurpleOrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('ProductObject')) }], 'any'),
-  ProductObject: o(
+  OrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('Product')) }], 'any'),
+  Product: o(
     [
       { json: 'id', js: 'id', typ: m('') },
-      { json: 'instrument', js: 'instrument', typ: u(undefined, r('InstrumentElement')) },
+      { json: 'instrument', js: 'instrument', typ: u(undefined, r('Instrument')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ProductType') },
     ],
     'any'
   ),
-  OrderList: o(
-    [
-      { json: 'orders', js: 'orders', typ: a(r('OrderElement')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  OrderElement: o(
-    [
-      { json: 'details', js: 'details', typ: u(undefined, r('FluffyOrderDetails')) },
-      { json: 'id', js: 'id', typ: m('') },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
-    ],
-    'any'
-  ),
-  FluffyOrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('ProductObject')) }], 'any'),
   Organization: o(
     [
       { json: 'id', js: 'id', typ: r('OrganizationIdentifiers') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('StickyInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
@@ -2681,18 +2362,8 @@ const typeMap: any = {
   ),
   Portfolio: o(
     [
-      { json: 'positions', js: 'positions', typ: a(r('PositionElement')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  PositionElement: o(
-    [
-      { json: 'holding', js: 'holding', typ: 3.14 },
-      { json: 'instrument', js: 'instrument', typ: r('InstrumentElement') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'positions', js: 'positions', typ: a(r('Position')) },
+      { json: 'type', js: 'type', typ: r('PortfolioType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2701,27 +2372,17 @@ const typeMap: any = {
   Position: o(
     [
       { json: 'holding', js: 'holding', typ: 3.14 },
-      { json: 'instrument', js: 'instrument', typ: r('InstrumentElement') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'instrument', js: 'instrument', typ: r('Instrument') },
+      { json: 'type', js: 'type', typ: r('PositionType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  Product: o(
+  TradeList: o(
     [
-      { json: 'id', js: 'id', typ: m('') },
-      { json: 'instrument', js: 'instrument', typ: u(undefined, r('InstrumentElement')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'type', js: 'type', typ: '' },
-    ],
-    'any'
-  ),
-  TimeRange: o(
-    [
-      { json: 'endTime', js: 'endTime', typ: u(undefined, Date) },
-      { json: 'startTime', js: 'startTime', typ: u(undefined, Date) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'trades', js: 'trades', typ: a(r('Trade')) },
+      { json: 'type', js: 'type', typ: r('TradeListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2731,34 +2392,16 @@ const typeMap: any = {
     [
       { json: 'id', js: 'id', typ: m('') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'product', js: 'product', typ: r('ProductObject') },
-      { json: 'type', js: 'type', typ: '' },
-    ],
-    'any'
-  ),
-  TradeList: o(
-    [
-      { json: 'trades', js: 'trades', typ: a(r('TradeElement')) },
-      { json: 'type', js: 'type', typ: '' },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
-  TradeElement: o(
-    [
-      { json: 'id', js: 'id', typ: m('') },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'product', js: 'product', typ: r('ProductObject') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'product', js: 'product', typ: r('Product') },
+      { json: 'type', js: 'type', typ: r('TradeType') },
     ],
     'any'
   ),
   TransactionResult: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
       { json: 'status', js: 'status', typ: r('TransactionStatus') },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('TransactionResultType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2769,7 +2412,7 @@ const typeMap: any = {
       { json: 'CURRENCY_ISOCODE', js: 'CURRENCY_ISOCODE', typ: '' },
       { json: 'expiryTime', js: 'expiryTime', typ: u(undefined, Date) },
       { json: 'price', js: 'price', typ: u(undefined, 3.14) },
-      { json: 'type', js: 'type', typ: '' },
+      { json: 'type', js: 'type', typ: r('ValuationType') },
       { json: 'valuationTime', js: 'valuationTime', typ: u(undefined, Date) },
       { json: 'value', js: 'value', typ: 3.14 },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
@@ -2777,6 +2420,36 @@ const typeMap: any = {
     ],
     'any'
   ),
+  ActionType: ['fdc3.action'],
+  PurpleInteractionType: ['fdc3.instrument'],
+  TimeRangeType: ['fdc3.timerange'],
   ChartStyle: ['bar', 'candle', 'custom', 'heatmap', 'histogram', 'line', 'mountain', 'pie', 'scatter', 'stacked-bar'],
+  ChartType: ['fdc3.chart'],
+  FluffyInteractionType: ['fdc3.contact'],
+  ContactListType: ['fdc3.contactList'],
+  EntityType: ['fdc3.action', 'fdc3.entity.fileAttachment'],
+  MessageType: ['fdc3.message'],
+  ChatInitSettingsType: ['fdc3.chat.initSettings'],
+  ChatRoomType: ['fdc3.chat.room'],
+  ChatMessageType: ['fdc3.chat.message'],
+  TentacledInteractionType: ['fdc3.contact', 'fdc3.instrument', 'fdc3.organization'],
+  ChatSearchCriteriaType: ['fdc3.chat.searchCriteria'],
+  CountryType: ['fdc3.country'],
+  CurrencyType: ['fdc3.currency'],
+  EmailRecipientsType: ['fdc3.contact', 'fdc3.contactList'],
+  EmailType: ['fdc3.email'],
+  InstrumentListType: ['fdc3.instrumentList'],
+  InteractionType: ['fdc3.interaction'],
+  NothingType: ['fdc3.nothing'],
+  ProductType: ['fdc3.product'],
+  OrderType: ['fdc3.order'],
+  OrderListType: ['fdc3.orderList'],
+  StickyInteractionType: ['fdc3.organization'],
+  PositionType: ['fdc3.position'],
+  PortfolioType: ['fdc3.portfolio'],
+  TradeType: ['fdc3.trade'],
+  TradeListType: ['fdc3.tradeList'],
   TransactionStatus: ['Created', 'Deleted', 'Failed', 'Updated'],
+  TransactionResultType: ['fdc3.transactionResult'],
+  ValuationType: ['fdc3.valuation'],
 };

--- a/website/static/schemas/2.1/api/api.schema.json
+++ b/website/static/schemas/2.1/api/api.schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://fdc3.finos.org/schemas/2.1/api/api.schema.json",
+    "title": "FDC3 Desktop Agent API Schema",
     "definitions": {
         "AppIdentifier": {
             "description": "Identifies an application, or instance of an application, and is used to target FDC3 API calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application instances.\n\nWill always include at least an `appId` field, which uniquely identifies a specific app.\n\nIf the `instanceId` field is set then the `AppMetadata` object represents a specific instance of the application that may be addressed using that Id.",

--- a/website/static/schemas/2.1/bridging/agentRequest.schema.json
+++ b/website/static/schemas/2.1/bridging/agentRequest.schema.json
@@ -17,6 +17,7 @@
         "openRequest",
         "PrivateChannel.broadcast",
         "PrivateChannel.eventListenerAdded",
+        "PrivateChannel.eventListenerRemoved",
         "PrivateChannel.onAddContextListener",
         "PrivateChannel.onDisconnect",
         "PrivateChannel.onUnsubscribe",

--- a/website/static/schemas/2.1/bridging/common.schema.json
+++ b/website/static/schemas/2.1/bridging/common.schema.json
@@ -112,7 +112,8 @@
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
     },
     "PrivateChannelEventListenerTypes": {
-      "title": "",
+      "title": "Private Channel Event Listener Types",
+      "description": "Event listener type names for Private Channel events",
       "type": "string",
       "enum": [
         "onAddContextListener",

--- a/website/static/schemas/next/api/api.schema.json
+++ b/website/static/schemas/next/api/api.schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://fdc3.finos.org/schemas/next/api/api.schema.json",
+    "title": "FDC3 Desktop Agent API Schema",
     "definitions": {
         "AppIdentifier": {
             "description": "Identifies an application, or instance of an application, and is used to target FDC3 API calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application instances.\n\nWill always include at least an `appId` field, which uniquely identifies a specific app.\n\nIf the `instanceId` field is set then the `AppMetadata` object represents a specific instance of the application that may be addressed using that Id.",

--- a/website/static/schemas/next/bridging/agentRequest.schema.json
+++ b/website/static/schemas/next/bridging/agentRequest.schema.json
@@ -17,6 +17,7 @@
         "openRequest",
         "PrivateChannel.broadcast",
         "PrivateChannel.eventListenerAdded",
+        "PrivateChannel.eventListenerRemoved",
         "PrivateChannel.onAddContextListener",
         "PrivateChannel.onDisconnect",
         "PrivateChannel.onUnsubscribe",

--- a/website/static/schemas/next/bridging/common.schema.json
+++ b/website/static/schemas/next/bridging/common.schema.json
@@ -112,7 +112,8 @@
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
     },
     "PrivateChannelEventListenerTypes": {
-      "title": "",
+      "title": "Private Channel Event Listener Types",
+      "description": "Event listener type names for Private Channel events",
       "type": "string",
       "enum": [
         "onAddContextListener",


### PR DESCRIPTION
While trying to generate Zod schemas for bridging messages I upgraded quicktype (which now does a better job of controlling the const type fields in COntext and bridging message types via single value enums, and in a future version, via const declarations see https://github.com/glideapps/quicktype/pull/2314).

However, I then ran into an issue with one of the bridging schemas, whose message type was missing from the enumeration of all message types. This PR: 
- applies the quicktype update, 
- corrects the missing message type
- regenerates the context and bridging types exposed in the NPM module
- updates the schemas files in 2.1 and next with the correction.