### PR TITLE
Fixing a build error introduced by quicktype enums

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.2",
+  "version": "2.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/fdc3",
-      "version": "2.1.0-beta.2",
+      "version": "2.1.0-beta.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "husky": "^4.3.0",
@@ -53,15 +53,87 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -104,12 +176,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-      "integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.4",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -218,9 +290,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -239,25 +311,25 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz",
-      "integrity": "sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.20.7",
-        "@babel/types": "^7.21.0"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -387,30 +459,30 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -455,13 +527,13 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -540,9 +612,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-      "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1691,33 +1763,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-      "integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.4",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.21.0",
-        "@babel/helper-hoist-variables": "^7.18.6",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.4",
-        "@babel/types": "^7.21.4",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1726,13 +1798,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
-        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "tsdx build",
     "test": "tsdx test --verbose",
     "lint": "tsdx lint src/api test",
-    "preprepare": "npm run typegen && npm run typegen-bridging",
+    "disabled-preprepare": "npm run typegen && npm run typegen-bridging",
     "prepare": "tsdx build",
     "typegen": "node s2tQuicktypeUtil.js schemas/context src/context/ContextTypes.ts && tsdx lint src/context/ --fix",
     "typegen-bridging": "node s2tQuicktypeUtil.js schemas/api schemas/bridging schemas/context/context.schema.json src/bridging/BridgingTypes.ts && tsdx lint src/bridging/ --fix"

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -76,6 +76,54 @@
 // match the expected interface, even if the JSON is valid.
 
 /**
+ * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
+ */
+export interface BaseImplementationMetadata {
+  /**
+   * The version number of the FDC3 specification that the implementation provides.
+   * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
+   */
+  fdc3Version: string;
+  /**
+   * Metadata indicating whether the Desktop Agent implements optional features of
+   * the Desktop Agent API.
+   */
+  optionalFeatures: BaseImplementationMetadataOptionalFeatures;
+  /**
+   * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
+   * OpenFin etc.).
+   */
+  provider: string;
+  /**
+   * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
+   */
+  providerVersion?: string;
+}
+
+/**
+ * Metadata indicating whether the Desktop Agent implements optional features of
+ * the Desktop Agent API.
+ */
+export interface BaseImplementationMetadataOptionalFeatures {
+  /**
+   * Used to indicate whether the experimental Desktop Agent Bridging
+   * feature is implemented by the Desktop Agent.
+   */
+  DesktopAgentBridging: boolean;
+  /**
+   * Used to indicate whether the exposure of 'originating app metadata' for
+   * context and intent messages is supported by the Desktop Agent.
+   */
+  OriginatingAppMetadata: boolean;
+  /**
+   * Used to indicate whether the optional `fdc3.joinUserChannel`,
+   * `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
+   * the Desktop Agent.
+   */
+  UserChannelMembershipAPIs: boolean;
+}
+
+/**
  * A response message from a Desktop Agent to the Bridge containing an error, to be used in
  * preference to the standard response when an error needs to be returned.
  */
@@ -507,7 +555,7 @@ export interface BroadcastAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: BroadcastRequestMessageType;
+  type: 'broadcastRequest';
 }
 
 /**
@@ -596,7 +644,7 @@ export interface BroadcastAgentRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -614,7 +662,7 @@ export interface BroadcastAgentRequestPayload {
  * data object of a particular type can be expected to have, but this can always be extended
  * with custom fields as appropriate.
  */
-export interface Context {
+export interface ContextElement {
   /**
    * Context data objects may include a set of equivalent key-value pairs that can be used to
    * help applications identify and look up the context type they receive in their own domain.
@@ -662,9 +710,6 @@ export interface Context {
  *
  * UUID for this specific response message.
  */
-export enum BroadcastRequestMessageType {
-  BroadcastRequest = 'broadcastRequest',
-}
 
 /**
  * A request to broadcast context on a channel.
@@ -681,7 +726,7 @@ export interface BroadcastBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: BroadcastRequestMessageType;
+  type: 'broadcastRequest';
 }
 
 /**
@@ -779,7 +824,7 @@ export interface BroadcastBridgeRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -833,7 +878,7 @@ export interface ConnectionStep2Hello {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStep2HelloType;
+  type: 'hello';
 }
 
 /**
@@ -869,9 +914,6 @@ export interface ConnectionStep2HelloPayload {
 /**
  * Identifies the type of the connection step message.
  */
-export enum ConnectionStep2HelloType {
-  Hello = 'hello',
-}
 
 /**
  * Handshake message sent by the Desktop Agent to the Bridge (including requested name,
@@ -889,7 +931,7 @@ export interface ConnectionStep3Handshake {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStep3HandshakeType;
+  type: 'handshake';
 }
 
 /**
@@ -909,11 +951,11 @@ export interface ConnectionStep3HandshakePayload {
    * The current state of the Desktop Agent's channels, excluding any private channels, as a
    * mapping of channel id to an array of Context objects, most recent first.
    */
-  channelsState: { [key: string]: Context[] };
+  channelsState: { [key: string]: ContextElement[] };
   /**
    * Desktop Agent ImplementationMetadata trying to connect to the bridge.
    */
-  implementationMetadata: BaseImplementationMetadata;
+  implementationMetadata: ImplementationMetadataElement;
   /**
    * The requested Desktop Agent name
    */
@@ -921,11 +963,11 @@ export interface ConnectionStep3HandshakePayload {
 }
 
 /**
- * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
- *
  * Desktop Agent ImplementationMetadata trying to connect to the bridge.
+ *
+ * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
  */
-export interface BaseImplementationMetadata {
+export interface ImplementationMetadataElement {
   /**
    * The version number of the FDC3 specification that the implementation provides.
    * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
@@ -935,7 +977,7 @@ export interface BaseImplementationMetadata {
    * Metadata indicating whether the Desktop Agent implements optional features of
    * the Desktop Agent API.
    */
-  optionalFeatures: OptionalFeatures;
+  optionalFeatures: ImplementationMetadataOptionalFeatures;
   /**
    * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
    * OpenFin etc.).
@@ -951,7 +993,7 @@ export interface BaseImplementationMetadata {
  * Metadata indicating whether the Desktop Agent implements optional features of
  * the Desktop Agent API.
  */
-export interface OptionalFeatures {
+export interface ImplementationMetadataOptionalFeatures {
   /**
    * Used to indicate whether the experimental Desktop Agent Bridging
    * feature is implemented by the Desktop Agent.
@@ -973,9 +1015,6 @@ export interface OptionalFeatures {
 /**
  * Identifies the type of the connection step message.
  */
-export enum ConnectionStep3HandshakeType {
-  Handshake = 'handshake',
-}
 
 /**
  * Message sent by Bridge to Desktop Agent if their authentication fails.
@@ -992,7 +1031,7 @@ export interface ConnectionStep4AuthenticationFailed {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStep4AuthenticationFailedType;
+  type: 'authenticationFailed';
 }
 
 /**
@@ -1014,9 +1053,6 @@ export interface ConnectionStep4AuthenticationFailedPayload {
 /**
  * Identifies the type of the connection step message.
  */
-export enum ConnectionStep4AuthenticationFailedType {
-  AuthenticationFailed = 'authenticationFailed',
-}
 
 /**
  * Message sent by Bridge to all Desktop Agent when an agent joins or leaves the bridge,
@@ -1035,7 +1071,7 @@ export interface ConnectionStep6ConnectedAgentsUpdate {
   /**
    * Identifies the type of the connection step message.
    */
-  type: ConnectionStep6ConnectedAgentsUpdateType;
+  type: 'connectedAgentsUpdate';
 }
 
 /**
@@ -1058,12 +1094,12 @@ export interface ConnectionStep6ConnectedAgentsUpdatePayload {
   /**
    * Desktop Agent Bridge implementation metadata of all connected agents.
    */
-  allAgents: BaseImplementationMetadata[];
+  allAgents: ImplementationMetadataElement[];
   /**
    * The updated state of channels that should be adopted by the agents. Should only be set
    * when an agent is connecting to the bridge.
    */
-  channelsState?: { [key: string]: Context[] };
+  channelsState?: { [key: string]: ContextElement[] };
   /**
    * Should be set when an agent disconnects from the bridge and provide the name that no
    * longer is assigned.
@@ -1074,9 +1110,6 @@ export interface ConnectionStep6ConnectedAgentsUpdatePayload {
 /**
  * Identifies the type of the connection step message.
  */
-export enum ConnectionStep6ConnectedAgentsUpdateType {
-  ConnectedAgentsUpdate = 'connectedAgentsUpdate',
-}
 
 /**
  * A response to a findInstances request that contains an error.
@@ -1094,7 +1127,7 @@ export interface FindInstancesAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindInstancesResponseMessageType;
+  type: 'findInstancesResponse';
 }
 
 /**
@@ -1149,9 +1182,6 @@ export enum ErrorMessage {
  *
  * UUID for this specific response message.
  */
-export enum FindInstancesResponseMessageType {
-  FindInstancesResponse = 'findInstancesResponse',
-}
 
 /**
  * A request for details of instances of a particular app
@@ -1168,7 +1198,7 @@ export interface FindInstancesAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindInstancesRequestMessageType;
+  type: 'findInstancesRequest';
 }
 
 /**
@@ -1311,9 +1341,6 @@ export interface AppIdentifier {
  *
  * UUID for this specific response message.
  */
-export enum FindInstancesRequestMessageType {
-  FindInstancesRequest = 'findInstancesRequest',
-}
 
 /**
  * A response to a findInstances request.
@@ -1330,7 +1357,7 @@ export interface FindInstancesAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindInstancesResponseMessageType;
+  type: 'findInstancesResponse';
 }
 
 /**
@@ -1483,7 +1510,7 @@ export interface FindInstancesBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindInstancesResponseMessageType;
+  type: 'findInstancesResponse';
 }
 
 /**
@@ -1520,7 +1547,7 @@ export interface FindInstancesBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindInstancesRequestMessageType;
+  type: 'findInstancesRequest';
 }
 
 /**
@@ -1642,7 +1669,7 @@ export interface FindInstancesBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindInstancesResponseMessageType;
+  type: 'findInstancesResponse';
 }
 
 /**
@@ -1680,7 +1707,7 @@ export interface FindIntentAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentResponseMessageType;
+  type: 'findIntentResponse';
 }
 
 /**
@@ -1707,9 +1734,6 @@ export interface FindIntentAgentErrorResponsePayload {
  *
  * UUID for this specific response message.
  */
-export enum FindIntentResponseMessageType {
-  FindIntentResponse = 'findIntentResponse',
-}
 
 /**
  * A request for details of apps available to resolve a particular intent and context pair.
@@ -1726,7 +1750,7 @@ export interface FindIntentAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindIntentRequestMessageType;
+  type: 'findIntentRequest';
 }
 
 /**
@@ -1752,7 +1776,7 @@ export interface FindIntentAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentAgentRequestPayload {
-  context?: Context;
+  context?: ContextElement;
   intent: string;
 }
 
@@ -1764,9 +1788,6 @@ export interface FindIntentAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum FindIntentRequestMessageType {
-  FindIntentRequest = 'findIntentRequest',
-}
 
 /**
  * A response to a findIntent request.
@@ -1783,7 +1804,7 @@ export interface FindIntentAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentResponseMessageType;
+  type: 'findIntentResponse';
 }
 
 /**
@@ -1849,7 +1870,7 @@ export interface FindIntentBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentResponseMessageType;
+  type: 'findIntentResponse';
 }
 
 /**
@@ -1886,7 +1907,7 @@ export interface FindIntentBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindIntentRequestMessageType;
+  type: 'findIntentRequest';
 }
 
 /**
@@ -1913,7 +1934,7 @@ export interface FindIntentBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentBridgeRequestPayload {
-  context?: Context;
+  context?: ContextElement;
   intent: string;
 }
 
@@ -1933,7 +1954,7 @@ export interface FindIntentBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentResponseMessageType;
+  type: 'findIntentResponse';
 }
 
 /**
@@ -1971,7 +1992,7 @@ export interface FindIntentsByContextAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentsByContextResponseMessageType;
+  type: 'findIntentsByContextResponse';
 }
 
 /**
@@ -1998,9 +2019,6 @@ export interface FindIntentsByContextAgentErrorResponsePayload {
  *
  * UUID for this specific response message.
  */
-export enum FindIntentsByContextResponseMessageType {
-  FindIntentsByContextResponse = 'findIntentsByContextResponse',
-}
 
 /**
  * A request for details of intents and apps available to resolve them for a particular
@@ -2018,7 +2036,7 @@ export interface FindIntentsByContextAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindIntentsByContextRequestMessageType;
+  type: 'findIntentsByContextRequest';
 }
 
 /**
@@ -2044,7 +2062,7 @@ export interface FindIntentsByContextAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentsByContextAgentRequestPayload {
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -2055,9 +2073,6 @@ export interface FindIntentsByContextAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum FindIntentsByContextRequestMessageType {
-  FindIntentsByContextRequest = 'findIntentsByContextRequest',
-}
 
 /**
  * A response to a findIntentsByContext request.
@@ -2074,7 +2089,7 @@ export interface FindIntentsByContextAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentsByContextResponseMessageType;
+  type: 'findIntentsByContextResponse';
 }
 
 /**
@@ -2110,7 +2125,7 @@ export interface FindIntentsByContextBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentsByContextResponseMessageType;
+  type: 'findIntentsByContextResponse';
 }
 
 /**
@@ -2148,7 +2163,7 @@ export interface FindIntentsByContextBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: FindIntentsByContextRequestMessageType;
+  type: 'findIntentsByContextRequest';
 }
 
 /**
@@ -2175,7 +2190,7 @@ export interface FindIntentsByContextBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface FindIntentsByContextBridgeRequestPayload {
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -2194,7 +2209,7 @@ export interface FindIntentsByContextBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: FindIntentsByContextResponseMessageType;
+  type: 'findIntentsByContextResponse';
 }
 
 /**
@@ -2232,7 +2247,7 @@ export interface GetAppMetadataAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: GetAppMetadataResponseMessageType;
+  type: 'getAppMetadataResponse';
 }
 
 /**
@@ -2259,9 +2274,6 @@ export interface GetAppMetadataAgentErrorResponsePayload {
  *
  * UUID for this specific response message.
  */
-export enum GetAppMetadataResponseMessageType {
-  GetAppMetadataResponse = 'getAppMetadataResponse',
-}
 
 /**
  * A request for metadata about an app
@@ -2278,7 +2290,7 @@ export interface GetAppMetadataAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: GetAppMetadataRequestMessageType;
+  type: 'getAppMetadataRequest';
 }
 
 /**
@@ -2374,9 +2386,6 @@ export interface AppDestinationIdentifier {
  *
  * UUID for this specific response message.
  */
-export enum GetAppMetadataRequestMessageType {
-  GetAppMetadataRequest = 'getAppMetadataRequest',
-}
 
 /**
  * A response to a getAppMetadata request.
@@ -2393,7 +2402,7 @@ export interface GetAppMetadataAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: GetAppMetadataResponseMessageType;
+  type: 'getAppMetadataResponse';
 }
 
 /**
@@ -2429,7 +2438,7 @@ export interface GetAppMetadataBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: GetAppMetadataResponseMessageType;
+  type: 'getAppMetadataResponse';
 }
 
 /**
@@ -2466,7 +2475,7 @@ export interface GetAppMetadataBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: GetAppMetadataRequestMessageType;
+  type: 'getAppMetadataRequest';
 }
 
 /**
@@ -2512,7 +2521,7 @@ export interface GetAppMetadataBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: GetAppMetadataResponseMessageType;
+  type: 'getAppMetadataResponse';
 }
 
 /**
@@ -2550,7 +2559,7 @@ export interface OpenAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: OpenResponseMessageType;
+  type: 'openResponse';
 }
 
 /**
@@ -2602,9 +2611,6 @@ export enum OpenErrorMessage {
  *
  * UUID for this specific response message.
  */
-export enum OpenResponseMessageType {
-  OpenResponse = 'openResponse',
-}
 
 /**
  * A request to open an application
@@ -2621,7 +2627,7 @@ export interface OpenAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: OpenRequestMessageType;
+  type: 'openRequest';
 }
 
 /**
@@ -2651,7 +2657,7 @@ export interface OpenAgentRequestPayload {
    * The application to open on the specified Desktop Agent
    */
   app: AppToOpen;
-  context?: Context;
+  context?: ContextElement;
 }
 
 /**
@@ -2720,9 +2726,6 @@ export interface AppToOpen {
  *
  * UUID for this specific response message.
  */
-export enum OpenRequestMessageType {
-  OpenRequest = 'openRequest',
-}
 
 /**
  * A response to an open request
@@ -2739,7 +2742,7 @@ export interface OpenAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: OpenResponseMessageType;
+  type: 'openResponse';
 }
 
 /**
@@ -2775,7 +2778,7 @@ export interface OpenBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: OpenResponseMessageType;
+  type: 'openResponse';
 }
 
 /**
@@ -2812,7 +2815,7 @@ export interface OpenBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: OpenRequestMessageType;
+  type: 'openRequest';
 }
 
 /**
@@ -2843,7 +2846,7 @@ export interface OpenBridgeRequestPayload {
    * The application to open on the specified Desktop Agent
    */
   app: AppToOpen;
-  context?: Context;
+  context?: ContextElement;
 }
 
 /**
@@ -2862,7 +2865,7 @@ export interface OpenBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: OpenResponseMessageType;
+  type: 'openResponse';
 }
 
 /**
@@ -2899,7 +2902,7 @@ export interface PrivateChannelBroadcastAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelBroadcastMessageType;
+  type: 'PrivateChannel.broadcast';
 }
 
 /**
@@ -3002,7 +3005,7 @@ export interface PrivateChannelBroadcastAgentRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -3013,9 +3016,6 @@ export interface PrivateChannelBroadcastAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelBroadcastMessageType {
-  PrivateChannelBroadcast = 'PrivateChannel.broadcast',
-}
 
 /**
  * A request to broadcast on a PrivateChannel.
@@ -3032,7 +3032,7 @@ export interface PrivateChannelBroadcastBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelBroadcastMessageType;
+  type: 'PrivateChannel.broadcast';
 }
 
 /**
@@ -3066,7 +3066,7 @@ export interface PrivateChannelBroadcastBridgeRequestPayload {
   /**
    * The context object that was the payload of a broadcast message.
    */
-  context: Context;
+  context: ContextElement;
 }
 
 /**
@@ -3084,7 +3084,7 @@ export interface PrivateChannelEventListenerAddedAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelEventListenerAddedMessageType;
+  type: 'PrivateChannel.eventListenerAdded';
 }
 
 /**
@@ -3131,9 +3131,6 @@ export enum PrivateChannelEventListenerTypes {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelEventListenerAddedMessageType {
-  PrivateChannelEventListenerAdded = 'PrivateChannel.eventListenerAdded',
-}
 
 /**
  * A request to forward on an EventListenerAdded event, relating to a PrivateChannel
@@ -3150,7 +3147,7 @@ export interface PrivateChannelEventListenerAddedBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelEventListenerAddedMessageType;
+  type: 'PrivateChannel.eventListenerAdded';
 }
 
 /**
@@ -3196,7 +3193,7 @@ export interface PrivateChannelEventListenerRemovedAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelEventListenerRemovedMessageType;
+  type: 'PrivateChannel.eventListenerRemoved';
 }
 
 /**
@@ -3234,9 +3231,6 @@ export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelEventListenerRemovedMessageType {
-  PrivateChannelEventListenerRemoved = 'PrivateChannel.eventListenerRemoved',
-}
 
 /**
  * A request to forward on an EventListenerRemoved event, relating to a PrivateChannel
@@ -3253,7 +3247,7 @@ export interface PrivateChannelEventListenerRemovedBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelEventListenerRemovedMessageType;
+  type: 'PrivateChannel.eventListenerRemoved';
 }
 
 /**
@@ -3299,7 +3293,7 @@ export interface PrivateChannelOnAddContextListenerAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnAddContextListenerMessageType;
+  type: 'PrivateChannel.onAddContextListener';
 }
 
 /**
@@ -3337,9 +3331,6 @@ export interface PrivateChannelOnAddContextListenerAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelOnAddContextListenerMessageType {
-  PrivateChannelOnAddContextListener = 'PrivateChannel.onAddContextListener',
-}
 
 /**
  * A request to forward on an AddContextListener event, relating to a PrivateChannel
@@ -3356,7 +3347,7 @@ export interface PrivateChannelOnAddContextListenerBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnAddContextListenerMessageType;
+  type: 'PrivateChannel.onAddContextListener';
 }
 
 /**
@@ -3402,7 +3393,7 @@ export interface PrivateChannelOnDisconnectAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnDisconnectMessageType;
+  type: 'PrivateChannel.onDisconnect';
 }
 
 /**
@@ -3439,9 +3430,6 @@ export interface PrivateChannelOnDisconnectAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelOnDisconnectMessageType {
-  PrivateChannelOnDisconnect = 'PrivateChannel.onDisconnect',
-}
 
 /**
  * A request to forward on a Disconnect event, relating to a PrivateChannel
@@ -3458,7 +3446,7 @@ export interface PrivateChannelOnDisconnectBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnDisconnectMessageType;
+  type: 'PrivateChannel.onDisconnect';
 }
 
 /**
@@ -3503,7 +3491,7 @@ export interface PrivateChannelOnUnsubscribeAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnUnsubscribeMessageType;
+  type: 'PrivateChannel.onUnsubscribe';
 }
 
 /**
@@ -3541,9 +3529,6 @@ export interface PrivateChannelOnUnsubscribeAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum PrivateChannelOnUnsubscribeMessageType {
-  PrivateChannelOnUnsubscribe = 'PrivateChannel.onUnsubscribe',
-}
 
 /**
  * A request to forward on an Unsubscribe event, relating to a PrivateChannel
@@ -3560,7 +3545,7 @@ export interface PrivateChannelOnUnsubscribeBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: PrivateChannelOnUnsubscribeMessageType;
+  type: 'PrivateChannel.onUnsubscribe';
 }
 
 /**
@@ -3607,7 +3592,7 @@ export interface RaiseIntentAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResponseMessageType;
+  type: 'raiseIntentResponse';
 }
 
 /**
@@ -3634,9 +3619,6 @@ export interface RaiseIntentAgentErrorResponsePayload {
  *
  * UUID for this specific response message.
  */
-export enum RaiseIntentResponseMessageType {
-  RaiseIntentResponse = 'raiseIntentResponse',
-}
 
 /**
  * A request to raise an intent.
@@ -3653,7 +3635,7 @@ export interface RaiseIntentAgentRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RaiseIntentRequestMessageType;
+  type: 'raiseIntentRequest';
 }
 
 /**
@@ -3680,7 +3662,7 @@ export interface RaiseIntentAgentRequestMeta {
  */
 export interface RaiseIntentAgentRequestPayload {
   app: AppDestinationIdentifier;
-  context: Context;
+  context: ContextElement;
   intent: string;
 }
 
@@ -3692,9 +3674,6 @@ export interface RaiseIntentAgentRequestPayload {
  *
  * UUID for this specific response message.
  */
-export enum RaiseIntentRequestMessageType {
-  RaiseIntentRequest = 'raiseIntentRequest',
-}
 
 /**
  * A response to a request to raise an intent.
@@ -3711,7 +3690,7 @@ export interface RaiseIntentAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResponseMessageType;
+  type: 'raiseIntentResponse';
 }
 
 /**
@@ -3791,7 +3770,7 @@ export interface RaiseIntentBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResponseMessageType;
+  type: 'raiseIntentResponse';
 }
 
 /**
@@ -3828,7 +3807,7 @@ export interface RaiseIntentBridgeRequest {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Request' appended.
    */
-  type: RaiseIntentRequestMessageType;
+  type: 'raiseIntentRequest';
 }
 
 /**
@@ -3856,7 +3835,7 @@ export interface RaiseIntentBridgeRequestMeta {
  */
 export interface RaiseIntentBridgeRequestPayload {
   app: AppDestinationIdentifier;
-  context: Context;
+  context: ContextElement;
   intent: string;
 }
 
@@ -3876,7 +3855,7 @@ export interface RaiseIntentBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResponseMessageType;
+  type: 'raiseIntentResponse';
 }
 
 /**
@@ -3915,7 +3894,7 @@ export interface RaiseIntentResultAgentErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResultResponseMessageType;
+  type: 'raiseIntentResultResponse';
 }
 
 /**
@@ -3963,9 +3942,6 @@ export enum RaiseIntentResultErrorMessage {
  *
  * UUID for this specific response message.
  */
-export enum RaiseIntentResultResponseMessageType {
-  RaiseIntentResultResponse = 'raiseIntentResultResponse',
-}
 
 /**
  * A secondary response to a request to raise an intent used to deliver the intent result
@@ -3982,7 +3958,7 @@ export interface RaiseIntentResultAgentResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResultResponseMessageType;
+  type: 'raiseIntentResultResponse';
 }
 
 /**
@@ -4002,7 +3978,7 @@ export interface RaiseIntentResultAgentResponsePayload {
 }
 
 export interface IntentResult {
-  context?: Context;
+  context?: ContextElement;
   channel?: Channel;
 }
 
@@ -4093,7 +4069,7 @@ export interface RaiseIntentResultBridgeErrorResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResultResponseMessageType;
+  type: 'raiseIntentResultResponse';
 }
 
 /**
@@ -4131,7 +4107,7 @@ export interface RaiseIntentResultBridgeResponse {
    * Identifies the type of the message and it is typically set to the FDC3 function name that
    * the message relates to, e.g. 'findIntent', with 'Response' appended.
    */
-  type: RaiseIntentResultResponseMessageType;
+  type: 'raiseIntentResultResponse';
 }
 
 /**
@@ -4151,6 +4127,59 @@ export interface RaiseIntentResultBridgeResponseMeta {
  */
 export interface RaiseIntentResultBridgeResponsePayload {
   intentResult: IntentResult;
+}
+
+/**
+ * The `fdc3.context` type defines the basic contract or "shape" for all data exchanged by
+ * FDC3 operations. As such, it is not really meant to be used on its own, but is imported
+ * by more specific type definitions (standardized or custom) to provide the structure and
+ * properties shared by all FDC3 context data types.
+ *
+ * The key element of FDC3 context types is their mandatory `type` property, which is used
+ * to identify what type of data the object represents, and what shape it has.
+ *
+ * The FDC3 context type, and all derived types, define the minimum set of fields a context
+ * data object of a particular type can be expected to have, but this can always be extended
+ * with custom fields as appropriate.
+ */
+export interface Context {
+  /**
+   * Context data objects may include a set of equivalent key-value pairs that can be used to
+   * help applications identify and look up the context type they receive in their own domain.
+   * The idea behind this design is that applications can provide as many equivalent
+   * identifiers to a target application as possible, e.g. an instrument may be represented by
+   * an ISIN, CUSIP or Bloomberg identifier.
+   *
+   * Identifiers do not make sense for all types of data, so the `id` property is therefore
+   * optional, but some derived types may choose to require at least one identifier.
+   */
+  id?: { [key: string]: any };
+  /**
+   * Context data objects may include a name property that can be used for more information,
+   * or display purposes. Some derived types may require the name object as mandatory,
+   * depending on use case.
+   */
+  name?: string;
+  /**
+   * The type property is the only _required_ part of the FDC3 context data schema. The FDC3
+   * [API](https://fdc3.finos.org/docs/api/spec) relies on the `type` property being present
+   * to route shared context data appropriately.
+   *
+   * FDC3 [Intents](https://fdc3.finos.org/docs/intents/spec) also register the context data
+   * types they support in an FDC3 [App
+   * Directory](https://fdc3.finos.org/docs/app-directory/overview), used for intent discovery
+   * and routing.
+   *
+   * Standardized FDC3 context types have well-known `type` properties prefixed with the
+   * `fdc3` namespace, e.g. `fdc3.instrument`. For non-standard types, e.g. those defined and
+   * used by a particular organization, the convention is to prefix them with an
+   * organization-specific namespace, e.g. `blackrock.fund`.
+   *
+   * See the [Context Data Specification](https://fdc3.finos.org/docs/context/spec) for more
+   * information about context data types.
+   */
+  type: string;
+  [property: string]: any;
 }
 
 // Converts JSON strings to/from your types
@@ -4902,6 +4931,23 @@ function r(name: string) {
 }
 
 const typeMap: any = {
+  BaseImplementationMetadata: o(
+    [
+      { json: 'fdc3Version', js: 'fdc3Version', typ: '' },
+      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('BaseImplementationMetadataOptionalFeatures') },
+      { json: 'provider', js: 'provider', typ: '' },
+      { json: 'providerVersion', js: 'providerVersion', typ: u(undefined, '') },
+    ],
+    false
+  ),
+  BaseImplementationMetadataOptionalFeatures: o(
+    [
+      { json: 'DesktopAgentBridging', js: 'DesktopAgentBridging', typ: true },
+      { json: 'OriginatingAppMetadata', js: 'OriginatingAppMetadata', typ: true },
+      { json: 'UserChannelMembershipAPIs', js: 'UserChannelMembershipAPIs', typ: true },
+    ],
+    false
+  ),
   AgentErrorResponseMessage: o(
     [
       { json: 'meta', js: 'meta', typ: r('AgentResponseMetadata') },
@@ -5043,11 +5089,11 @@ const typeMap: any = {
   BroadcastAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
   ),
-  Context: o(
+  ContextElement: o(
     [
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
@@ -5082,7 +5128,7 @@ const typeMap: any = {
   BroadcastBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
   ),
@@ -5138,22 +5184,22 @@ const typeMap: any = {
   ConnectionStep3HandshakePayload: o(
     [
       { json: 'authToken', js: 'authToken', typ: u(undefined, '') },
-      { json: 'channelsState', js: 'channelsState', typ: m(a(r('Context'))) },
-      { json: 'implementationMetadata', js: 'implementationMetadata', typ: r('BaseImplementationMetadata') },
+      { json: 'channelsState', js: 'channelsState', typ: m(a(r('ContextElement'))) },
+      { json: 'implementationMetadata', js: 'implementationMetadata', typ: r('ImplementationMetadataElement') },
       { json: 'requestedName', js: 'requestedName', typ: '' },
     ],
     false
   ),
-  BaseImplementationMetadata: o(
+  ImplementationMetadataElement: o(
     [
       { json: 'fdc3Version', js: 'fdc3Version', typ: '' },
-      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('OptionalFeatures') },
+      { json: 'optionalFeatures', js: 'optionalFeatures', typ: r('ImplementationMetadataOptionalFeatures') },
       { json: 'provider', js: 'provider', typ: '' },
       { json: 'providerVersion', js: 'providerVersion', typ: u(undefined, '') },
     ],
     false
   ),
-  OptionalFeatures: o(
+  ImplementationMetadataOptionalFeatures: o(
     [
       { json: 'DesktopAgentBridging', js: 'DesktopAgentBridging', typ: true },
       { json: 'OriginatingAppMetadata', js: 'OriginatingAppMetadata', typ: true },
@@ -5197,8 +5243,8 @@ const typeMap: any = {
   ConnectionStep6ConnectedAgentsUpdatePayload: o(
     [
       { json: 'addAgent', js: 'addAgent', typ: u(undefined, '') },
-      { json: 'allAgents', js: 'allAgents', typ: a(r('BaseImplementationMetadata')) },
-      { json: 'channelsState', js: 'channelsState', typ: u(undefined, m(a(r('Context')))) },
+      { json: 'allAgents', js: 'allAgents', typ: a(r('ImplementationMetadataElement')) },
+      { json: 'channelsState', js: 'channelsState', typ: u(undefined, m(a(r('ContextElement')))) },
       { json: 'removeAgent', js: 'removeAgent', typ: u(undefined, '') },
     ],
     false
@@ -5412,7 +5458,7 @@ const typeMap: any = {
   ),
   FindIntentAgentRequestPayload: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -5486,7 +5532,7 @@ const typeMap: any = {
   ),
   FindIntentBridgeRequestPayload: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -5545,7 +5591,7 @@ const typeMap: any = {
     ],
     false
   ),
-  FindIntentsByContextAgentRequestPayload: o([{ json: 'context', js: 'context', typ: r('Context') }], false),
+  FindIntentsByContextAgentRequestPayload: o([{ json: 'context', js: 'context', typ: r('ContextElement') }], false),
   FindIntentsByContextAgentResponse: o(
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentResponseMeta') },
@@ -5602,7 +5648,7 @@ const typeMap: any = {
     ],
     false
   ),
-  FindIntentsByContextBridgeRequestPayload: o([{ json: 'context', js: 'context', typ: r('Context') }], false),
+  FindIntentsByContextBridgeRequestPayload: o([{ json: 'context', js: 'context', typ: r('ContextElement') }], false),
   FindIntentsByContextBridgeResponse: o(
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeResponseMeta') },
@@ -5780,7 +5826,7 @@ const typeMap: any = {
   OpenAgentRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppToOpen') },
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
     ],
     false
   ),
@@ -5848,7 +5894,7 @@ const typeMap: any = {
   OpenBridgeRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppToOpen') },
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
     ],
     false
   ),
@@ -5900,7 +5946,7 @@ const typeMap: any = {
   PrivateChannelBroadcastAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
   ),
@@ -5924,7 +5970,7 @@ const typeMap: any = {
   PrivateChannelBroadcastBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
     ],
     false
   ),
@@ -6193,7 +6239,7 @@ const typeMap: any = {
   RaiseIntentAgentRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppDestinationIdentifier') },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -6265,7 +6311,7 @@ const typeMap: any = {
   RaiseIntentBridgeRequestPayload: o(
     [
       { json: 'app', js: 'app', typ: r('AppDestinationIdentifier') },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
       { json: 'intent', js: 'intent', typ: '' },
     ],
     false
@@ -6335,7 +6381,7 @@ const typeMap: any = {
   ),
   IntentResult: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'channel', js: 'channel', typ: u(undefined, r('Channel')) },
     ],
     false
@@ -6400,6 +6446,14 @@ const typeMap: any = {
   RaiseIntentResultBridgeResponsePayload: o(
     [{ json: 'intentResult', js: 'intentResult', typ: r('IntentResult') }],
     false
+  ),
+  Context: o(
+    [
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'type', js: 'type', typ: '' },
+    ],
+    'any'
   ),
   ResponseErrorDetail: [
     'AccessDenied',

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -53,7 +53,7 @@ export interface Action {
   /**
    * A context object with which the action will be performed
    */
-  context: Context;
+  context: ContextElement;
   /**
    * Optional Intent to raise to perform the actions. Should reference an intent type name,
    * such as those defined in the FDC3 Standard. If intent is not set then
@@ -65,7 +65,7 @@ export interface Action {
    * A human readable display name for the action
    */
   title: string;
-  type: ActionType;
+  type: 'fdc3.action';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -119,7 +119,7 @@ export interface ActionTargetApp {
  * data object of a particular type can be expected to have, but this can always be extended
  * with custom fields as appropriate.
  */
-export interface Context {
+export interface ContextElement {
   /**
    * Context data objects may include a set of equivalent key-value pairs that can be used to
    * help applications identify and look up the context type they receive in their own domain.
@@ -165,9 +165,6 @@ export interface Context {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ActionType {
-  Fdc3Action = 'fdc3.action',
-}
 
 /**
  * A context type representing details of a Chart, which may be used to request plotting of
@@ -187,22 +184,22 @@ export interface Chart {
   /**
    * An array of instrument contexts whose data should be plotted.
    */
-  instruments: Instrument[];
+  instruments: InstrumentElement[];
   /**
    * It is common for charts to support other configuration, such as indicators, annotations
    * etc., which do not have standardized formats, but may be included in the `otherConfig`
    * array as context objects.
    */
-  otherConfig?: Context[];
+  otherConfig?: ContextElement[];
   /**
    * The time range that should be plotted
    */
-  range?: TimeRange;
+  range?: TimeRangeObject;
   /**
    * The type of chart that should be plotted
    */
   style?: ChartStyle;
-  type: ChartType;
+  type: 'fdc3.chart';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -215,7 +212,7 @@ export interface Chart {
  *
  * A financial instrument from any asset class.
  */
-export interface Instrument {
+export interface InstrumentElement {
   /**
    * Any combination of instrument identifiers can be used together to resolve ambiguity, or
    * for a better match. Not all applications will use the same instrument identifiers, which
@@ -231,14 +228,14 @@ export interface Instrument {
    * fields, define a property that makes it clear what the value represents. Doing so will
    * make interpretation easier for the developers of target applications.
    */
-  id: InstrumentIdentifiers;
+  id: PurpleInstrumentIdentifiers;
   /**
    * The `market` map can be used to further specify the instrument and help achieve
    * interoperability between disparate data sources. This is especially useful when using an
    * `id` field that is not globally unique.
    */
-  market?: Market;
-  type: PurpleInteractionType;
+  market?: OrganizationMarket;
+  type: 'fdc3.instrument';
   name?: string;
   [property: string]: any;
 }
@@ -258,7 +255,7 @@ export interface Instrument {
  * fields, define a property that makes it clear what the value represents. Doing so will
  * make interpretation easier for the developers of target applications.
  */
-export interface InstrumentIdentifiers {
+export interface PurpleInstrumentIdentifiers {
   /**
    * <https://www.bloomberg.com/>
    */
@@ -303,7 +300,7 @@ export interface InstrumentIdentifiers {
  * interoperability between disparate data sources. This is especially useful when using an
  * `id` field that is not globally unique.
  */
-export interface Market {
+export interface OrganizationMarket {
   /**
    * <https://www.bloomberg.com/>
    */
@@ -329,9 +326,6 @@ export interface Market {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum PurpleInteractionType {
-  Fdc3Instrument = 'fdc3.instrument',
-}
 
 /**
  * The time range that should be plotted
@@ -369,7 +363,7 @@ export enum PurpleInteractionType {
  * `"2022-05-12T16:18:03+01:00"`
  * - Times MAY be specified with millisecond precision, e.g. `"2022-05-12T15:18:03.349Z"`
  */
-export interface TimeRange {
+export interface TimeRangeObject {
   /**
    * The end time of the range, encoded according to [ISO
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
@@ -380,7 +374,7 @@ export interface TimeRange {
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
    */
   startTime?: Date;
-  type: TimeRangeType;
+  type: 'fdc3.timerange';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -392,9 +386,6 @@ export interface TimeRange {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum TimeRangeType {
-  Fdc3Timerange = 'fdc3.timerange',
-}
 
 /**
  * The type of chart that should be plotted
@@ -418,9 +409,6 @@ export enum ChartStyle {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ChartType {
-  Fdc3Chart = 'fdc3.chart',
-}
 
 /**
  * A collection of settings to start a new chat conversation
@@ -433,16 +421,16 @@ export interface ChatInitSettings {
   /**
    * Contacts to add to the chat
    */
-  members?: ContactList;
+  members?: ContactListObject;
   /**
    * An initial message to post in the chat when created.
    */
-  message?: Message | string;
+  message?: MessageObject | string;
   /**
    * Option settings that affect the creation of the chat
    */
   options?: ChatOptions;
-  type: ChatInitSettingsType;
+  type: 'fdc3.chat.initSettings';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -459,12 +447,12 @@ export interface ChatInitSettings {
  * there is not a common standard for such identifiers. Applications can, however, populate
  * this part of the contract with custom identifiers if so desired.
  */
-export interface ContactList {
+export interface ContactListObject {
   /**
    * An array of contact contexts that forms the list.
    */
-  contacts: Contact[];
-  type: ContactListType;
+  contacts: ContactElement[];
+  type: 'fdc3.contactList';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -475,12 +463,12 @@ export interface ContactList {
  *
  * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface Contact {
+export interface ContactElement {
   /**
    * Identifiers that relate to the Contact represented by this context
    */
-  id: ContactID;
-  type: FluffyInteractionType;
+  id: PurpleContactIdentifiers;
+  type: 'fdc3.contact';
   name?: string;
   [property: string]: any;
 }
@@ -488,7 +476,7 @@ export interface Contact {
 /**
  * Identifiers that relate to the Contact represented by this context
  */
-export interface ContactID {
+export interface PurpleContactIdentifiers {
   /**
    * The email address for the contact
    */
@@ -506,9 +494,6 @@ export interface ContactID {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum FluffyInteractionType {
-  Fdc3Contact = 'fdc3.contact',
-}
 
 /**
  * Free text to be used for a keyword search
@@ -516,9 +501,6 @@ export enum FluffyInteractionType {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ContactListType {
-  Fdc3ContactList = 'fdc3.contactList',
-}
 
 /**
  * A chat message to be sent through an instant messaging application. Can contain one or
@@ -526,17 +508,17 @@ export enum ContactListType {
  * entities (either arbitrary file attachments or FDC3 actions to be embedded in the
  * message). To be put inside a ChatInitSettings object.
  */
-export interface Message {
+export interface MessageObject {
   /**
    * A map of string IDs to entities that should be attached to the message, such as an action
    * to perform, a file attachment, or other FDC3 context object.
    */
-  entities?: { [key: string]: EntityValue };
+  entities?: { [key: string]: PurpleAction };
   /**
    * A map of string mime-type to string content
    */
-  text?: MessageText;
-  type: MessageType;
+  text?: PurpleMessageText;
+  type: 'fdc3.message';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -555,7 +537,7 @@ export interface Message {
  *
  * A File attachment encoded in the form of a data URI
  */
-export interface EntityValue {
+export interface PurpleAction {
   /**
    * An optional target application identifier that should perform the action
    */
@@ -563,7 +545,7 @@ export interface EntityValue {
   /**
    * A context object with which the action will be performed
    */
-  context?: Context;
+  context?: ContextElement;
   /**
    * Optional Intent to raise to perform the actions. Should reference an intent type name,
    * such as those defined in the FDC3 Standard. If intent is not set then
@@ -578,11 +560,11 @@ export interface EntityValue {
   type: EntityType;
   id?: { [key: string]: any };
   name?: string;
-  data?: Data;
+  data?: PurpleData;
   [property: string]: any;
 }
 
-export interface Data {
+export interface PurpleData {
   /**
    * A data URI encoding the content of the file to be attached
    */
@@ -608,7 +590,7 @@ export enum EntityType {
 /**
  * A map of string mime-type to string content
  */
-export interface MessageText {
+export interface PurpleMessageText {
   /**
    * Markdown encoded content
    */
@@ -626,9 +608,6 @@ export interface MessageText {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum MessageType {
-  Fdc3Message = 'fdc3.message',
-}
 
 /**
  * Option settings that affect the creation of the chat
@@ -663,25 +642,61 @@ export interface ChatOptions {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ChatInitSettingsType {
-  Fdc3ChatInitSettings = 'fdc3.chat.initSettings',
-}
 
 /**
  * A context representing a chat message. Typically used to send the message or to
  * pre-populate a message for sending.
  */
 export interface ChatMessage {
-  chatRoom: ChatRoom;
+  chatRoom: ChatRoomObject;
   /**
    * The content of the message to post in the chat when created.
    */
-  message: Message | string;
-  type: ChatMessageType;
+  message: MessageObject | string;
+  type: 'fdc3.chat.message';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
 }
+
+/**
+ * Reference to the chat room which could be used to send a message to the room
+ */
+export interface ChatRoomObject {
+  /**
+   * Identifier(s) for the chat - currently unstandardized
+   */
+  id: { [key: string]: any };
+  /**
+   * Display name for the chat room
+   */
+  name?: string;
+  /**
+   * The name of the service that hosts the chat
+   */
+  providerName: string;
+  type: 'fdc3.chat.room';
+  /**
+   * Universal url to access to the room. It could be opened from a browser, a mobile app,
+   * etc...
+   */
+  url?: string;
+  [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
 
 /**
  * Reference to the chat room which could be used to send a message to the room
@@ -699,33 +714,13 @@ export interface ChatRoom {
    * The name of the service that hosts the chat
    */
   providerName: string;
-  type: ChatRoomType;
+  type: 'fdc3.chat.room';
   /**
    * Universal url to access to the room. It could be opened from a browser, a mobile app,
    * etc...
    */
   url?: string;
   [property: string]: any;
-}
-
-/**
- * Free text to be used for a keyword search
- *
- * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
- * `'Meeting'` although other string values are permitted.
- */
-export enum ChatRoomType {
-  Fdc3ChatRoom = 'fdc3.chat.room',
-}
-
-/**
- * Free text to be used for a keyword search
- *
- * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
- * `'Meeting'` although other string values are permitted.
- */
-export enum ChatMessageType {
-  Fdc3ChatMessage = 'fdc3.chat.message',
 }
 
 /**
@@ -742,8 +737,8 @@ export interface ChatSearchCriteria {
    *
    * Empty search criteria can be supported to allow resetting of filters.
    */
-  criteria: Array<InstrumentObject | string>;
-  type: ChatSearchCriteriaType;
+  criteria: Array<OrganizationObject | string>;
+  type: 'fdc3.chat.searchCriteria';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -766,7 +761,7 @@ export interface ChatSearchCriteria {
  *
  * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface InstrumentObject {
+export interface OrganizationObject {
   /**
    * Any combination of instrument identifiers can be used together to resolve ambiguity, or
    * for a better match. Not all applications will use the same instrument identifiers, which
@@ -792,7 +787,7 @@ export interface InstrumentObject {
    * interoperability between disparate data sources. This is especially useful when using an
    * `id` field that is not globally unique.
    */
-  market?: Market;
+  market?: OrganizationMarket;
   type: TentacledInteractionType;
   name?: string;
   [property: string]: any;
@@ -892,8 +887,104 @@ export enum TentacledInteractionType {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ChatSearchCriteriaType {
-  Fdc3ChatSearchCriteria = 'fdc3.chat.searchCriteria',
+
+/**
+ * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
+ */
+export interface Contact {
+  /**
+   * Identifiers that relate to the Contact represented by this context
+   */
+  id: FluffyContactIdentifiers;
+  type: 'fdc3.contact';
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * Identifiers that relate to the Contact represented by this context
+ */
+export interface FluffyContactIdentifiers {
+  /**
+   * The email address for the contact
+   */
+  email?: string;
+  /**
+   * FactSet Permanent Identifier representing the contact
+   */
+  FDS_ID?: string;
+  [property: string]: any;
+}
+
+/**
+ * A collection of contacts, e.g. for chatting to or calling multiple contacts.
+ *
+ * The contact list schema does not explicitly include identifiers in the `id` section, as
+ * there is not a common standard for such identifiers. Applications can, however, populate
+ * this part of the contract with custom identifiers if so desired.
+ */
+export interface ContactList {
+  /**
+   * An array of contact contexts that forms the list.
+   */
+  contacts: ContactElement[];
+  type: 'fdc3.contactList';
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * The `fdc3.context` type defines the basic contract or "shape" for all data exchanged by
+ * FDC3 operations. As such, it is not really meant to be used on its own, but is imported
+ * by more specific type definitions (standardized or custom) to provide the structure and
+ * properties shared by all FDC3 context data types.
+ *
+ * The key element of FDC3 context types is their mandatory `type` property, which is used
+ * to identify what type of data the object represents, and what shape it has.
+ *
+ * The FDC3 context type, and all derived types, define the minimum set of fields a context
+ * data object of a particular type can be expected to have, but this can always be extended
+ * with custom fields as appropriate.
+ */
+export interface Context {
+  /**
+   * Context data objects may include a set of equivalent key-value pairs that can be used to
+   * help applications identify and look up the context type they receive in their own domain.
+   * The idea behind this design is that applications can provide as many equivalent
+   * identifiers to a target application as possible, e.g. an instrument may be represented by
+   * an ISIN, CUSIP or Bloomberg identifier.
+   *
+   * Identifiers do not make sense for all types of data, so the `id` property is therefore
+   * optional, but some derived types may choose to require at least one identifier.
+   */
+  id?: { [key: string]: any };
+  /**
+   * Context data objects may include a name property that can be used for more information,
+   * or display purposes. Some derived types may require the name object as mandatory,
+   * depending on use case.
+   */
+  name?: string;
+  /**
+   * The type property is the only _required_ part of the FDC3 context data schema. The FDC3
+   * [API](https://fdc3.finos.org/docs/api/spec) relies on the `type` property being present
+   * to route shared context data appropriately.
+   *
+   * FDC3 [Intents](https://fdc3.finos.org/docs/intents/spec) also register the context data
+   * types they support in an FDC3 [App
+   * Directory](https://fdc3.finos.org/docs/app-directory/overview), used for intent discovery
+   * and routing.
+   *
+   * Standardized FDC3 context types have well-known `type` properties prefixed with the
+   * `fdc3` namespace, e.g. `fdc3.instrument`. For non-standard types, e.g. those defined and
+   * used by a particular organization, the convention is to prefix them with an
+   * organization-specific namespace, e.g. `blackrock.fund`.
+   *
+   * See the [Context Data Specification](https://fdc3.finos.org/docs/context/spec) for more
+   * information about context data types.
+   */
+  type: string;
+  [property: string]: any;
 }
 
 /**
@@ -915,7 +1006,7 @@ export enum ChatSearchCriteriaType {
  */
 export interface Country {
   id: CountryID;
-  type: CountryType;
+  type: 'fdc3.country';
   name?: string;
   [property: string]: any;
 }
@@ -948,9 +1039,6 @@ export interface CountryID {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum CountryType {
-  Fdc3Country = 'fdc3.country',
-}
 
 /**
  * A context representing an individual Currency.
@@ -961,7 +1049,7 @@ export interface Currency {
    * The name of the currency for display purposes
    */
   name?: string;
-  type: CurrencyType;
+  type: 'fdc3.currency';
   [property: string]: any;
 }
 
@@ -980,9 +1068,6 @@ export interface CurrencyID {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum CurrencyType {
-  Fdc3Currency = 'fdc3.currency',
-}
 
 /**
  * A collection of information to be used to initiate an email with a Contact or ContactList.
@@ -1000,7 +1085,7 @@ export interface Email {
    * Body content for the email.
    */
   textBody?: string;
-  type: EmailType;
+  type: 'fdc3.email';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1033,7 +1118,7 @@ export interface EmailRecipients {
   /**
    * An array of contact contexts that forms the list.
    */
-  contacts?: Contact[];
+  contacts?: ContactElement[];
   [property: string]: any;
 }
 
@@ -1069,8 +1154,116 @@ export enum EmailRecipientsType {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum EmailType {
-  Fdc3Email = 'fdc3.email',
+
+/**
+ * A financial instrument from any asset class.
+ */
+export interface Instrument {
+  /**
+   * Any combination of instrument identifiers can be used together to resolve ambiguity, or
+   * for a better match. Not all applications will use the same instrument identifiers, which
+   * is why FDC3 allows for multiple to be specified. In general, the more identifiers an
+   * application can provide, the easier it will be to achieve interoperability.
+   *
+   * It is valid to include extra properties and metadata as part of the instrument payload,
+   * but the minimum requirement is for at least one instrument identifier to be provided.
+   *
+   * Try to only use instrument identifiers as intended. E.g. the `ticker` property is meant
+   * for tickers as used by an exchange.
+   * If the identifier you want to share is not a ticker or one of the other standardized
+   * fields, define a property that makes it clear what the value represents. Doing so will
+   * make interpretation easier for the developers of target applications.
+   */
+  id: FluffyInstrumentIdentifiers;
+  /**
+   * The `market` map can be used to further specify the instrument and help achieve
+   * interoperability between disparate data sources. This is especially useful when using an
+   * `id` field that is not globally unique.
+   */
+  market?: PurpleMarket;
+  type: 'fdc3.instrument';
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * Any combination of instrument identifiers can be used together to resolve ambiguity, or
+ * for a better match. Not all applications will use the same instrument identifiers, which
+ * is why FDC3 allows for multiple to be specified. In general, the more identifiers an
+ * application can provide, the easier it will be to achieve interoperability.
+ *
+ * It is valid to include extra properties and metadata as part of the instrument payload,
+ * but the minimum requirement is for at least one instrument identifier to be provided.
+ *
+ * Try to only use instrument identifiers as intended. E.g. the `ticker` property is meant
+ * for tickers as used by an exchange.
+ * If the identifier you want to share is not a ticker or one of the other standardized
+ * fields, define a property that makes it clear what the value represents. Doing so will
+ * make interpretation easier for the developers of target applications.
+ */
+export interface FluffyInstrumentIdentifiers {
+  /**
+   * <https://www.bloomberg.com/>
+   */
+  BBG?: string;
+  /**
+   * <https://www.cusip.com/>
+   */
+  CUSIP?: string;
+  /**
+   * <https://www.factset.com/>
+   */
+  FDS_ID?: string;
+  /**
+   * <https://www.openfigi.com/>
+   */
+  FIGI?: string;
+  /**
+   * <https://www.isin.org/>
+   */
+  ISIN?: string;
+  /**
+   * <https://permid.org/>
+   */
+  PERMID?: string;
+  /**
+   * <https://www.refinitiv.com/>
+   */
+  RIC?: string;
+  /**
+   * <https://www.lseg.com/sedol>
+   */
+  SEDOL?: string;
+  /**
+   * Unstandardized stock tickers
+   */
+  ticker?: string;
+  [property: string]: any;
+}
+
+/**
+ * The `market` map can be used to further specify the instrument and help achieve
+ * interoperability between disparate data sources. This is especially useful when using an
+ * `id` field that is not globally unique.
+ */
+export interface PurpleMarket {
+  /**
+   * <https://www.bloomberg.com/>
+   */
+  BBG?: string;
+  /**
+   * <https://www.iso.org/iso-3166-country-codes.html>
+   */
+  COUNTRY_ISOALPHA2?: string;
+  /**
+   * <https://en.wikipedia.org/wiki/Market_Identifier_Code>
+   */
+  MIC?: string;
+  /**
+   * Human readable market name
+   */
+  name?: string;
+  [property: string]: any;
 }
 
 /**
@@ -1087,8 +1280,8 @@ export interface InstrumentList {
   /**
    * An array of instrument contexts that forms the list.
    */
-  instruments: Instrument[];
-  type: InstrumentListType;
+  instruments: InstrumentElement[];
+  type: 'fdc3.instrumentList';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1100,9 +1293,6 @@ export interface InstrumentList {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum InstrumentListType {
-  Fdc3InstrumentList = 'fdc3.instrumentList',
-}
 
 /**
  * An `Interaction` is a significant direct exchange of ideas or information between a
@@ -1126,7 +1316,7 @@ export interface Interaction {
   /**
    * The contact that initiated the interaction
    */
-  initiator?: Contact;
+  initiator?: ContactElement;
   /**
    * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
    * `'Meeting'` although other string values are permitted.
@@ -1140,12 +1330,12 @@ export interface Interaction {
   /**
    * A list of contacts involved in the interaction
    */
-  participants: ContactList;
+  participants: ContactListObject;
   /**
    * The time range over which the interaction occurred
    */
-  timeRange: TimeRange;
-  type: InteractionType;
+  timeRange: TimeRangeObject;
+  type: 'fdc3.interaction';
   name?: string;
   [property: string]: any;
 }
@@ -1181,8 +1371,94 @@ export interface InteractionID {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum InteractionType {
-  Fdc3Interaction = 'fdc3.interaction',
+
+/**
+ * A chat message to be sent through an instant messaging application. Can contain one or
+ * several text bodies (organized by mime-type, plaintext or markdown), as well as attached
+ * entities (either arbitrary file attachments or FDC3 actions to be embedded in the
+ * message). To be put inside a ChatInitSettings object.
+ */
+export interface Message {
+  /**
+   * A map of string IDs to entities that should be attached to the message, such as an action
+   * to perform, a file attachment, or other FDC3 context object.
+   */
+  entities?: { [key: string]: FluffyAction };
+  /**
+   * A map of string mime-type to string content
+   */
+  text?: FluffyMessageText;
+  type: 'fdc3.message';
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * A representation of an FDC3 Action (specified via a Context or Context & Intent) that can
+ * be inserted inside another object, for example a chat message.
+ *
+ * The action may be completed by calling `fdc3.raiseIntent()` with the specified Intent and
+ * Context, or, if only a context is specified, by calling `fdc3.raiseIntentForContext()`
+ * (which the Desktop Agent will resolve by presenting the user with a list of available
+ * Intents for the Context).
+ *
+ * Accepts an optional `app` parameter in order to specify a specific app.
+ *
+ * A File attachment encoded in the form of a data URI
+ */
+export interface FluffyAction {
+  /**
+   * An optional target application identifier that should perform the action
+   */
+  app?: ActionTargetApp;
+  /**
+   * A context object with which the action will be performed
+   */
+  context?: ContextElement;
+  /**
+   * Optional Intent to raise to perform the actions. Should reference an intent type name,
+   * such as those defined in the FDC3 Standard. If intent is not set then
+   * `fdc3.raiseIntentForContext` should be used to perform the action as this will usually
+   * allow the user to choose the intent to raise.
+   */
+  intent?: string;
+  /**
+   * A human readable display name for the action
+   */
+  title?: string;
+  type: EntityType;
+  id?: { [key: string]: any };
+  name?: string;
+  data?: FluffyData;
+  [property: string]: any;
+}
+
+export interface FluffyData {
+  /**
+   * A data URI encoding the content of the file to be attached
+   */
+  dataUri: string;
+  /**
+   * The name of the attached file
+   */
+  name: string;
+  [property: string]: any;
+}
+
+/**
+ * A map of string mime-type to string content
+ */
+export interface FluffyMessageText {
+  /**
+   * Markdown encoded content
+   */
+  'text/markdown'?: string;
+  /**
+   * Plain text encoded content.
+   */
+  'text/plain'?: string;
+  [property: string]: any;
 }
 
 /**
@@ -1200,7 +1476,7 @@ export enum InteractionType {
  * for a lack of context, for example in their intent metadata in an app directory.
  */
 export interface Nothing {
-  type: NothingType;
+  type: 'fdc3.nothing';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1212,28 +1488,6 @@ export interface Nothing {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum NothingType {
-  Fdc3Nothing = 'fdc3.nothing',
-}
-
-/**
- * @experimental A list of orders. Use this type for use cases that require not just a
- * single order, but multiple.
- *
- * The OrderList schema does not explicitly include identifiers in the id section, as there
- * is not a common standard for such identifiers. Applications can, however, populate this
- * part of the contract with custom identifiers if so desired.
- */
-export interface OrderList {
-  /**
-   * An array of order contexts that forms the list.
-   */
-  orders: Order[];
-  type: OrderListType;
-  id?: { [key: string]: any };
-  name?: string;
-  [property: string]: any;
-}
 
 /**
  * @experimental context type representing an order. To be used with OMS and EMS systems.
@@ -1251,7 +1505,7 @@ export interface Order {
    * Optional additional details about the order, which may include a product element that is
    * an, as yet undefined but extensible, Context
    */
-  details?: OrderDetails;
+  details?: PurpleOrderDetails;
   /**
    * One or more identifiers that refer to the order in an OMS, EMS or related system.
    * Specific key names for systems are expected to be standardized in future.
@@ -1261,7 +1515,7 @@ export interface Order {
    * An optional human-readable summary of the order.
    */
   name?: string;
-  type: OrderType;
+  type: 'fdc3.order';
   [property: string]: any;
 }
 
@@ -1269,8 +1523,8 @@ export interface Order {
  * Optional additional details about the order, which may include a product element that is
  * an, as yet undefined but extensible, Context
  */
-export interface OrderDetails {
-  product?: Product;
+export interface PurpleOrderDetails {
+  product?: ProductObject;
   [property: string]: any;
 }
 
@@ -1287,7 +1541,7 @@ export interface OrderDetails {
  * not a common standard for such identifiers. Applications can, however, populate this part
  * of the contract with custom identifiers if so desired.
  */
-export interface Product {
+export interface ProductObject {
   /**
    * One or more identifiers that refer to the product. Specific key names for systems are
    * expected to be standardized in future.
@@ -1296,12 +1550,12 @@ export interface Product {
   /**
    * financial instrument that relates to the definition of this product
    */
-  instrument?: Instrument;
+  instrument?: InstrumentElement;
   /**
    * A human-readable summary of the product.
    */
   name?: string;
-  type: ProductType;
+  type: 'fdc3.product';
   [property: string]: any;
 }
 
@@ -1311,8 +1565,70 @@ export interface Product {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ProductType {
-  Fdc3Product = 'fdc3.product',
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+
+/**
+ * @experimental A list of orders. Use this type for use cases that require not just a
+ * single order, but multiple.
+ *
+ * The OrderList schema does not explicitly include identifiers in the id section, as there
+ * is not a common standard for such identifiers. Applications can, however, populate this
+ * part of the contract with custom identifiers if so desired.
+ */
+export interface OrderList {
+  /**
+   * An array of order contexts that forms the list.
+   */
+  orders: OrderElement[];
+  type: 'fdc3.orderList';
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * @experimental context type representing an order. To be used with OMS and EMS systems.
+ *
+ * This type currently only defines a required `id` field, which should provide a reference
+ * to the order in one or more systems, an optional human readable `name` field to be used
+ * to summarize the order and an optional `details` field that may be used to provide
+ * additional detail about the order, including a context representing a `product`, which
+ * may be extended with arbitrary properties. The `details.product` field is currently typed
+ * as a unspecified Context type, but both `details` and `details.product` are expected to
+ * be standardized in future.
+ */
+export interface OrderElement {
+  /**
+   * Optional additional details about the order, which may include a product element that is
+   * an, as yet undefined but extensible, Context
+   */
+  details?: FluffyOrderDetails;
+  /**
+   * One or more identifiers that refer to the order in an OMS, EMS or related system.
+   * Specific key names for systems are expected to be standardized in future.
+   */
+  id: { [key: string]: string };
+  /**
+   * An optional human-readable summary of the order.
+   */
+  name?: string;
+  type: 'fdc3.order';
+  [property: string]: any;
+}
+
+/**
+ * Optional additional details about the order, which may include a product element that is
+ * an, as yet undefined but extensible, Context
+ */
+export interface FluffyOrderDetails {
+  product?: ProductObject;
+  [property: string]: any;
 }
 
 /**
@@ -1321,19 +1637,6 @@ export enum ProductType {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum OrderType {
-  Fdc3Order = 'fdc3.order',
-}
-
-/**
- * Free text to be used for a keyword search
- *
- * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
- * `'Meeting'` although other string values are permitted.
- */
-export enum OrderListType {
-  Fdc3OrderList = 'fdc3.orderList',
-}
 
 /**
  * An entity that can be used when referencing private companies and other organizations
@@ -1347,7 +1650,7 @@ export interface Organization {
    * Identifiers for the organization, at least one must be provided.
    */
   id: OrganizationIdentifiers;
-  type: StickyInteractionType;
+  type: 'fdc3.organization';
   name?: string;
   [property: string]: any;
 }
@@ -1380,9 +1683,6 @@ export interface OrganizationIdentifiers {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum StickyInteractionType {
-  Fdc3Organization = 'fdc3.organization',
-}
 
 /**
  * A financial portfolio made up of multiple positions (holdings) in several instruments.
@@ -1403,12 +1703,52 @@ export interface Portfolio {
   /**
    * The List of Positions which make up the Portfolio
    */
-  positions: Position[];
-  type: PortfolioType;
+  positions: PositionElement[];
+  type: 'fdc3.portfolio';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
 }
+
+/**
+ * A financial position made up of an instrument and a holding in that instrument. This type
+ * is a good example of how new context types can be composed from existing types.
+ *
+ * In this case, the instrument and the holding amount for that instrument are required
+ * values.
+ *
+ * The [Position](Position) type goes hand-in-hand with the [Portfolio](Portfolio) type,
+ * which represents multiple holdings in a combination of instruments.
+ *
+ * The position schema does not explicitly include identifiers in the `id` section, as there
+ * is not a common standard for such identifiers. Applications can, however, populate this
+ * part of the contract with custom identifiers if so desired.
+ */
+export interface PositionElement {
+  /**
+   * The amount of the holding, e.g. a number of shares
+   */
+  holding: number;
+  instrument: InstrumentElement;
+  type: 'fdc3.position';
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
+
+/**
+ * Free text to be used for a keyword search
+ *
+ * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
+ * `'Meeting'` although other string values are permitted.
+ */
 
 /**
  * A financial position made up of an instrument and a holding in that instrument. This type
@@ -1429,47 +1769,86 @@ export interface Position {
    * The amount of the holding, e.g. a number of shares
    */
   holding: number;
-  instrument: Instrument;
-  type: PositionType;
+  instrument: InstrumentElement;
+  type: 'fdc3.position';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
 }
 
 /**
- * Free text to be used for a keyword search
+ * @experimental context type representing a tradable product. To be used with OMS and EMS
+ * systems.
  *
- * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
- * `'Meeting'` although other string values are permitted.
- */
-export enum PositionType {
-  Fdc3Position = 'fdc3.position',
-}
-
-/**
- * Free text to be used for a keyword search
+ * This type is currently only loosely defined as an extensible context object, with an
+ * optional instrument field.
  *
- * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
- * `'Meeting'` although other string values are permitted.
+ * The Product schema does not explicitly include identifiers in the id section, as there is
+ * not a common standard for such identifiers. Applications can, however, populate this part
+ * of the contract with custom identifiers if so desired.
  */
-export enum PortfolioType {
-  Fdc3Portfolio = 'fdc3.portfolio',
-}
-
-/**
- * @experimental A list of trades. Use this type for use cases that require not just a
- * single trade, but multiple.
- *
- * The TradeList schema does not explicitly include identifiers in the id section, as there
- * is not a common standard for such identifiers. Applications can, however, populate this
- * part of the contract with custom identifiers if so desired.
- */
-export interface TradeList {
+export interface Product {
   /**
-   * An array of trade contexts that forms the list.
+   * One or more identifiers that refer to the product. Specific key names for systems are
+   * expected to be standardized in future.
    */
-  trades: Trade[];
-  type: TradeListType;
+  id: { [key: string]: string };
+  /**
+   * financial instrument that relates to the definition of this product
+   */
+  instrument?: InstrumentElement;
+  /**
+   * A human-readable summary of the product.
+   */
+  name?: string;
+  type: 'fdc3.product';
+  [property: string]: any;
+}
+
+/**
+ * A context representing a period of time. Any user interfaces that represent or visualize
+ * events or activity over time can be filtered or focused on a particular time period,
+ * e.g.:
+ *
+ * - A pricing chart
+ * - A trade blotter
+ * - A record of client contact/activity in a CRM
+ *
+ * Example use cases:
+ *
+ * - User may want to view pricing/trades/customer activity for a security over a particular
+ * time period, the time range might be specified as the context for the `ViewChart` intent
+ * OR it might be embedded in another context (e.g. a context representing a chart to plot).
+ * - User filters a visualization (e.g. a pricing chart) to show a particular period, the
+ * `TimeRange` is broadcast and other visualizations (e.g. a heatmap of activity by
+ * instrument, or industry sector etc.) receive it and filter themselves to show data over
+ * the same range.
+ *
+ * Notes:
+ *
+ * - A `TimeRange` may be closed (i.e. `startTime` and `endTime` are both known) or open
+ * (i.e. only one of `startTime` or `endTime` is known).
+ * - Ranges corresponding to dates (e.g. `2022-05-12` to `2022-05-19`) should be specified
+ * using times as this prevents issues with timezone conversions and inclusive/exclusive
+ * date ranges.
+ * - String fields representing times are encoded according to [ISO
+ * 8601-1:2019](https://www.iso.org/standard/70907.html).
+ * - A timezone indicator should be specified, e.g. `"2022-05-12T15:18:03Z"` or
+ * `"2022-05-12T16:18:03+01:00"`
+ * - Times MAY be specified with millisecond precision, e.g. `"2022-05-12T15:18:03.349Z"`
+ */
+export interface TimeRange {
+  /**
+   * The end time of the range, encoded according to [ISO
+   * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
+   */
+  endTime?: Date;
+  /**
+   * The start time of the range, encoded according to [ISO
+   * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
+   */
+  startTime?: Date;
+  type: 'fdc3.timerange';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1501,8 +1880,8 @@ export interface Trade {
   /**
    * A product that is the subject of th trade.
    */
-  product: Product;
-  type: TradeType;
+  product: ProductObject;
+  type: 'fdc3.trade';
   [property: string]: any;
 }
 
@@ -1512,8 +1891,55 @@ export interface Trade {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum TradeType {
-  Fdc3Trade = 'fdc3.trade',
+
+/**
+ * @experimental A list of trades. Use this type for use cases that require not just a
+ * single trade, but multiple.
+ *
+ * The TradeList schema does not explicitly include identifiers in the id section, as there
+ * is not a common standard for such identifiers. Applications can, however, populate this
+ * part of the contract with custom identifiers if so desired.
+ */
+export interface TradeList {
+  /**
+   * An array of trade contexts that forms the list.
+   */
+  trades: TradeElement[];
+  type: 'fdc3.tradeList';
+  id?: { [key: string]: any };
+  name?: string;
+  [property: string]: any;
+}
+
+/**
+ * @experimental context type representing a trade. To be used with execution systems.
+ *
+ * This type currently only defines a required `id` field, which should provide a reference
+ * to the trade in one or more systems, an optional human readable `name` field to be used
+ * to summarize the trade and a required `product` field that may be used to provide
+ * additional detail about the trade, which is currently typed as a unspecified Context
+ * type, but `product` is expected to be standardized in future.
+ *
+ * The Trade schema does not explicitly include identifiers in the id section, as there is
+ * not a common standard for such identifiers. Applications can, however, populate this part
+ * of the contract with custom identifiers if so desired.
+ */
+export interface TradeElement {
+  /**
+   * One or more identifiers that refer to the trade in an OMS, EMS or related system.
+   * Specific key names for systems are expected to be standardized in future.
+   */
+  id: { [key: string]: string };
+  /**
+   * A human-readable summary of the trade.
+   */
+  name?: string;
+  /**
+   * A product that is the subject of th trade.
+   */
+  product: ProductObject;
+  type: 'fdc3.trade';
+  [property: string]: any;
 }
 
 /**
@@ -1522,9 +1948,6 @@ export enum TradeType {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum TradeListType {
-  Fdc3TradeList = 'fdc3.tradeList',
-}
 
 /**
  * A context type representing the result of a transaction initiated via FDC3, which SHOULD
@@ -1536,12 +1959,12 @@ export interface TransactionResult {
   /**
    * A context object returned by the transaction, possibly with updated data.
    */
-  context?: Context;
+  context?: ContextElement;
   /**
    * The status of the transaction being reported.
    */
   status: TransactionStatus;
-  type: TransactionResultType;
+  type: 'fdc3.transactionResult';
   id?: { [key: string]: any };
   name?: string;
   [property: string]: any;
@@ -1563,9 +1986,6 @@ export enum TransactionStatus {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum TransactionResultType {
-  Fdc3TransactionResult = 'fdc3.transactionResult',
-}
 
 /**
  * A context type representing the price and value of a holding.
@@ -1585,7 +2005,7 @@ export interface Valuation {
    * The price per unit the the valuation is based on.
    */
   price?: number;
-  type: ValuationType;
+  type: 'fdc3.valuation';
   /**
    * The time at which the valuation was performed, encoded according to [ISO
    * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator included.
@@ -1606,9 +2026,6 @@ export interface Valuation {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum ValuationType {
-  Fdc3Valuation = 'fdc3.valuation',
-}
 
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
@@ -2008,7 +2425,7 @@ const typeMap: any = {
   Action: o(
     [
       { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
-      { json: 'context', js: 'context', typ: r('Context') },
+      { json: 'context', js: 'context', typ: r('ContextElement') },
       { json: 'intent', js: 'intent', typ: u(undefined, '') },
       { json: 'title', js: 'title', typ: '' },
       { json: 'type', js: 'type', typ: r('ActionType') },
@@ -2025,7 +2442,7 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Context: o(
+  ContextElement: o(
     [
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
@@ -2035,9 +2452,9 @@ const typeMap: any = {
   ),
   Chart: o(
     [
-      { json: 'instruments', js: 'instruments', typ: a(r('Instrument')) },
-      { json: 'otherConfig', js: 'otherConfig', typ: u(undefined, a(r('Context'))) },
-      { json: 'range', js: 'range', typ: u(undefined, r('TimeRange')) },
+      { json: 'instruments', js: 'instruments', typ: a(r('InstrumentElement')) },
+      { json: 'otherConfig', js: 'otherConfig', typ: u(undefined, a(r('ContextElement'))) },
+      { json: 'range', js: 'range', typ: u(undefined, r('TimeRangeObject')) },
       { json: 'style', js: 'style', typ: u(undefined, r('ChartStyle')) },
       { json: 'type', js: 'type', typ: r('ChartType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
@@ -2045,16 +2462,16 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Instrument: o(
+  InstrumentElement: o(
     [
-      { json: 'id', js: 'id', typ: r('InstrumentIdentifiers') },
-      { json: 'market', js: 'market', typ: u(undefined, r('Market')) },
+      { json: 'id', js: 'id', typ: r('PurpleInstrumentIdentifiers') },
+      { json: 'market', js: 'market', typ: u(undefined, r('OrganizationMarket')) },
       { json: 'type', js: 'type', typ: r('PurpleInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  InstrumentIdentifiers: o(
+  PurpleInstrumentIdentifiers: o(
     [
       { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
       { json: 'CUSIP', js: 'CUSIP', typ: u(undefined, '') },
@@ -2068,7 +2485,7 @@ const typeMap: any = {
     ],
     'any'
   ),
-  Market: o(
+  OrganizationMarket: o(
     [
       { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
       { json: 'COUNTRY_ISOALPHA2', js: 'COUNTRY_ISOALPHA2', typ: u(undefined, '') },
@@ -2077,7 +2494,7 @@ const typeMap: any = {
     ],
     'any'
   ),
-  TimeRange: o(
+  TimeRangeObject: o(
     [
       { json: 'endTime', js: 'endTime', typ: u(undefined, Date) },
       { json: 'startTime', js: 'startTime', typ: u(undefined, Date) },
@@ -2090,8 +2507,8 @@ const typeMap: any = {
   ChatInitSettings: o(
     [
       { json: 'chatName', js: 'chatName', typ: u(undefined, '') },
-      { json: 'members', js: 'members', typ: u(undefined, r('ContactList')) },
-      { json: 'message', js: 'message', typ: u(undefined, u(r('Message'), '')) },
+      { json: 'members', js: 'members', typ: u(undefined, r('ContactListObject')) },
+      { json: 'message', js: 'message', typ: u(undefined, u(r('MessageObject'), '')) },
       { json: 'options', js: 'options', typ: u(undefined, r('ChatOptions')) },
       { json: 'type', js: 'type', typ: r('ChatInitSettingsType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
@@ -2099,61 +2516,61 @@ const typeMap: any = {
     ],
     'any'
   ),
-  ContactList: o(
+  ContactListObject: o(
     [
-      { json: 'contacts', js: 'contacts', typ: a(r('Contact')) },
+      { json: 'contacts', js: 'contacts', typ: a(r('ContactElement')) },
       { json: 'type', js: 'type', typ: r('ContactListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  Contact: o(
+  ContactElement: o(
     [
-      { json: 'id', js: 'id', typ: r('ContactID') },
+      { json: 'id', js: 'id', typ: r('PurpleContactIdentifiers') },
       { json: 'type', js: 'type', typ: r('FluffyInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  ContactID: o(
+  PurpleContactIdentifiers: o(
     [
       { json: 'email', js: 'email', typ: u(undefined, '') },
       { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
     ],
     'any'
   ),
-  Message: o(
+  MessageObject: o(
     [
-      { json: 'entities', js: 'entities', typ: u(undefined, m(r('EntityValue'))) },
-      { json: 'text', js: 'text', typ: u(undefined, r('MessageText')) },
+      { json: 'entities', js: 'entities', typ: u(undefined, m(r('PurpleAction'))) },
+      { json: 'text', js: 'text', typ: u(undefined, r('PurpleMessageText')) },
       { json: 'type', js: 'type', typ: r('MessageType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  EntityValue: o(
+  PurpleAction: o(
     [
       { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'intent', js: 'intent', typ: u(undefined, '') },
       { json: 'title', js: 'title', typ: u(undefined, '') },
       { json: 'type', js: 'type', typ: r('EntityType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'data', js: 'data', typ: u(undefined, r('Data')) },
+      { json: 'data', js: 'data', typ: u(undefined, r('PurpleData')) },
     ],
     'any'
   ),
-  Data: o(
+  PurpleData: o(
     [
       { json: 'dataUri', js: 'dataUri', typ: '' },
       { json: 'name', js: 'name', typ: '' },
     ],
     'any'
   ),
-  MessageText: o(
+  PurpleMessageText: o(
     [
       { json: 'text/markdown', js: 'text/markdown', typ: u(undefined, '') },
       { json: 'text/plain', js: 'text/plain', typ: u(undefined, '') },
@@ -2172,11 +2589,21 @@ const typeMap: any = {
   ),
   ChatMessage: o(
     [
-      { json: 'chatRoom', js: 'chatRoom', typ: r('ChatRoom') },
-      { json: 'message', js: 'message', typ: u(r('Message'), '') },
+      { json: 'chatRoom', js: 'chatRoom', typ: r('ChatRoomObject') },
+      { json: 'message', js: 'message', typ: u(r('MessageObject'), '') },
       { json: 'type', js: 'type', typ: r('ChatMessageType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  ChatRoomObject: o(
+    [
+      { json: 'id', js: 'id', typ: m('any') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'providerName', js: 'providerName', typ: '' },
+      { json: 'type', js: 'type', typ: r('ChatRoomType') },
+      { json: 'url', js: 'url', typ: u(undefined, '') },
     ],
     'any'
   ),
@@ -2192,17 +2619,17 @@ const typeMap: any = {
   ),
   ChatSearchCriteria: o(
     [
-      { json: 'criteria', js: 'criteria', typ: a(u(r('InstrumentObject'), '')) },
+      { json: 'criteria', js: 'criteria', typ: a(u(r('OrganizationObject'), '')) },
       { json: 'type', js: 'type', typ: r('ChatSearchCriteriaType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  InstrumentObject: o(
+  OrganizationObject: o(
     [
       { json: 'id', js: 'id', typ: r('Identifiers') },
-      { json: 'market', js: 'market', typ: u(undefined, r('Market')) },
+      { json: 'market', js: 'market', typ: u(undefined, r('OrganizationMarket')) },
       { json: 'type', js: 'type', typ: r('TentacledInteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2221,6 +2648,38 @@ const typeMap: any = {
       { json: 'ticker', js: 'ticker', typ: u(undefined, '') },
       { json: 'LEI', js: 'LEI', typ: u(undefined, '') },
       { json: 'email', js: 'email', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  Contact: o(
+    [
+      { json: 'id', js: 'id', typ: r('FluffyContactIdentifiers') },
+      { json: 'type', js: 'type', typ: r('FluffyInteractionType') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  FluffyContactIdentifiers: o(
+    [
+      { json: 'email', js: 'email', typ: u(undefined, '') },
+      { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  ContactList: o(
+    [
+      { json: 'contacts', js: 'contacts', typ: a(r('ContactElement')) },
+      { json: 'type', js: 'type', typ: r('ContactListType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  Context: o(
+    [
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'type', js: 'type', typ: '' },
     ],
     'any'
   ),
@@ -2266,7 +2725,7 @@ const typeMap: any = {
       { json: 'id', js: 'id', typ: u(undefined, r('EmailRecipientsID')) },
       { json: 'type', js: 'type', typ: r('EmailRecipientsType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'contacts', js: 'contacts', typ: u(undefined, a(r('Contact'))) },
+      { json: 'contacts', js: 'contacts', typ: u(undefined, a(r('ContactElement'))) },
     ],
     'any'
   ),
@@ -2277,9 +2736,41 @@ const typeMap: any = {
     ],
     'any'
   ),
+  Instrument: o(
+    [
+      { json: 'id', js: 'id', typ: r('FluffyInstrumentIdentifiers') },
+      { json: 'market', js: 'market', typ: u(undefined, r('PurpleMarket')) },
+      { json: 'type', js: 'type', typ: r('PurpleInteractionType') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  FluffyInstrumentIdentifiers: o(
+    [
+      { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
+      { json: 'CUSIP', js: 'CUSIP', typ: u(undefined, '') },
+      { json: 'FDS_ID', js: 'FDS_ID', typ: u(undefined, '') },
+      { json: 'FIGI', js: 'FIGI', typ: u(undefined, '') },
+      { json: 'ISIN', js: 'ISIN', typ: u(undefined, '') },
+      { json: 'PERMID', js: 'PERMID', typ: u(undefined, '') },
+      { json: 'RIC', js: 'RIC', typ: u(undefined, '') },
+      { json: 'SEDOL', js: 'SEDOL', typ: u(undefined, '') },
+      { json: 'ticker', js: 'ticker', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  PurpleMarket: o(
+    [
+      { json: 'BBG', js: 'BBG', typ: u(undefined, '') },
+      { json: 'COUNTRY_ISOALPHA2', js: 'COUNTRY_ISOALPHA2', typ: u(undefined, '') },
+      { json: 'MIC', js: 'MIC', typ: u(undefined, '') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
   InstrumentList: o(
     [
-      { json: 'instruments', js: 'instruments', typ: a(r('Instrument')) },
+      { json: 'instruments', js: 'instruments', typ: a(r('InstrumentElement')) },
       { json: 'type', js: 'type', typ: r('InstrumentListType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
@@ -2290,11 +2781,11 @@ const typeMap: any = {
     [
       { json: 'description', js: 'description', typ: '' },
       { json: 'id', js: 'id', typ: u(undefined, r('InteractionID')) },
-      { json: 'initiator', js: 'initiator', typ: u(undefined, r('Contact')) },
+      { json: 'initiator', js: 'initiator', typ: u(undefined, r('ContactElement')) },
       { json: 'interactionType', js: 'interactionType', typ: '' },
       { json: 'origin', js: 'origin', typ: u(undefined, '') },
-      { json: 'participants', js: 'participants', typ: r('ContactList') },
-      { json: 'timeRange', js: 'timeRange', typ: r('TimeRange') },
+      { json: 'participants', js: 'participants', typ: r('ContactListObject') },
+      { json: 'timeRange', js: 'timeRange', typ: r('TimeRangeObject') },
       { json: 'type', js: 'type', typ: r('InteractionType') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2308,6 +2799,43 @@ const typeMap: any = {
     ],
     'any'
   ),
+  Message: o(
+    [
+      { json: 'entities', js: 'entities', typ: u(undefined, m(r('FluffyAction'))) },
+      { json: 'text', js: 'text', typ: u(undefined, r('FluffyMessageText')) },
+      { json: 'type', js: 'type', typ: r('MessageType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  FluffyAction: o(
+    [
+      { json: 'app', js: 'app', typ: u(undefined, r('ActionTargetApp')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
+      { json: 'intent', js: 'intent', typ: u(undefined, '') },
+      { json: 'title', js: 'title', typ: u(undefined, '') },
+      { json: 'type', js: 'type', typ: r('EntityType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'data', js: 'data', typ: u(undefined, r('FluffyData')) },
+    ],
+    'any'
+  ),
+  FluffyData: o(
+    [
+      { json: 'dataUri', js: 'dataUri', typ: '' },
+      { json: 'name', js: 'name', typ: '' },
+    ],
+    'any'
+  ),
+  FluffyMessageText: o(
+    [
+      { json: 'text/markdown', js: 'text/markdown', typ: u(undefined, '') },
+      { json: 'text/plain', js: 'text/plain', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
   Nothing: o(
     [
       { json: 'type', js: 'type', typ: r('NothingType') },
@@ -2316,34 +2844,44 @@ const typeMap: any = {
     ],
     'any'
   ),
-  OrderList: o(
-    [
-      { json: 'orders', js: 'orders', typ: a(r('Order')) },
-      { json: 'type', js: 'type', typ: r('OrderListType') },
-      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
-      { json: 'name', js: 'name', typ: u(undefined, '') },
-    ],
-    'any'
-  ),
   Order: o(
     [
-      { json: 'details', js: 'details', typ: u(undefined, r('OrderDetails')) },
+      { json: 'details', js: 'details', typ: u(undefined, r('PurpleOrderDetails')) },
       { json: 'id', js: 'id', typ: m('') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
       { json: 'type', js: 'type', typ: r('OrderType') },
     ],
     'any'
   ),
-  OrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('Product')) }], 'any'),
-  Product: o(
+  PurpleOrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('ProductObject')) }], 'any'),
+  ProductObject: o(
     [
       { json: 'id', js: 'id', typ: m('') },
-      { json: 'instrument', js: 'instrument', typ: u(undefined, r('Instrument')) },
+      { json: 'instrument', js: 'instrument', typ: u(undefined, r('InstrumentElement')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
       { json: 'type', js: 'type', typ: r('ProductType') },
     ],
     'any'
   ),
+  OrderList: o(
+    [
+      { json: 'orders', js: 'orders', typ: a(r('OrderElement')) },
+      { json: 'type', js: 'type', typ: r('OrderListType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  OrderElement: o(
+    [
+      { json: 'details', js: 'details', typ: u(undefined, r('FluffyOrderDetails')) },
+      { json: 'id', js: 'id', typ: m('') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'type', js: 'type', typ: r('OrderType') },
+    ],
+    'any'
+  ),
+  FluffyOrderDetails: o([{ json: 'product', js: 'product', typ: u(undefined, r('ProductObject')) }], 'any'),
   Organization: o(
     [
       { json: 'id', js: 'id', typ: r('OrganizationIdentifiers') },
@@ -2362,8 +2900,18 @@ const typeMap: any = {
   ),
   Portfolio: o(
     [
-      { json: 'positions', js: 'positions', typ: a(r('Position')) },
+      { json: 'positions', js: 'positions', typ: a(r('PositionElement')) },
       { json: 'type', js: 'type', typ: r('PortfolioType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  PositionElement: o(
+    [
+      { json: 'holding', js: 'holding', typ: 3.14 },
+      { json: 'instrument', js: 'instrument', typ: r('InstrumentElement') },
+      { json: 'type', js: 'type', typ: r('PositionType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2372,17 +2920,27 @@ const typeMap: any = {
   Position: o(
     [
       { json: 'holding', js: 'holding', typ: 3.14 },
-      { json: 'instrument', js: 'instrument', typ: r('Instrument') },
+      { json: 'instrument', js: 'instrument', typ: r('InstrumentElement') },
       { json: 'type', js: 'type', typ: r('PositionType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
     'any'
   ),
-  TradeList: o(
+  Product: o(
     [
-      { json: 'trades', js: 'trades', typ: a(r('Trade')) },
-      { json: 'type', js: 'type', typ: r('TradeListType') },
+      { json: 'id', js: 'id', typ: m('') },
+      { json: 'instrument', js: 'instrument', typ: u(undefined, r('InstrumentElement')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'type', js: 'type', typ: r('ProductType') },
+    ],
+    'any'
+  ),
+  TimeRange: o(
+    [
+      { json: 'endTime', js: 'endTime', typ: u(undefined, Date) },
+      { json: 'startTime', js: 'startTime', typ: u(undefined, Date) },
+      { json: 'type', js: 'type', typ: r('TimeRangeType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },
       { json: 'name', js: 'name', typ: u(undefined, '') },
     ],
@@ -2392,14 +2950,32 @@ const typeMap: any = {
     [
       { json: 'id', js: 'id', typ: m('') },
       { json: 'name', js: 'name', typ: u(undefined, '') },
-      { json: 'product', js: 'product', typ: r('Product') },
+      { json: 'product', js: 'product', typ: r('ProductObject') },
+      { json: 'type', js: 'type', typ: r('TradeType') },
+    ],
+    'any'
+  ),
+  TradeList: o(
+    [
+      { json: 'trades', js: 'trades', typ: a(r('TradeElement')) },
+      { json: 'type', js: 'type', typ: r('TradeListType') },
+      { json: 'id', js: 'id', typ: u(undefined, m('any')) },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+    ],
+    'any'
+  ),
+  TradeElement: o(
+    [
+      { json: 'id', js: 'id', typ: m('') },
+      { json: 'name', js: 'name', typ: u(undefined, '') },
+      { json: 'product', js: 'product', typ: r('ProductObject') },
       { json: 'type', js: 'type', typ: r('TradeType') },
     ],
     'any'
   ),
   TransactionResult: o(
     [
-      { json: 'context', js: 'context', typ: u(undefined, r('Context')) },
+      { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'status', js: 'status', typ: r('TransactionStatus') },
       { json: 'type', js: 'type', typ: r('TransactionResultType') },
       { json: 'id', js: 'id', typ: u(undefined, m('any')) },


### PR DESCRIPTION
THe latest version of quicktype has started generating single value enums for constant values, which are causing issues in the context type tests (Context types serialize but cause type errors on deserialization). However, its also capable of generating const values - although this option hasn't been exposed correctly through the CLI  (raising a PR to fix). Generating true const value fixes the issue.

I hadn't noticed this test failing when I merged:
- #1082 
This PR is needed to get the build passing again - although we also need a quicktype release to make it repeatable

Also resolving a critical vulnerability (babel) via `npm audit fix`