### PR TITLE
Switch to unions from enums for constrained string types in generated source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Updated definition of the `otherConfig` element of the `Chart` context type from an Object to an array of Contexts as this allows the `type` of each additional item of config to be examined before it is used ([#985](https://github.com/finos/FDC3/pull/985))
 * Corrected the appD `interop.appChannels` metadata to use an `id` field to identify channels, rather than `name` ([#981](https://github.com/finos/FDC3/pull/981))
 * The App Directory OpenAPI schema was converted from YAML to JSON Schema, containing the same definitions. ([#1035](https://github.com/finos/FDC3/pull/1035))
+* Switched to union types (from enums) for constrained string values in generated source files as they provide better type checking and cross-compatability of types. ([#1093](https://github.com/finos/FDC3/pull/1093))
 
 ### Deprecated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/s2tQuicktypeUtil.js
+++ b/s2tQuicktypeUtil.js
@@ -41,9 +41,10 @@ while (dirIndex < inputs.length) {
 }
 
 // Normalise path to local quicktype executable.
+//const quicktypeExec = "node " + ["..","quicktype","dist","index.js"].join(path.sep);
 const quicktypeExec = ['.', 'node_modules', '.bin', 'quicktype'].join(path.sep);
 
-const command = `${quicktypeExec} --no-combine-classes -s schema -o ${outputFile} ${sources}`;
+const command = `${quicktypeExec} --prefer-const-values --prefer-unions -s schema -o ${outputFile} ${sources}`;
 console.log('command to run: ' + command);
 
 exec(command, function(error, stdout, stderr) {

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -169,43 +169,41 @@ export interface ErrorResponseMessagePayload {
  * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
  * DesktopAgent (`fdc3`).
  */
-export enum ResponseErrorDetail {
-  AccessDenied = 'AccessDenied',
-  AgentDisconnected = 'AgentDisconnected',
-  AppNotFound = 'AppNotFound',
-  AppTimeout = 'AppTimeout',
-  CreationFailed = 'CreationFailed',
-  DesktopAgentNotFound = 'DesktopAgentNotFound',
-  ErrorOnLaunch = 'ErrorOnLaunch',
-  IntentDeliveryFailed = 'IntentDeliveryFailed',
-  IntentHandlerRejected = 'IntentHandlerRejected',
-  MalformedContext = 'MalformedContext',
-  MalformedMessage = 'MalformedMessage',
-  NoAppsFound = 'NoAppsFound',
-  NoChannelFound = 'NoChannelFound',
-  NoResultReturned = 'NoResultReturned',
-  NotConnectedToBridge = 'NotConnectedToBridge',
-  ResolverTimeout = 'ResolverTimeout',
-  ResolverUnavailable = 'ResolverUnavailable',
-  ResponseToBridgeTimedOut = 'ResponseToBridgeTimedOut',
-  TargetAppUnavailable = 'TargetAppUnavailable',
-  TargetInstanceUnavailable = 'TargetInstanceUnavailable',
-  UserCancelledResolution = 'UserCancelledResolution',
-}
+export type ResponseErrorDetail =
+  | 'AccessDenied'
+  | 'CreationFailed'
+  | 'MalformedContext'
+  | 'NoChannelFound'
+  | 'AppNotFound'
+  | 'AppTimeout'
+  | 'DesktopAgentNotFound'
+  | 'ErrorOnLaunch'
+  | 'ResolverUnavailable'
+  | 'IntentDeliveryFailed'
+  | 'NoAppsFound'
+  | 'ResolverTimeout'
+  | 'TargetAppUnavailable'
+  | 'TargetInstanceUnavailable'
+  | 'UserCancelledResolution'
+  | 'IntentHandlerRejected'
+  | 'NoResultReturned'
+  | 'AgentDisconnected'
+  | 'NotConnectedToBridge'
+  | 'ResponseToBridgeTimedOut'
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
-export enum ResponseMessageType {
-  FindInstancesResponse = 'findInstancesResponse',
-  FindIntentResponse = 'findIntentResponse',
-  FindIntentsByContextResponse = 'findIntentsByContextResponse',
-  GetAppMetadataResponse = 'getAppMetadataResponse',
-  OpenResponse = 'openResponse',
-  RaiseIntentResponse = 'raiseIntentResponse',
-  RaiseIntentResultResponse = 'raiseIntentResultResponse',
-}
+export type ResponseMessageType =
+  | 'findInstancesResponse'
+  | 'findIntentResponse'
+  | 'findIntentsByContextResponse'
+  | 'getAppMetadataResponse'
+  | 'openResponse'
+  | 'raiseIntentResponse'
+  | 'raiseIntentResultResponse';
 
 /**
  * A request message from a Desktop Agent to the Bridge.
@@ -378,21 +376,20 @@ export interface SourceIdentifier {
  * Identifies the type of the message and it is typically set to the FDC3 function name that
  * the message relates to, e.g. 'findIntent', with 'Request' appended.
  */
-export enum RequestMessageType {
-  BroadcastRequest = 'broadcastRequest',
-  FindInstancesRequest = 'findInstancesRequest',
-  FindIntentRequest = 'findIntentRequest',
-  FindIntentsByContextRequest = 'findIntentsByContextRequest',
-  GetAppMetadataRequest = 'getAppMetadataRequest',
-  OpenRequest = 'openRequest',
-  PrivateChannelBroadcast = 'PrivateChannel.broadcast',
-  PrivateChannelEventListenerAdded = 'PrivateChannel.eventListenerAdded',
-  PrivateChannelEventListenerRemoved = 'PrivateChannel.eventListenerRemoved',
-  PrivateChannelOnAddContextListener = 'PrivateChannel.onAddContextListener',
-  PrivateChannelOnDisconnect = 'PrivateChannel.onDisconnect',
-  PrivateChannelOnUnsubscribe = 'PrivateChannel.onUnsubscribe',
-  RaiseIntentRequest = 'raiseIntentRequest',
-}
+export type RequestMessageType =
+  | 'broadcastRequest'
+  | 'findInstancesRequest'
+  | 'findIntentRequest'
+  | 'findIntentsByContextRequest'
+  | 'getAppMetadataRequest'
+  | 'openRequest'
+  | 'PrivateChannel.broadcast'
+  | 'PrivateChannel.eventListenerAdded'
+  | 'PrivateChannel.eventListenerRemoved'
+  | 'PrivateChannel.onAddContextListener'
+  | 'PrivateChannel.onDisconnect'
+  | 'PrivateChannel.onUnsubscribe'
+  | 'raiseIntentRequest';
 
 /**
  * A response message from a Desktop Agent to the Bridge.
@@ -855,12 +852,7 @@ export interface ConnectionStepMetadata {
 /**
  * Identifies the type of the connection step message.
  */
-export enum ConnectionStepMessageType {
-  AuthenticationFailed = 'authenticationFailed',
-  ConnectedAgentsUpdate = 'connectedAgentsUpdate',
-  Handshake = 'handshake',
-  Hello = 'hello',
-}
+export type ConnectionStepMessageType = 'hello' | 'handshake' | 'authenticationFailed' | 'connectedAgentsUpdate';
 
 /**
  * Hello message sent by the Bridge to anyone connecting to the Bridge (enables
@@ -1158,21 +1150,20 @@ export interface FindInstancesAgentErrorResponsePayload {
  * Constants representing the errors that can be encountered when calling the `open` method
  * on the DesktopAgent object (`fdc3`).
  */
-export enum ErrorMessage {
-  AgentDisconnected = 'AgentDisconnected',
-  DesktopAgentNotFound = 'DesktopAgentNotFound',
-  IntentDeliveryFailed = 'IntentDeliveryFailed',
-  MalformedContext = 'MalformedContext',
-  MalformedMessage = 'MalformedMessage',
-  NoAppsFound = 'NoAppsFound',
-  NotConnectedToBridge = 'NotConnectedToBridge',
-  ResolverTimeout = 'ResolverTimeout',
-  ResolverUnavailable = 'ResolverUnavailable',
-  ResponseToBridgeTimedOut = 'ResponseToBridgeTimedOut',
-  TargetAppUnavailable = 'TargetAppUnavailable',
-  TargetInstanceUnavailable = 'TargetInstanceUnavailable',
-  UserCancelledResolution = 'UserCancelledResolution',
-}
+export type ErrorMessage =
+  | 'DesktopAgentNotFound'
+  | 'IntentDeliveryFailed'
+  | 'MalformedContext'
+  | 'NoAppsFound'
+  | 'ResolverTimeout'
+  | 'ResolverUnavailable'
+  | 'TargetAppUnavailable'
+  | 'TargetInstanceUnavailable'
+  | 'UserCancelledResolution'
+  | 'AgentDisconnected'
+  | 'NotConnectedToBridge'
+  | 'ResponseToBridgeTimedOut'
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -2590,18 +2581,17 @@ export interface OpenAgentErrorResponsePayload {
  * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
  * DesktopAgent (`fdc3`).
  */
-export enum OpenErrorMessage {
-  AgentDisconnected = 'AgentDisconnected',
-  AppNotFound = 'AppNotFound',
-  AppTimeout = 'AppTimeout',
-  DesktopAgentNotFound = 'DesktopAgentNotFound',
-  ErrorOnLaunch = 'ErrorOnLaunch',
-  MalformedContext = 'MalformedContext',
-  MalformedMessage = 'MalformedMessage',
-  NotConnectedToBridge = 'NotConnectedToBridge',
-  ResolverUnavailable = 'ResolverUnavailable',
-  ResponseToBridgeTimedOut = 'ResponseToBridgeTimedOut',
-}
+export type OpenErrorMessage =
+  | 'AppNotFound'
+  | 'AppTimeout'
+  | 'DesktopAgentNotFound'
+  | 'ErrorOnLaunch'
+  | 'MalformedContext'
+  | 'ResolverUnavailable'
+  | 'AgentDisconnected'
+  | 'NotConnectedToBridge'
+  | 'ResponseToBridgeTimedOut'
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -3117,11 +3107,7 @@ export interface PrivateChannelEventListenerAddedAgentRequestPayload {
 /**
  * Event listener type names for Private Channel events
  */
-export enum PrivateChannelEventListenerTypes {
-  OnAddContextListener = 'onAddContextListener',
-  OnDisconnect = 'onDisconnect',
-  OnUnsubscribe = 'onUnsubscribe',
-}
+export type PrivateChannelEventListenerTypes = 'onAddContextListener' | 'onUnsubscribe' | 'onDisconnect';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -3925,14 +3911,13 @@ export interface RaiseIntentResultAgentErrorResponsePayload {
  * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
  * DesktopAgent (`fdc3`).
  */
-export enum RaiseIntentResultErrorMessage {
-  AgentDisconnected = 'AgentDisconnected',
-  IntentHandlerRejected = 'IntentHandlerRejected',
-  MalformedMessage = 'MalformedMessage',
-  NoResultReturned = 'NoResultReturned',
-  NotConnectedToBridge = 'NotConnectedToBridge',
-  ResponseToBridgeTimedOut = 'ResponseToBridgeTimedOut',
-}
+export type RaiseIntentResultErrorMessage =
+  | 'IntentHandlerRejected'
+  | 'NoResultReturned'
+  | 'AgentDisconnected'
+  | 'NotConnectedToBridge'
+  | 'ResponseToBridgeTimedOut'
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -4045,11 +4030,7 @@ export interface DisplayMetadata {
  * Uniquely defines each channel type.
  * Can be "user", "app" or "private".
  */
-export enum Type {
-  App = 'app',
-  Private = 'private',
-  User = 'user',
-}
+export type Type = 'app' | 'private' | 'user';
 
 /**
  * A secondary response to a request to raise an intent used to deliver the intent result,

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -390,18 +390,17 @@ export interface TimeRangeObject {
 /**
  * The type of chart that should be plotted
  */
-export enum ChartStyle {
-  Bar = 'bar',
-  Candle = 'candle',
-  Custom = 'custom',
-  Heatmap = 'heatmap',
-  Histogram = 'histogram',
-  Line = 'line',
-  Mountain = 'mountain',
-  Pie = 'pie',
-  Scatter = 'scatter',
-  StackedBar = 'stacked-bar',
-}
+export type ChartStyle =
+  | 'line'
+  | 'bar'
+  | 'stacked-bar'
+  | 'mountain'
+  | 'candle'
+  | 'pie'
+  | 'scatter'
+  | 'histogram'
+  | 'heatmap'
+  | 'custom';
 
 /**
  * Free text to be used for a keyword search
@@ -582,10 +581,7 @@ export interface PurpleData {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum EntityType {
-  Fdc3Action = 'fdc3.action',
-  Fdc3EntityFileAttachment = 'fdc3.entity.fileAttachment',
-}
+export type EntityType = 'fdc3.action' | 'fdc3.entity.fileAttachment';
 
 /**
  * A map of string mime-type to string content
@@ -875,11 +871,7 @@ export interface Identifiers {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum TentacledInteractionType {
-  Fdc3Contact = 'fdc3.contact',
-  Fdc3Instrument = 'fdc3.instrument',
-  Fdc3Organization = 'fdc3.organization',
-}
+export type TentacledInteractionType = 'fdc3.instrument' | 'fdc3.organization' | 'fdc3.contact';
 
 /**
  * Free text to be used for a keyword search
@@ -1143,10 +1135,7 @@ export interface EmailRecipientsID {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export enum EmailRecipientsType {
-  Fdc3Contact = 'fdc3.contact',
-  Fdc3ContactList = 'fdc3.contactList',
-}
+export type EmailRecipientsType = 'fdc3.contact' | 'fdc3.contactList';
 
 /**
  * Free text to be used for a keyword search
@@ -1973,12 +1962,7 @@ export interface TransactionResult {
 /**
  * The status of the transaction being reported.
  */
-export enum TransactionStatus {
-  Created = 'Created',
-  Deleted = 'Deleted',
-  Failed = 'Failed',
-  Updated = 'Updated',
-}
+export type TransactionStatus = 'Created' | 'Deleted' | 'Updated' | 'Failed';
 
 /**
  * Free text to be used for a keyword search


### PR DESCRIPTION
After some testing I've found that the enums that QuickType generates for constrained string types are not ideal and cause typing issues between types that should be compatible (const strings don't match to enums that contain them). This leads to using less specific types and hence more errors. 

This PR switches the code generation to generating union types for fields that can have several string values instead of enums. The advantage to an enum was that you could reference the enum value in your code, but it would also make polymorphism difficult as the more specific types (with a const for the value) were not compatible with less specific types (which had an enum of the possible values). 

After the switch I had to update some code where I was using the generated types (specifically wherever I was referencing those enums), but also, after moving to more specific types I could now use, I immediately found some errors that the types were not picking up because of how I had to use them.