### PR TITLE
Update FINOS IP policy link

### DIFF
--- a/docs/fdc3-charter.md
+++ b/docs/fdc3-charter.md
@@ -32,7 +32,7 @@ The group's activities do not include:
 
 - Version 1.0 of the FDC3 specification is licensed under the [FDC3 1.0 Final Specification License](https://github.com/finos/FDC3/blob/17892008c26a73ff1fd9f6e40ceb8c8bfd58c610/PATENTS-FDC3-1.0.md).
 
-- Versions 1.1 - 2.1 of the FDC3 specification are subject to the [FINOS IP Policy](https://github.com/finos/community/blob/master/website/static/governance-docs/IP-Policy.pdf), which authorizes implementation of FDC3 specifications without charge, on a RAND basis, subject to the terms of the policy. For details of the IP commitments made by contributors to FDC3, please refer to the policy.
+- Versions 1.1 - 2.1 of the FDC3 specification are subject to the [FINOS IP Policy](https://github.com/finos/community/blob/fdd059c93b6ceefadd8cf60c4bef995366695337/website/static/governance-docs/IP-Policy.pdf), which authorizes implementation of FDC3 specifications without charge, on a RAND basis, subject to the terms of the policy. For details of the IP commitments made by contributors to FDC3, please refer to the policy.
 
 - Versions of the FDC3 specification following 2.1 and subsequent draft specifications are licensed under the [Community Specification License 1.0](https://github.com/finos/FDC3/blob/45ca765e5ff9a44a1fa5437eb70cf876bf4898aa/LICENSE)
 - All code in the FDC3 specification (including JSON Schema) are licensed under [Apache 2.0](https://github.com/finos/FDC3/blob/master/LICENSE)

--- a/website/versioned_docs/version-2.1/fdc3-charter.md
+++ b/website/versioned_docs/version-2.1/fdc3-charter.md
@@ -5,49 +5,37 @@ title: FDC3 Charter
 
 ## Scope
 
-Financial desktop applications include any app used in common financial workflows:
+The FDC3 Standard specifies protocols and taxonomies to enable applications in financial services workflows to interoperate in a plug-and-play fashion, without prior bi-lateral agreements between app developers.
 
-- Traditional native applications implemented in C++, .NET, Java, Python, etc.
-- Hybrid web/native applications - stand-alone native apps embedding Chromium (e.g. a .NET application embedding WebView using CEF or WebView2)
-- Desktop web applications - Web applications running in a desktop container (e.g. OpenFin, Finsemble, Glue42, Electron, FDC3-Sail)
-- Common desktop applications not specific to finance, but critical to workflows - such as Excel, Outlook, etc.
+Financial applications include any type of application used in common financial workflows, including:
+
+- Containerized Web applications - Interoperability platforms extending Chromium (e.g. Electron, OpenFin, interop.io's io.Connect)
 - PWAs & Web applications running in a commercial browser
+- Traditional native applications implemented in C++, .NET, Java, Python, etc.
+- Hybrid web/native applications - stand alone native apps embedding a WebView (e.g. Electron, CEF, WebView2, NW.js etc.)
+- Common desktop applications not specific to finance, but critical to workflows - such as Excel, Outlook, Slack, etc.
 
-This Standard is focused specifically on the desktop.  Activities of the desktop interoperability group do not include:
+This standards group is focused specifically on establishing and promoting standards for the interoperability of front-end applications, hence, its activities are focused on:
 
-- Defining financial objects - where existing standards are well established
-- Interoperability between mobile apps
-- Interoperability via REST or other client to server communication
+- The discovery, configuration, identity and use of financial services applications (e.g. the FDC3 [App Directory](https://fdc3.finos.org/docs/app-directory/overview)),
+- APIs for communication and interaction between applications (e.g. the [Desktop Agent API](https://fdc3.finos.org/docs/api/spec) and [Agent Bridging API](https://fdc3.finos.org/docs/agent-bridging/spec)),
+- Message formats used for communication (e.g. [Context Data](https://fdc3.finos.org/docs/context/spec))
+- Names for requested functionality and workflow steps (e.g. [Intents](https://fdc3.finos.org/docs/intents/spec))
+- Creating and promoting tests for conformance to these standards (e.g. the FDC3 Conformance Framework) and training & certification programs that relate to them (e.g. [Introduction to FDC3](https://training.linuxfoundation.org/express-learning/introduction-to-fdc3-lfel1000/))
 
-:::note
-While these areas are out of scope, compatibility with Mobile and/or REST are still valid points of consideration for FDC3.
-:::
+The group's activities do not include:
 
-### Success Criteria
-
-- Commitment from major banks and application vendors to support the standards set out by the FDC3
-- Workflow integrations in the wild leveraging the standards
-
-### Deliverables
-
-- Define criteria and mechanics for secure communication between apps
-- Define key functions that require specific standards for interoperability
-- Create an agreed taxonomy for common app “intents” within financial desktop workflows
-- Create an agreed taxonomy for common data to be shared across apps within financial desktop workflows
-- Provide reference implementations of all standards
-- Maintain the above standards and reference implementations
-
-## Participation
-
-To be successful, the maintenance and evolution of this Standard needs to have a critical mass of active participants for its duration. Effective participation in FDC3 means participation in the form of research, authoring, editing, and development activities outside the scope of attending regular meetings.
+- Interoperability or communication between back-end platforms.
+- Defining financial objects - where existing standards are well established and can be reused.
 
 ## Licensing
 
-Version 1.0 of the FDC3 specification is licensed under the [FDC3 1.0 Final Specification License](https://github.com/finos/FDC3/blob/17892008c26a73ff1fd9f6e40ceb8c8bfd58c610/PATENTS-FDC3-1.0.md).
+- Version 1.0 of the FDC3 specification is licensed under the [FDC3 1.0 Final Specification License](https://github.com/finos/FDC3/blob/17892008c26a73ff1fd9f6e40ceb8c8bfd58c610/PATENTS-FDC3-1.0.md).
 
-Subsequent FDC3 specifications and draft specifications are subject to the [FINOS IP Policy](https://github.com/finos/community/blob/master/website/static/governance-docs/IP-Policy.pdf)), which authorizes implementation of FDC3 specifications without charge, on a [RAND basis](https://en.wikipedia.org/wiki/Reasonable_and_non-discriminatory_licensing), subject to the terms of the policy. For details of the IP commitments made by contributors to FDC3, please refer to the policy.
+- Versions 1.1 - 2.1 of the FDC3 specification are subject to the [FINOS IP Policy](https://github.com/finos/community/blob/fdd059c93b6ceefadd8cf60c4bef995366695337/website/static/governance-docs/IP-Policy.pdf), which authorizes implementation of FDC3 specifications without charge, on a RAND basis, subject to the terms of the policy. For details of the IP commitments made by contributors to FDC3, please refer to the policy.
 
-Reference implementations and other software contained in FDC3 repositories is licensed under the [Apache License, Version 2.0](https://github.com/finos/FDC3/blob/17892008c26a73ff1fd9f6e40ceb8c8bfd58c610/LICENSE) unless otherwise noted. SPDX-License-Identifier: [Apache-2.0](https://spdx.org/licenses/Apache-2.0).
+- Versions of the FDC3 specification following 2.1 and subsequent draft specifications are licensed under the [Community Specification License 1.0](https://github.com/finos/FDC3/blob/45ca765e5ff9a44a1fa5437eb70cf876bf4898aa/LICENSE)
+- All code in the FDC3 specification (including JSON Schema) are licensed under [Apache 2.0](https://github.com/finos/FDC3/blob/master/LICENSE)
 
 ### Intellectual Property Claims
 


### PR DESCRIPTION
Linking to FINOS IP policy of current latest commit SHA; this will guarantee that the FINOS IP Policy content is unaltered, also after the publication its latest version.