### PR TITLE
Replace training link in website footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -144,7 +144,7 @@ module.exports={
             },
             {
               "label": "Training",
-              "to": "https://www.edx.org/course/fdc3-interoperability-for-the-financial-desktop"
+              "to": "https://fdc3.finos.org/training"
             },
             {
               "label": "Certification",


### PR DESCRIPTION
Use new training page instead of link to old training course