### PR TITLE
Update workbench for 2.1

### DIFF
--- a/docs/context/ref/ChatRoom.md
+++ b/docs/context/ref/ChatRoom.md
@@ -36,7 +36,7 @@ const chatRoom = {
   providerName: "Symphony",
   id: {
       streamId: "j75xqXy25NBOdacUI3FNBH"
-  }
+  },
   url: "http://symphony.com/ref/room/j75xqXy25NBOdacUI3FNBH___pqSsuJRdA",
   name: 'My new room'
 };

--- a/toolbox/fdc3-workbench/src/App.tsx
+++ b/toolbox/fdc3-workbench/src/App.tsx
@@ -286,8 +286,8 @@ export const App = observer(() => {
 								</Typography>
 								<Typography variant="body1">
 									For web applications to be FDC3-enabled, they need to run in the context of an agent that makes the
-									FDC3 API available to the application. This desktop agent is also responsible for lauching and
-									co-ordinating applications. It could be a browser extension, web app, or full-fledged desktop
+									FDC3 API available to the application. This desktop agent is also responsible for launching and
+									coordinating applications. It could be a browser extension, web app, or full-fledged desktop
 									container framework.
 								</Typography>
 								<Typography variant="body1">

--- a/toolbox/fdc3-workbench/src/components/Header.tsx
+++ b/toolbox/fdc3-workbench/src/components/Header.tsx
@@ -114,16 +114,19 @@ export const Header = (props: { fdc3Available: boolean }) => {
 					console.error("Failed to retrieve FDC3 implementation info", e);
 				}
 
+				
 				if (paramVersion) {
 					setChosenVersion(paramVersion);
-				} else if(implInfo?.fdc3Version && supportedVersion.includes(implInfo?.fdc3Version)) {
+				} else if(implInfo?.fdc3Version && implInfo.fdc3Version == "2.1") {
+					//API version 2.1 is backwards compatible with 2.0
+					setChosenVersion("2.0");
+				}else if(implInfo?.fdc3Version && supportedVersion.includes(implInfo.fdc3Version)) {
 					setChosenVersion(implInfo.fdc3Version);
 				} else {
 					setChosenVersion("2.0");
 				}
 
 				window.fdc3Version = chosenVersion;
-				
 			};
 
 			updateInfo();
@@ -144,10 +147,11 @@ export const Header = (props: { fdc3Available: boolean }) => {
 							{supportedVersion.map((ver, index) => (
 								<span key={index}>
 									{ver === chosenVersion ? (
-										<span><b>{ver}</b></span>
+										//version 2.0 serves for both 2.0 and 2.1
+										<span><b>{ver == "2.0" ? "2.0+" : ver}</b></span>
 									) : (
 										<a className={`${classes.link}`} href={`?fdc3Version=${ver}`}>
-											{ver}
+											{ver == "2.0" ? "2.0+" : ver}
 										</a>
 									)}
 									{supportedVersion.length - 1 !== index && <span> | </span>}

--- a/toolbox/fdc3-workbench/src/components/Intents.tsx
+++ b/toolbox/fdc3-workbench/src/components/Intents.tsx
@@ -39,7 +39,7 @@ import { Checkbox } from "@material-ui/core";
 import { FormGroup } from "@material-ui/core";
 import { FormControlLabel } from "@material-ui/core";
 import { RadioGroup } from "@material-ui/core";
-import { ToggleButton, ToggleButtonGroup } from "@material-ui/lab";
+import { Alert, ToggleButton, ToggleButtonGroup } from "@material-ui/lab";
 import InfoOutlinedIcon from "@material-ui/icons/InfoOutlined";
 
 // interface copied from lib @material-ui/lab/Autocomplete
@@ -979,6 +979,10 @@ export const Intents = observer(({ handleTabChange }: { handleTabChange: any }) 
 							</RadioGroup>
 						</Grid>
 					)}
+					<Grid item xs={12}>
+						<Alert severity="info">Desktop Agents often require apps that listen for intents to include the intent in their appD record. Refer to your Desktop Agent's documentation if the workbench doesn't appear in the intent resolver.</Alert>
+					</Grid>
+					
 				</Grid>
 			</form>
 		</div>

--- a/toolbox/fdc3-workbench/src/fixtures/contexts.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/contexts.ts
@@ -92,7 +92,21 @@ export const contexts: ContextItem[] = [
 					streamId: "j75xqXy25NBOdacUI3FNBH"
 				}
 			},
-			message: "A message to send"
+			message: {
+				type: 'fdc3.message',
+				text: {
+				  'text/plain': 'Hey all, can we discuss the issue together? I attached a screenshot'
+				},
+				entities: {
+				   0: {
+					   type: 'fdc3.fileAttachment',
+						data: {
+						name: 'myImage.png',
+							  dataUri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII'
+						}
+					}
+				}
+			  }
 		},
 		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chatMessage.schema.json"),
 	},

--- a/toolbox/fdc3-workbench/src/fixtures/contexts.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/contexts.ts
@@ -8,6 +8,138 @@ import { v4 as uuidv4 } from "uuid";
 export const contexts: ContextItem[] = [
 	{
 		uuid: uuidv4(),
+		id: "Chart example",
+		template: {
+			type: "fdc3.chart",
+			instruments: [
+				{
+					type: "fdc3.instrument",
+					id: {
+						ticker: "AAPL"
+					}
+				},
+				{
+					type: "fdc3.instrument",
+					id: {
+						ticker: "GOOG"
+					}
+				}
+			],
+			range: {
+				type: "fdc3.timeRange",
+				startTime: "2020-09-01T08:00:00.000Z",
+				endTime: "2020-10-31T08:00:00.000Z"
+			},
+			style: "line"
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chart.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Chat Initialization example",
+		template: {
+			type: 'fdc3.chat.initSettings',
+			chatName: 'Chat ABCD',
+			members: {
+				type: 'fdc3.contactList',
+				contacts: [{
+					type: 'fdc3.contact',
+					name: 'Jane Doe',
+					id: {
+						email: 'jane@mail.com'
+					}
+				},{
+					type: 'fdc3.contact',
+					name: 'John Doe',
+					id: {
+						email: 'john@mail.com'
+					},
+				}]
+			},
+			options: {
+				groupRecipients: true, // one chat with both contacts
+				isPublic: false, // private chat room
+				allowHistoryBrowsing: true,
+				allowMessageCopy: true
+			},
+			message: {
+			  type: 'fdc3.message',
+			  text: {
+				'text/plain': 'Hey all, can we discuss the issue together? I attached a screenshot'
+			  },
+			  entities: {
+				 0: {
+					 type: 'fdc3.fileAttachment',
+					  data: {
+					  name: 'myImage.png',
+							dataUri: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII'
+					  }
+				  }
+			  }
+			}
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chatInitSettings.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Chat Message example",
+		template:{
+			type: "fdc3.chat.message",
+			chatRoom: {
+				type: 'fdc3.chat.room',
+				providerName: "Symphony",
+				id: {
+					streamId: "j75xqXy25NBOdacUI3FNBH"
+				}
+			},
+			message: "A message to send"
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chatMessage.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Chat room example",
+		template: {
+			type: "fdc3.chat.room",
+			providerName: "Symphony",
+			id: {
+				streamId: "j75xqXy25NBOdacUI3FNBH"
+			},
+			url: "http://symphony.com/ref/room/j75xqXy25NBOdacUI3FNBH___pqSsuJRdA",
+			name: 'My new room'
+		  },
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chatRoom.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Chat search example",
+		template: {
+			type: "fdc3.chat.searchCriteria",
+			criteria: [
+				{
+					type: "fdc3.instrument",
+					id: {
+						ticker: "AAPL"
+					}
+				},
+				{
+					type: "fdc3.contact",
+					name: "Jane Doe",
+					id: {
+						email: "jane.doe@mail.com"
+					}
+				},
+				{
+					type: "fdc3.organization",
+					name: "Symphony"
+				},
+				"#OrderID45788422"
+			]
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/chatSearchCriteria.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
 		id: "Contact example",
 		template: {
 			type: "fdc3.contact",
@@ -16,7 +148,7 @@ export const contexts: ContextItem[] = [
 				email: "jane.doe@mail.com",
 			},
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/contact.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/contact.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
@@ -40,11 +172,52 @@ export const contexts: ContextItem[] = [
 				},
 			],
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/contactList.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/contactList.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
-		id: "Instrument example",
+		id: "Country example",
+		template: {
+			type: "fdc3.country",
+			name: "Sweden",
+			id: {
+				ISOALPHA3: "SWE",
+			},
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/country.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Currency example",
+		template: {
+			type: 'fdc3.currency',
+			name: 'US Dollar',
+			id: {
+				CURRENCY_ISOCODE: "USD"
+			}
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/currency.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Email example",
+		template: {
+			type: 'fdc3.email',
+			recipients: {
+			  type: 'fdc3.contact',
+			  name: 'Jane Doe',
+			  id: {
+				email: 'jane.doe@example.com'
+			  }
+			},
+			subject: 'The information you requested',
+			textBody: 'Blah, blah, blah ...'
+		  },
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/email.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Instrument example - MSFT",
 		template: {
 			type: "fdc3.instrument",
 			name: "Microsoft",
@@ -54,7 +227,19 @@ export const contexts: ContextItem[] = [
 				ISIN: "US5949181045",
 			},
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/instrument.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/instrument.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Instrument example - AAPL",
+		template: {
+			type: "fdc3.instrument",
+			name: "Apple",
+			id: {
+				ticker: "AAPL"
+			},
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/instrument.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
@@ -76,7 +261,82 @@ export const contexts: ContextItem[] = [
 				},
 			],
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/instrumentList.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/instrumentList.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Interaction example",
+		template: {
+			type: 'fdc3.interaction',
+			participants: {
+				type: 'fdc3.contactList',
+				contacts: [
+					{
+						type: 'fdc3.contact',
+						name: 'Jane Doe',
+						id: {
+							email: 'jane.doe@mail.com'
+						}
+					 },
+					{
+						type: 'fdc3.contact',
+						name: 'John Doe',
+						id: {
+							email: 'john.doe@mail.com'
+						}
+					},
+				]
+			},
+			interactionType: 'Instant Message',
+			timeRange: {
+				type: 'fdc3.timeRange',
+				startTime: '2022-02-10T15:12:00Z'
+			},
+			description: 'Laboris libero dapibus fames elit adipisicing eu, fermentum, dignissimos laboriosam, erat, risus qui deserunt. Praesentium! Reiciendis. Hic harum nostrud, harum potenti amet? Mauris. Pretium aliquid animi, eget eiusmod integer proident. Architecto ipsum blandit ducimus, possimus illum sunt illum necessitatibus ab litora sed, nonummy integer minus corrupti ducimus iste senectus accumsan, fugiat nostrud? Pede vero dictumst excepturi, iure earum consequuntur voluptatum',
+			initiator:  {
+				type: 'fdc3.contact',
+				name: 'Jane Doe',
+				id: {
+					email: 'jane.doe@mail.com'
+				}
+			},
+			origin: 'Outlook'
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/interaction.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Nothing example",
+		template: {
+			type: 'fdc3.nothing'
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/nothing.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Order example",
+		template: {
+			type: "fdc3.order",
+			name: "...",
+			id: {
+				myOMS: "12345"
+			},
+			details: {
+				product: {
+					type: "fdc3.product",
+					id: {
+					  productId: "ABC123"
+					},
+					instrument: {
+						type: "fdc3.instrument",
+						id: {
+							ticker: "MSFT"
+						}
+					}
+				}
+			}
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/order.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
@@ -89,19 +349,7 @@ export const contexts: ContextItem[] = [
 				FDS_ID: "00161G-E",
 			},
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/organization.schema.json"),
-	},
-	{
-		uuid: uuidv4(),
-		id: "Country example",
-		template: {
-			type: "fdc3.country",
-			name: "Sweden",
-			id: {
-				ISOALPHA3: "SWE",
-			},
-		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/country.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/organization.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
@@ -116,7 +364,7 @@ export const contexts: ContextItem[] = [
 			},
 			holding: 2000000,
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/position.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/position.schema.json"),
 	},
 	{
 		uuid: uuidv4(),
@@ -156,6 +404,76 @@ export const contexts: ContextItem[] = [
 				},
 			],
 		},
-		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/portfolio.schema.json"),
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/portfolio.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Product example",
+		template: {
+			type: "fdc3.product",
+			id: {
+			  productId: "ABC123"
+			},
+			instrument: {
+			  type: "fdc3.instrument",
+			  id: {
+				ticker: "MSFT"
+			  }
+			}
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/product.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Trade example",
+		template: {
+			type: "fdc3.trade",
+			name: "...",
+			id: {
+				myEMS: "12345"
+			},
+			product: {
+				type: "fdc3.product",
+				id: {
+				  productId: "ABC123"
+				},
+			instrument: {
+					type: "fdc3.instrument",
+					id: {
+						ticker: "MSFT"
+					}
+				}
+			}
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/trade.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Transaction result example",
+		template: {
+			type: "fdc3.transactionResult",
+			status: "Updated",
+			context: {
+				type: "fdc3.contact",
+				name: "Jane Doe",
+				id: {
+					email: "jane.doe@mail.com"
+				}
+			},
+			message: "record with id 'jane.doe@mail.com' was updated"
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/transactionresult.schema.json"),
+	},
+	{
+		uuid: uuidv4(),
+		id: "Valuation example",
+		template: {
+			type: 'fdc3.valuation',
+			value: 500.0,
+			price: 5.0,
+			CURRENCY_ISOCODE: 'USD',
+			expiryTime: "2022-05-13T16:16:24+01:00"
+		},
+		schemaUrl: new URL("https://fdc3.finos.org/schemas/next/context/valuation.schema.json"),
 	},
 ];

--- a/toolbox/fdc3-workbench/src/fixtures/intentTypes.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/intentTypes.ts
@@ -4,6 +4,14 @@
  */
 export const intentTypes: Array<{ title: string; value: string }> = [
 	{
+		title: "CreateInteraction",
+		value: "CreateInteraction",
+	},
+	{
+		title: "SendChatMessage",
+		value: "SendChatMessage",
+	},
+	{
 		title: "StartCall",
 		value: "StartCall",
 	},
@@ -12,27 +20,63 @@ export const intentTypes: Array<{ title: string; value: string }> = [
 		value: "StartChat",
 	},
 	{
-		title: "ViewChart",
-		value: "ViewChart",
-	},
-	{
-		title: "ViewContact",
-		value: "ViewContact",
-	},
-	{
-		title: "ViewQuote",
-		value: "ViewQuote",
-	},
-	{
-		title: "ViewNews",
-		value: "ViewNews",
+		title: "StartEmail",
+		value: "StartEmail",
 	},
 	{
 		title: "ViewAnalysis",
 		value: "ViewAnalysis",
 	},
 	{
+		title: "ViewChart",
+		value: "ViewChart",
+	},
+	{
+		title: "ViewChat",
+		value: "ViewChat",
+	},
+	{
+		title: "ViewContact",
+		value: "ViewContact",
+	},
+	{
+		title: "ViewHoldings",
+		value: "ViewHoldings",
+	},
+	{
 		title: "ViewInstrument",
 		value: "ViewInstrument",
 	},
+	{
+		title: "ViewInteractions",
+		value: "ViewInteractions",
+	},
+	{
+		title: "ViewMessages",
+		value: "ViewMessages",
+	},
+	{
+		title: "ViewMessages",
+		value: "ViewMessages",
+	},
+	{
+		title: "ViewNews",
+		value: "ViewNews",
+	},
+	{
+		title: "ViewOrders",
+		value: "ViewOrders",
+	},
+	{
+		title: "ViewProfile",
+		value: "ViewProfile",
+	},
+	{
+		title: "ViewQuote",
+		value: "ViewQuote",
+	},
+	{
+		title: "ViewResearch",
+		value: "ViewResearch",
+	}
 ];


### PR DESCRIPTION
resolves #1087 

- Renames 2.0 version to 2.0+
- Auto-select 2.0 version if 2.1 DA version is reported
- Adds context templates for types added in 2.1
- Adds an alert under addIntentListener to indicate that DAs may require intents to be added to the apps appD record to be usable
- Adds intents standardized in 2.1