### PR TITLE
Fix bridging event messages that should allow a null context type

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -96,7 +96,7 @@ jobs:
       run: 'echo "package version already exists on npm registry"'
       
     - name: Report not yet published status
-      if: steps.check-version.outputs.exists == '1' 
+      if: steps.check-version.outputs.exists == '0' 
       run: 'echo "package version does not exist on npm registry, publishing..."'
       
     - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.4",
+  "version": "2.1.0-beta.5",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerAddedAgentRequest.schema.json
@@ -26,7 +26,9 @@
           "type": "object",
           "properties": {
             "channelId": {
-              "type": "string"
+              "type": "string",
+              "title": "Channel Id",
+              "description": "The id of the PrivateChannel that the event listener was added to."
             },
             "listenerType": {
               "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"

--- a/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelEventListenerRemovedAgentRequest.schema.json
@@ -26,7 +26,9 @@
           "type": "object",
           "properties": {
             "channelId": {
-              "type": "string"
+              "type": "string",
+              "title": "Channel Id",
+              "description": "The id of the PrivateChannel that the event listener was removed from."
             },
             "listenerType": {
               "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"

--- a/schemas/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnAddContextListenerAgentRequest.schema.json
@@ -26,10 +26,17 @@
           "type": "object",
           "properties": {
             "channelId": {
-              "type": "string"
+              "type": "string",
+              "title": "Channel Id",
+              "description": "The id of the PrivateChannel that the context listener was added to."
             },
             "contextType": {
-              "type": "string"
+              "oneOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
+              "title": "Context Type",
+              "description": "The type of the context listener added. Should be null for an untyped listener."
             }
           },
           "additionalProperties": false,

--- a/schemas/bridging/privateChannelOnDisconnectAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnDisconnectAgentRequest.schema.json
@@ -26,7 +26,9 @@
           "type": "object",
           "properties": {
             "channelId": {
-              "type": "string"
+              "type": "string",
+              "title": "Channel Id",
+              "description": "The id of the PrivateChannel that the agent discconnected from."
             }
           },
           "additionalProperties": false,

--- a/schemas/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
+++ b/schemas/bridging/privateChannelOnUnsubscribeAgentRequest.schema.json
@@ -26,10 +26,17 @@
           "type": "object",
           "properties": {
             "channelId": {
-              "type": "string"
+              "type": "string",
+              "title": "Channel Id",
+              "description": "The id of the PrivateChannel that the context listener was unsubscribed from."
             },
             "contextType": {
-              "type": "string"
+              "oneOf": [
+                { "type": "string" },
+                { "type": "null" }
+              ],
+              "title": "Context Type",
+              "description": "The type of the context listener that was unsubscribed. Should be null for an untyped listener."
             }
           },
           "additionalProperties": false,

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -3100,6 +3100,9 @@ export interface PrivateChannelEventListenerAddedAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerAddedAgentRequestPayload {
+  /**
+   * The id of the PrivateChannel that the event listener was added to
+   */
   channelId: string;
   listenerType: PrivateChannelEventListenerTypes;
 }
@@ -3160,6 +3163,9 @@ export interface PrivateChannelEventListenerAddedBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerAddedBridgeRequestPayload {
+  /**
+   * The id of the PrivateChannel that the event listener was added to
+   */
   channelId: string;
   listenerType: PrivateChannelEventListenerTypes;
 }
@@ -3205,6 +3211,9 @@ export interface PrivateChannelEventListenerRemovedAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
+  /**
+   * The id of the PrivateChannel that the event listener was removed from
+   */
   channelId: string;
   listenerType: PrivateChannelEventListenerTypes;
 }
@@ -3260,6 +3269,9 @@ export interface PrivateChannelEventListenerRemovedBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelEventListenerRemovedBridgeRequestPayload {
+  /**
+   * The id of the PrivateChannel that the event listener was removed from
+   */
   channelId: string;
   listenerType: PrivateChannelEventListenerTypes;
 }
@@ -3305,8 +3317,14 @@ export interface PrivateChannelOnAddContextListenerAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnAddContextListenerAgentRequestPayload {
+  /**
+   * The id of the PrivateChannel that the context listener was added to.
+   */
   channelId: string;
-  contextType: string;
+  /**
+   * The type of the context listener added. Should be null for an untyped listener.
+   */
+  contextType: null | string;
 }
 
 /**
@@ -3360,8 +3378,14 @@ export interface PrivateChannelOnAddContextListenerBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnAddContextListenerBridgeRequestPayload {
+  /**
+   * The id of the PrivateChannel that the context listener was added to.
+   */
   channelId: string;
-  contextType: string;
+  /**
+   * The type of the context listener added. Should be null for an untyped listener.
+   */
+  contextType: null | string;
 }
 
 /**
@@ -3405,6 +3429,9 @@ export interface PrivateChannelOnDisconnectAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnDisconnectAgentRequestPayload {
+  /**
+   * The id of the PrivateChannel that the agent discconnected from.
+   */
   channelId: string;
 }
 
@@ -3459,6 +3486,9 @@ export interface PrivateChannelOnDisconnectBridgeRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnDisconnectBridgeRequestPayload {
+  /**
+   * The id of the PrivateChannel that the agent discconnected from.
+   */
   channelId: string;
 }
 
@@ -3503,8 +3533,15 @@ export interface PrivateChannelOnUnsubscribeAgentRequestMeta {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnUnsubscribeAgentRequestPayload {
+  /**
+   * The id of the PrivateChannel that the context listener was unsubscribed from.
+   */
   channelId: string;
-  contextType: string;
+  /**
+   * The type of the context listener that was unsubscribed. Should be null for an untyped
+   * listener.
+   */
+  contextType: null | string;
 }
 
 /**
@@ -3558,8 +3595,15 @@ export interface ERequestMetadata {
  * The message payload typically contains the arguments to FDC3 API functions.
  */
 export interface PrivateChannelOnUnsubscribeBridgeRequestPayload {
+  /**
+   * The id of the PrivateChannel that the context listener was unsubscribed from.
+   */
   channelId: string;
-  contextType: string;
+  /**
+   * The type of the context listener that was unsubscribed. Should be null for an untyped
+   * listener.
+   */
+  contextType: null | string;
 }
 
 /**
@@ -5047,7 +5091,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('BroadcastAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('BroadcastAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('BroadcastRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('BroadcastAgentRequestType') },
     ],
     false
   ),
@@ -5086,7 +5130,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('BroadcastBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('BroadcastBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('BroadcastRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('BroadcastAgentRequestType') },
     ],
     false
   ),
@@ -5234,7 +5278,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentErrorResponseType') },
     ],
     false
   ),
@@ -5251,7 +5295,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentRequestType') },
     ],
     false
   ),
@@ -5285,7 +5329,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentErrorResponseType') },
     ],
     false
   ),
@@ -5339,7 +5383,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentErrorResponseType') },
     ],
     false
   ),
@@ -5358,7 +5402,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentRequestType') },
     ],
     false
   ),
@@ -5384,7 +5428,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindInstancesBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindInstancesBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindInstancesResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindInstancesAgentErrorResponseType') },
     ],
     false
   ),
@@ -5407,7 +5451,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -5424,7 +5468,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentRequestType') },
     ],
     false
   ),
@@ -5448,7 +5492,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -5479,7 +5523,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -5498,7 +5542,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentRequestType') },
     ],
     false
   ),
@@ -5522,7 +5566,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -5542,7 +5586,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentErrorResponseType') },
     ],
     false
   ),
@@ -5559,7 +5603,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentRequestType') },
     ],
     false
   ),
@@ -5577,7 +5621,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentErrorResponseType') },
     ],
     false
   ),
@@ -5597,7 +5641,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentErrorResponseType') },
     ],
     false
   ),
@@ -5616,7 +5660,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentRequestType') },
     ],
     false
   ),
@@ -5634,7 +5678,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('FindIntentsByContextBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('FindIntentsByContextBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('FindIntentsByContextResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('FindIntentsByContextAgentErrorResponseType') },
     ],
     false
   ),
@@ -5657,7 +5701,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentErrorResponseType') },
     ],
     false
   ),
@@ -5674,7 +5718,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentRequestType') },
     ],
     false
   ),
@@ -5700,7 +5744,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentErrorResponseType') },
     ],
     false
   ),
@@ -5717,7 +5761,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentErrorResponseType') },
     ],
     false
   ),
@@ -5736,7 +5780,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentRequestType') },
     ],
     false
   ),
@@ -5754,7 +5798,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('GetAppMetadataBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('GetAppMetadataBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('GetAppMetadataResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('GetAppMetadataAgentErrorResponseType') },
     ],
     false
   ),
@@ -5774,7 +5818,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentErrorResponseType') },
     ],
     false
   ),
@@ -5791,7 +5835,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('OpenRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentRequestType') },
     ],
     false
   ),
@@ -5823,7 +5867,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentErrorResponseType') },
     ],
     false
   ),
@@ -5840,7 +5884,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentErrorResponseType') },
     ],
     false
   ),
@@ -5859,7 +5903,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('OpenRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentRequestType') },
     ],
     false
   ),
@@ -5883,7 +5927,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('OpenBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('OpenBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('OpenResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('OpenAgentErrorResponseType') },
     ],
     false
   ),
@@ -5903,7 +5947,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelBroadcastAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelBroadcastAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastAgentRequestType') },
     ],
     false
   ),
@@ -5935,7 +5979,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelBroadcastBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelBroadcastBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelBroadcastAgentRequestType') },
     ],
     false
   ),
@@ -5959,7 +6003,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerAddedAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerAddedAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedAgentRequestType') },
     ],
     false
   ),
@@ -5983,7 +6027,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerAddedBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerAddedBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerAddedAgentRequestType') },
     ],
     false
   ),
@@ -6007,7 +6051,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerRemovedAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerRemovedAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedAgentRequestType') },
     ],
     false
   ),
@@ -6031,7 +6075,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelEventListenerRemovedBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelEventListenerRemovedBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelEventListenerRemovedAgentRequestType') },
     ],
     false
   ),
@@ -6055,7 +6099,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnAddContextListenerAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnAddContextListenerAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerAgentRequestType') },
     ],
     false
   ),
@@ -6071,7 +6115,7 @@ const typeMap: any = {
   PrivateChannelOnAddContextListenerAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'contextType', js: 'contextType', typ: '' },
+      { json: 'contextType', js: 'contextType', typ: u(null, '') },
     ],
     false
   ),
@@ -6079,7 +6123,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnAddContextListenerBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnAddContextListenerBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnAddContextListenerAgentRequestType') },
     ],
     false
   ),
@@ -6095,7 +6139,7 @@ const typeMap: any = {
   PrivateChannelOnAddContextListenerBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'contextType', js: 'contextType', typ: '' },
+      { json: 'contextType', js: 'contextType', typ: u(null, '') },
     ],
     false
   ),
@@ -6103,7 +6147,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnDisconnectAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnDisconnectAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectAgentRequestType') },
     ],
     false
   ),
@@ -6121,7 +6165,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnDisconnectBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnDisconnectBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnDisconnectAgentRequestType') },
     ],
     false
   ),
@@ -6139,7 +6183,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('PrivateChannelOnUnsubscribeAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnUnsubscribeAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeAgentRequestType') },
     ],
     false
   ),
@@ -6155,7 +6199,7 @@ const typeMap: any = {
   PrivateChannelOnUnsubscribeAgentRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'contextType', js: 'contextType', typ: '' },
+      { json: 'contextType', js: 'contextType', typ: u(null, '') },
     ],
     false
   ),
@@ -6163,7 +6207,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('ERequestMetadata') },
       { json: 'payload', js: 'payload', typ: r('PrivateChannelOnUnsubscribeBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeMessageType') },
+      { json: 'type', js: 'type', typ: r('PrivateChannelOnUnsubscribeAgentRequestType') },
     ],
     false
   ),
@@ -6179,7 +6223,7 @@ const typeMap: any = {
   PrivateChannelOnUnsubscribeBridgeRequestPayload: o(
     [
       { json: 'channelId', js: 'channelId', typ: '' },
-      { json: 'contextType', js: 'contextType', typ: '' },
+      { json: 'contextType', js: 'contextType', typ: u(null, '') },
     ],
     false
   ),
@@ -6187,7 +6231,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -6204,7 +6248,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentRequestType') },
     ],
     false
   ),
@@ -6229,7 +6273,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -6257,7 +6301,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -6276,7 +6320,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeRequestMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeRequestPayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentRequestMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentRequestType') },
     ],
     false
   ),
@@ -6301,7 +6345,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentAgentErrorResponseType') },
     ],
     false
   ),
@@ -6324,7 +6368,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultAgentErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultAgentErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultAgentErrorResponseType') },
     ],
     false
   ),
@@ -6344,7 +6388,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultAgentResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultAgentResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultAgentErrorResponseType') },
     ],
     false
   ),
@@ -6387,7 +6431,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultBridgeErrorResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultBridgeErrorResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultAgentErrorResponseType') },
     ],
     false
   ),
@@ -6409,7 +6453,7 @@ const typeMap: any = {
     [
       { json: 'meta', js: 'meta', typ: r('RaiseIntentResultBridgeResponseMeta') },
       { json: 'payload', js: 'payload', typ: r('RaiseIntentResultBridgeResponsePayload') },
-      { json: 'type', js: 'type', typ: r('RaiseIntentResultResponseMessageType') },
+      { json: 'type', js: 'type', typ: r('RaiseIntentResultAgentErrorResponseType') },
     ],
     false
   ),
@@ -6483,7 +6527,7 @@ const typeMap: any = {
     'PrivateChannel.onUnsubscribe',
     'raiseIntentRequest',
   ],
-  BroadcastRequestMessageType: ['broadcastRequest'],
+  BroadcastAgentRequestType: ['broadcastRequest'],
   ConnectionStepMessageType: ['authenticationFailed', 'connectedAgentsUpdate', 'handshake', 'hello'],
   ConnectionStep2HelloType: ['hello'],
   ConnectionStep3HandshakeType: ['handshake'],
@@ -6504,14 +6548,14 @@ const typeMap: any = {
     'TargetInstanceUnavailable',
     'UserCancelledResolution',
   ],
-  FindInstancesResponseMessageType: ['findInstancesResponse'],
-  FindInstancesRequestMessageType: ['findInstancesRequest'],
-  FindIntentResponseMessageType: ['findIntentResponse'],
-  FindIntentRequestMessageType: ['findIntentRequest'],
-  FindIntentsByContextResponseMessageType: ['findIntentsByContextResponse'],
-  FindIntentsByContextRequestMessageType: ['findIntentsByContextRequest'],
-  GetAppMetadataResponseMessageType: ['getAppMetadataResponse'],
-  GetAppMetadataRequestMessageType: ['getAppMetadataRequest'],
+  FindInstancesAgentErrorResponseType: ['findInstancesResponse'],
+  FindInstancesAgentRequestType: ['findInstancesRequest'],
+  FindIntentAgentErrorResponseType: ['findIntentResponse'],
+  FindIntentAgentRequestType: ['findIntentRequest'],
+  FindIntentsByContextAgentErrorResponseType: ['findIntentsByContextResponse'],
+  FindIntentsByContextAgentRequestType: ['findIntentsByContextRequest'],
+  GetAppMetadataAgentErrorResponseType: ['getAppMetadataResponse'],
+  GetAppMetadataAgentRequestType: ['getAppMetadataRequest'],
   OpenErrorMessage: [
     'AgentDisconnected',
     'AppNotFound',
@@ -6524,17 +6568,17 @@ const typeMap: any = {
     'ResolverUnavailable',
     'ResponseToBridgeTimedOut',
   ],
-  OpenResponseMessageType: ['openResponse'],
-  OpenRequestMessageType: ['openRequest'],
-  PrivateChannelBroadcastMessageType: ['PrivateChannel.broadcast'],
+  OpenAgentErrorResponseType: ['openResponse'],
+  OpenAgentRequestType: ['openRequest'],
+  PrivateChannelBroadcastAgentRequestType: ['PrivateChannel.broadcast'],
   PrivateChannelEventListenerTypes: ['onAddContextListener', 'onDisconnect', 'onUnsubscribe'],
-  PrivateChannelEventListenerAddedMessageType: ['PrivateChannel.eventListenerAdded'],
-  PrivateChannelEventListenerRemovedMessageType: ['PrivateChannel.eventListenerRemoved'],
-  PrivateChannelOnAddContextListenerMessageType: ['PrivateChannel.onAddContextListener'],
-  PrivateChannelOnDisconnectMessageType: ['PrivateChannel.onDisconnect'],
-  PrivateChannelOnUnsubscribeMessageType: ['PrivateChannel.onUnsubscribe'],
-  RaiseIntentResponseMessageType: ['raiseIntentResponse'],
-  RaiseIntentRequestMessageType: ['raiseIntentRequest'],
+  PrivateChannelEventListenerAddedAgentRequestType: ['PrivateChannel.eventListenerAdded'],
+  PrivateChannelEventListenerRemovedAgentRequestType: ['PrivateChannel.eventListenerRemoved'],
+  PrivateChannelOnAddContextListenerAgentRequestType: ['PrivateChannel.onAddContextListener'],
+  PrivateChannelOnDisconnectAgentRequestType: ['PrivateChannel.onDisconnect'],
+  PrivateChannelOnUnsubscribeAgentRequestType: ['PrivateChannel.onUnsubscribe'],
+  RaiseIntentAgentErrorResponseType: ['raiseIntentResponse'],
+  RaiseIntentAgentRequestType: ['raiseIntentRequest'],
   RaiseIntentResultErrorMessage: [
     'AgentDisconnected',
     'IntentHandlerRejected',
@@ -6543,6 +6587,6 @@ const typeMap: any = {
     'NotConnectedToBridge',
     'ResponseToBridgeTimedOut',
   ],
-  RaiseIntentResultResponseMessageType: ['raiseIntentResultResponse'],
+  RaiseIntentResultAgentErrorResponseType: ['raiseIntentResultResponse'],
   Type: ['app', 'private', 'user'],
 };


### PR DESCRIPTION
resolves #1109 

Corrects the typing for the contextType fields in the `PrivateChannel.onAddContextListener` and `PrivateChannel.onUnsubscribe` messages and adds a few missing title/description field in other PrivateChannel messages that I spotted while fixing this.