### PR TITLE
Finsemble/Glue42 rebrand -> io.Connect

### DIFF
--- a/docs/agent-bridging/spec.md
+++ b/docs/agent-bridging/spec.md
@@ -244,7 +244,7 @@ The DA must then respond to the `hello` message with a `handshake` request to th
           *  provides. The string must be a numeric semver version, e.g. 1.2 or 1.2.1. */
           fdc3Version: string,
           /** The name of the provider of the FDC3 Desktop Agent Implementation
-           *  (e.g.Finsemble, Glue42, OpenFin etc.). */
+           *  (e.g.Finsemble, io.Connect, OpenFin etc.). */
           provider: string,
           /** The version of the provider of the FDC3 Desktop Agent Implementation (e.g. 5.3.0). */
           providerVersion: string,

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -243,7 +243,7 @@ interface ImplementationMetadata {
   readonly fdc3Version: string;
 
   /** The name of the provider of the FDC3 Desktop Agent Implementation
-   *  (e.g.Finsemble, Glue42, OpenFin etc.).
+   *  (e.g. io.Connect, OpenFin etc.).
    */
   readonly provider: string;
 

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -17,8 +17,7 @@ A Desktop Agent is a desktop component (or aggregate of components) that serves 
 Examples of Desktop Agents include:
 
 - Autobahn
-- Finsemble
-- Glue42
+- io.Connect
 - OpenFin
 - Refinitiv Eikon
 

--- a/docs/trademarks.md
+++ b/docs/trademarks.md
@@ -12,8 +12,9 @@ Trademarks used within this site and the FDC3 Standard include, but are not limi
 - Eikon is a registered trademark of Refinitiv
 - FDC3 is a registered trademark and brand of The Linux Foundation
 - Excel is a Microsoft Corporation product name
-- Finsemble is a registered trademark and product name of Finsemble, Inc.
-- Glue42 is a trademark of Tick42
+- Finsemble is a registered trademark and product name of interop.io, Inc.
+- Glue42 is a trademark and product name of interop.io, Inc.
+- io.Connect is a trademark and product name of interop.io, Inc.
 - Java is a registered trademark of Oracle America, Inc.
 - JavaScript  is a registered trademark of Oracle America, Inc.
 - .NET is a trademark of Microsoft Corporation

--- a/website/versioned_docs/version-2.1/agent-bridging/spec.md
+++ b/website/versioned_docs/version-2.1/agent-bridging/spec.md
@@ -244,7 +244,7 @@ The DA must then respond to the `hello` message with a `handshake` request to th
           *  provides. The string must be a numeric semver version, e.g. 1.2 or 1.2.1. */
           fdc3Version: string,
           /** The name of the provider of the FDC3 Desktop Agent Implementation
-           *  (e.g.Finsemble, Glue42, OpenFin etc.). */
+           *  (e.g.Finsemble, io.Connect, OpenFin etc.). */
           provider: string,
           /** The version of the provider of the FDC3 Desktop Agent Implementation (e.g. 5.3.0). */
           providerVersion: string,

--- a/website/versioned_docs/version-2.1/api/ref/Metadata.md
+++ b/website/versioned_docs/version-2.1/api/ref/Metadata.md
@@ -243,7 +243,7 @@ interface ImplementationMetadata {
   readonly fdc3Version: string;
 
   /** The name of the provider of the FDC3 Desktop Agent Implementation
-   *  (e.g.Finsemble, Glue42, OpenFin etc.).
+   *  (e.g. io.Connect, OpenFin etc.).
    */
   readonly provider: string;
 

--- a/website/versioned_docs/version-2.1/api/spec.md
+++ b/website/versioned_docs/version-2.1/api/spec.md
@@ -17,8 +17,7 @@ A Desktop Agent is a desktop component (or aggregate of components) that serves 
 Examples of Desktop Agents include:
 
 - Autobahn
-- Finsemble
-- Glue42
+- io.Connect
 - OpenFin
 - Refinitiv Eikon
 

--- a/website/versioned_docs/version-2.1/trademarks.md
+++ b/website/versioned_docs/version-2.1/trademarks.md
@@ -12,8 +12,9 @@ Trademarks used within this site and the FDC3 Standard include, but are not limi
 - Eikon is a registered trademark of Refinitiv
 - FDC3 is a registered trademark and brand of The Linux Foundation
 - Excel is a Microsoft Corporation product name
-- Finsemble is a registered trademark and product name of Finsemble, Inc.
-- Glue42 is a trademark of Tick42
+- Finsemble is a registered trademark and product name of interop.io, Inc.
+- Glue42 is a trademark and product name of interop.io, Inc.
+- io.Connect is a trademark and product name of interop.io, Inc.
 - Java is a registered trademark of Oracle America, Inc.
 - JavaScript  is a registered trademark of Oracle America, Inc.
 - .NET is a trademark of Microsoft Corporation


### PR DESCRIPTION
Minor docs changes to replace Glue42/Finsemble with io.Connect (which supersedes both) in the docs (current and future versions)