### PR TITLE
Add missing resultType argument to findIntent agent request bridging schema

### DIFF
--- a/docs/agent-bridging/ref/findIntent.md
+++ b/docs/agent-bridging/ref/findIntent.md
@@ -46,7 +46,7 @@ sequenceDiagram
 
 ### Example
 
-Outward message to the DAB:
+Outward message to the DAB (with `intent` and `context` specified, but not `resultType`):
 
 ```json
 // agent-A -> DAB

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0-beta.5",
+  "version": "2.1.0-beta.6",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/schemas/bridging/findIntentAgentRequest.schema.json
+++ b/schemas/bridging/findIntentAgentRequest.schema.json
@@ -32,6 +32,10 @@
             "context": {
               "title": "Context argument",
               "$ref": "../context/context.schema.json"
+            },
+            "resultType": {
+              "title": "Result type argument",
+              "type": "string"
             }
           },
           "required": ["intent"],

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -1771,6 +1771,7 @@ export interface FindIntentAgentRequestMeta {
 export interface FindIntentAgentRequestPayload {
   context?: ContextElement;
   intent: string;
+  resultType?: string;
 }
 
 /**
@@ -1929,6 +1930,7 @@ export interface FindIntentBridgeRequestMeta {
 export interface FindIntentBridgeRequestPayload {
   context?: ContextElement;
   intent: string;
+  resultType?: string;
 }
 
 /**
@@ -5488,6 +5490,7 @@ const typeMap: any = {
     [
       { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'intent', js: 'intent', typ: '' },
+      { json: 'resultType', js: 'resultType', typ: u(undefined, '') },
     ],
     false
   ),
@@ -5562,6 +5565,7 @@ const typeMap: any = {
     [
       { json: 'context', js: 'context', typ: u(undefined, r('ContextElement')) },
       { json: 'intent', js: 'intent', typ: '' },
+      { json: 'resultType', js: 'resultType', typ: u(undefined, '') },
     ],
     false
   ),


### PR DESCRIPTION
resolves #1153
Adds the missing (and optional) resultType parameter to bridging findIntent agent requests