### PR TITLE
Remove the IntentResolution.version field as defunct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Removed the `version` field from `IntentResolution` as there are no version fields for intents in the FDC3 API definitions and hence the field has no purpose. ([#1170](https://github.com/finos/FDC3/pull/1170))
+
 ## [FDC3 Standard 2.1](https://github.com/finos/FDC3/compare/v2.0..v2.1) - 2023-09-13
 
 ### Added

--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -795,7 +795,7 @@ Version of `raiseIntent` that targets an app by name rather than `AppIdentifier`
 ### `raiseIntentForContext` (deprecated)
 
 ```ts
-raiseIntentForContext(context: Context, name: string): Promise<IntentResolution>;;
+raiseIntentForContext(context: Context, name: string): Promise<IntentResolution>;
 ```
 
 Version of `raiseIntentForContext` that targets an app by name rather than `AppIdentifier`. Provided for backwards compatibility with versions of the FDC3 Standard <2.0.

--- a/docs/api/ref/Metadata.md
+++ b/docs/api/ref/Metadata.md
@@ -318,10 +318,6 @@ interface IntentResolution {
    *  chose in response to `fdc3.raiseIntentForContext()`.
    */
   readonly intent: string;
-
-  /** The version number of the Intents schema being used.
-   */
-  readonly version?: string;
   
   /** Retrieves a promise that will resolve to `Context` data returned 
    *  by the application that resolves the raised intent, a `Channel` 

--- a/schemas/api/api.schema.json
+++ b/schemas/api/api.schema.json
@@ -434,11 +434,6 @@
                     "description": "The intent that was raised. May be used to determine which intent the user\nchose in response to `fdc3.raiseIntentForContext()`.",
                     "type": "string",
                     "title": "intent"
-                },
-                "version": {
-                    "description": "The version number of the Intents schema being used.",
-                    "type": "string",
-                    "title": "version"
                 }
             },
             "additionalProperties": false,

--- a/src/api/IntentResolution.ts
+++ b/src/api/IntentResolution.ts
@@ -45,10 +45,6 @@ export interface IntentResolution {
    */
   readonly intent: string;
   /**
-   * The version number of the Intents schema being used.
-   */
-  readonly version?: string;
-  /**
    * Retrieves a promise that will resolve to `Context` data returned
    * by the application that resolves the raised intent, a `Channel`
    * established and returned by the app resolving the intent or void.

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -3781,10 +3781,6 @@ export interface IntentResolution {
    * received the intent.
    */
   source: AppIdentifier;
-  /**
-   * The version number of the Intents schema being used.
-   */
-  version?: string;
 }
 
 /**
@@ -6300,7 +6296,6 @@ const typeMap: any = {
     [
       { json: 'intent', js: 'intent', typ: '' },
       { json: 'source', js: 'source', typ: r('AppIdentifier') },
-      { json: 'version', js: 'version', typ: u(undefined, '') },
     ],
     false
   ),


### PR DESCRIPTION
resolves #1053

Removed the `version` field from `IntentResolution` as there are no version fields for intents in the FDC3 API definitions and hence the field has no purpose.