### PR TITLE
minor context schema description typos

### DIFF
--- a/schemas/context/context.schema.json
+++ b/schemas/context/context.schema.json
@@ -14,7 +14,7 @@
   ],
   "definitions": {
     "BaseContext": {
-      "$comment": "Base definition for the Context object without documentation (which will be imported into all derived types unless separated).",
+      "$comment": "Base definition for the Context object WITHOUT documentation (which will be imported into all derived types unless separated).",
       "type": "object",
       "properties": {
         "type": {
@@ -34,7 +34,7 @@
       ]
     },
     "DocumentedContext": {
-      "$comment": "Base definition for the Context object without documentation (which will be imported into all derived types unless separated).",
+      "$comment": "Base definition for the Context object WITH documentation (which will be imported into all derived types unless separated).",
       "type": "object",
       "properties": {
         "type": {

--- a/schemas/context/trade.schema.json
+++ b/schemas/context/trade.schema.json
@@ -27,7 +27,7 @@
 				"product": {
 					"$ref": "product.schema.json",
 					"title": "Traded product",
-					"description": "A product that is the subject of th trade."
+					"description": "A product that is the subject of the trade."
 				}
 			},
 			"required": [


### PR DESCRIPTION
I spotted a couple of minor types In context schema descriptions while working on a review.
