### PR TITLE
Correcting an error in the fdc3.country docs as they differ from the schema

### DIFF
--- a/docs/context/ref/Country.md
+++ b/docs/context/ref/Country.md
@@ -31,7 +31,7 @@ is for at least one standardized identifier to be provided
 |--------------------------|---------|----------|----------------------|
 | `type`                   | string  | Yes      | `'fdc3.country'`     |
 | `name`                   | string  | No       | `'Sweden'`           |
-| `id.COUNTRY_ISOALPHA2`   | string  | Yes      | `'SE'`               |
+| `id.COUNTRY_ISOALPHA2`   | string  | No       | `'SE'`               |
 | `id.COUNTRY_ISOALPHA3`   | string  | No       | `'SWE'`              |
 | `id.ISOALPHA2` *         | string  | No       | `'SE'`               |
 | `id.ISOALPHA3` *         | string  | No       | `'SWE'`              |

--- a/website/versioned_docs/version-2.0/context/ref/Country.md
+++ b/website/versioned_docs/version-2.0/context/ref/Country.md
@@ -11,7 +11,7 @@ A country entity.
 Notes:
 
 - It is valid to include extra properties and metadata as part of the country payload, but the minimum requirement
-is for at least one standardised identifier to be provided 
+is for at least one standardised identifier to be provided.
   - `COUNTRY_ISOALPHA2` SHOULD be preferred.
 
 - Try to only use country identifiers as intended and specified in the [ISO standard](https://en.wikipedia.org/wiki/ISO_3166-1). E.g. the `COUNTRY_ISOALPHA2` property must be a recognized value and not a proprietary two-letter code. If the identifier you want to share is not a standardised and recognized one, rather define a property that makes it clear what value it is. This makes it easier for target applications.
@@ -31,7 +31,7 @@ https://fdc3.finos.org/schemas/2.0/country.schema.json
 |--------------------------|---------|----------|----------------------|
 | `type`                   | string  | Yes      | `'fdc3.country'`     |
 | `name`                   | string  | No       | `'Sweden'`           |
-| `id.COUNTRY_ISOALPHA2`   | string  | Yes      | `'SE'`               |
+| `id.COUNTRY_ISOALPHA2`   | string  | No       | `'SE'`               |
 | `id.COUNTRY_ISOALPHA3`   | string  | No       | `'SWE'`              |
 | `id.ISOALPHA2` *         | string  | No       | `'SE'`               |
 | `id.ISOALPHA3` *         | string  | No       | `'SWE'`              |


### PR DESCRIPTION
A small error in the fdc3.country context docs was reported to me (states that id.COUNTRY_ISOALPHA2 is a required field, when its only preferred/recommended). This does not agree with the context schema (and hence generated code) and should be corrected - we recommend id.COUNTRY_ISOALPHA2, but any of the defined country code types is acceptable to use (or no code if you want to reset filter, for example).