### PR TITLE
Only trigger NPM releases on release/* branch merges

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,9 @@ on:
       - 'docs/**'
       - 'website/**'
   pull_request:
+    types: [opened, reopened, edited, ready_for_review]
     branches:
+      - main
       - release/*
     paths-ignore:
       - '.github/workflows/docusaurus.yml'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,6 @@ name: npm-build
 on:
   push:
     branches:
-      - main
       - release/**
     paths-ignore:
       - '.github/workflows/docusaurus.yml'
@@ -15,7 +14,6 @@ on:
       - 'website/**'
   pull_request:
     branches:
-      - main
       - release/*
     paths-ignore:
       - '.github/workflows/docusaurus.yml'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,9 +1,12 @@
 name: npm-build
 
-# Only trigger on:
-# - main branch
-# - PR or Pull Request event types
-# - Exclide Docusaurus files: this file, docs/** and website/**
+# This workflow publishes releases to NPM, after checking that the version they would create does not already exist.
+# Hence, it will only publish if the version number in package.json is not already listed at: 
+# https://www.npmjs.com/package/@finos/fdc3?activeTab=versions
+# The workflow will:
+# - Only trigger on a push or PR merge to a release/* branch in the repository
+# - Ignore Docusaurus workflow, docs/** and website/** as they don't affect the NPM module build
+# WARNING: the workflow does NOT confirm that the version number in package JSON matches the branch name, which should be manually confirmed
 on:
   push:
     branches:


### PR DESCRIPTION
This PR remove the trigger for NPM releases on merges to the main branch, meaning that all NPM release going forward will come from release/* branches. This is a more explicit workflow which should be safer and makes it easier to do maintenance releases on past FDC3 versions when errors in them are identified.