### PR TITLE
Fix publishing of FDC3 package to Github packages repository

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -63,6 +63,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     strategy:
       matrix:
        include:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://fdc3.finos.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/finos/FDC3.git"
+    "url": "git+https://github.com/finos/FDC3.git"
   },
   "publishConfig": {
     "tag": "latest"


### PR DESCRIPTION
Fix publishing of FDC3 package to Github packages repository (needed a new permission set).