### PR TITLE
Filter CVE scans on PRs a bit more

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -8,15 +8,15 @@ on:
       - 'toolbox/fdc3-workbench/package.json'
       - '.github/workflows/cve-scanning.yml'
       - 'website/package.json'
-  push:
-    paths:
-      - 'package.json'
-      - 'toolbox/fdc3-workbench/package.json'
-      - '.github/workflows/cve-scanning.yml'
-      - 'website/package.json'
-    schedule:
-      # Run every day at 5am and 5pm
-      - cron: '0 5,17 * * *'
+  # push:
+  #   paths:
+  #     - 'package.json'
+  #     - 'toolbox/fdc3-workbench/package.json'
+  #     - '.github/workflows/cve-scanning.yml'
+  #     - 'website/package.json'
+  schedule:
+    # Run every day at 5am and 5pm
+    - cron: '0 5,17 * * *'
 
 jobs:
   build:

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,7 +2,7 @@ name: Node.js CVE Scanning
 
 on:
   pull_request:
-    types: [opened, reopened, edited, ready_for_review]
+    types: [opened, reopened, edited, synchronize, ready_for_review]
     paths:
       - 'package.json'
       - 'toolbox/fdc3-workbench/package.json'

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,6 +2,7 @@ name: Node.js CVE Scanning
 
 on:
   pull_request:
+    types: [opened, reopened, edited, ready_for_review]
     paths:
       - 'package.json'
       - 'toolbox/fdc3-workbench/package.json'

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,7 +2,7 @@ name: Node.js CVE Scanning
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'package.json'
       - 'toolbox/fdc3-workbench/package.json'

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,11 @@
 name: Static code analysis
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+  schedule:
+    # Run every day at 5am and 5pm
+    - cron: '0 5,17 * * *'
 
 jobs:
   semgrep:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,7 @@ name: Static code analysis
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   schedule:
     # Run every day at 5am and 5pm
     - cron: '0 5,17 * * *'


### PR DESCRIPTION
These are double triggering on PRs, ~not sure why - this won't entirely solve it but will reduce it~

We were triggering on both pushes and PRs, finessed the triggers as we only accept changes via PRs and we can use the `synchronize` trigger for when those are updated.