### PR TITLE
Add missing id, name fields to json schema docs

### DIFF
--- a/s2tQuicktypeUtil.js
+++ b/s2tQuicktypeUtil.js
@@ -44,7 +44,7 @@ while (dirIndex < inputs.length) {
 //const quicktypeExec = "node " + ["..","quicktype","dist","index.js"].join(path.sep);
 const quicktypeExec = ['.', 'node_modules', '.bin', 'quicktype'].join(path.sep);
 
-const command = `${quicktypeExec} --prefer-const-values --prefer-unions -s schema -o ${outputFile} ${sources}`;
+const command = `${quicktypeExec} --prefer-const-values --prefer-unions --no-combine-classes -s schema -o ${outputFile} ${sources}`;
 console.log('command to run: ' + command);
 
 exec(command, function(error, stdout, stderr) {

--- a/schemas/context/chatSearchCriteria.schema.json
+++ b/schemas/context/chatSearchCriteria.schema.json
@@ -16,22 +16,7 @@
           "description": "An array of criteria that should match chats returned from by a search.\n\n⚠️ Operators (and/or/not) are not defined in `fdc3.chat.searchCriteria`. It is up to the application that processes the FDC3 Intent to choose and apply the operators between the criteria.\n\nEmpty search criteria can be supported to allow resetting of filters.",
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "instrument.schema.json#"
-              },
-              {
-                "$ref": "organization.schema.json#"
-              },
-              {
-                "$ref": "contact.schema.json#"
-              },
-              {
-                "type": "string",
-                "title": "Free text",
-                "description": "Free text to be used for a keyword search"
-              }
-            ]
+            "$ref": "#/$defs/SearchCriteria"
           }
         }
       },
@@ -41,6 +26,29 @@
     },
     { "$ref": "context.schema.json#/definitions/BaseContext" }
   ],
+  "$defs": {
+    "SearchCriteria": {
+      "type": "object",
+      "title": "Search Criteria",
+      "description": "An individual criteria against which to match chat messages, based on an FDC3 context or free-text string.",
+      "oneOf": [
+        {
+          "$ref": "instrument.schema.json#"
+        },
+        {
+          "$ref": "contact.schema.json#"
+        },
+        {
+          "$ref": "organization.schema.json#"
+        },
+        {
+          "type": "string",
+          "title": "Free text",
+          "description": "Free text to be used for a keyword search"
+        }
+      ]
+    }
+  },
   "examples": [
     {
       "type": "fdc3.chat.searchCriteria",

--- a/schemas/context/contact.schema.json
+++ b/schemas/context/contact.schema.json
@@ -28,6 +28,10 @@
               "description": "FactSet Permanent Identifier representing the contact"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the contact"
         }
       },
       "required": [

--- a/schemas/context/contactList.schema.json
+++ b/schemas/context/contactList.schema.json
@@ -11,6 +11,18 @@
         "type": {
           "const": "fdc3.contactList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Contact List Identifiers",
+          "description": "One or more identifiers that refer to the contact list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable summary of the contact list"
+        },
         "contacts": {
           "type": "array",
           "title": "List of Contacts",

--- a/schemas/context/country.schema.json
+++ b/schemas/context/country.schema.json
@@ -37,6 +37,10 @@
               "deprecated": true
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the country"
         }
       },
       "required": [

--- a/schemas/context/instrument.schema.json
+++ b/schemas/context/instrument.schema.json
@@ -63,6 +63,11 @@
             }
           }
         },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the instrument"
+        },  
         "market": {
           "description": "The `market` map can be used to further specify the instrument and help achieve interoperability between disparate data sources. This is especially useful when using an `id` field that is not globally unique.",
           "type": "object",

--- a/schemas/context/instrumentList.schema.json
+++ b/schemas/context/instrumentList.schema.json
@@ -11,6 +11,18 @@
         "type": {
           "const": "fdc3.instrumentList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Instrument List Identifiers",
+          "description": "One or more identifiers that refer to the instrument list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable summary of the instrument list"
+        },
         "instruments": {
           "type": "array",
           "title": "List of instruments",

--- a/schemas/context/orderList.schema.json
+++ b/schemas/context/orderList.schema.json
@@ -11,6 +11,18 @@
         "type": {
           "const": "fdc3.orderList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Order List Identifiers",
+          "description": "One or more identifiers that refer to the order list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable summary of the order list"
+        },
         "orders": {
           "type": "array",
           "items": {

--- a/schemas/context/organization.schema.json
+++ b/schemas/context/organization.schema.json
@@ -33,6 +33,10 @@
               "description": "FactSet Permanent Identifier representing the organization"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the organization"
         }
       },
       "required": [

--- a/schemas/context/portfolio.schema.json
+++ b/schemas/context/portfolio.schema.json
@@ -18,6 +18,18 @@
           },
           "title": "Portfolio positions",
           "description": "The List of Positions which make up the Portfolio"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Portfolio Identifiers",
+          "description": "One or more identifiers that refer to the portfolio in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the portfolio"
         }
       },
       "required": [

--- a/schemas/context/position.schema.json
+++ b/schemas/context/position.schema.json
@@ -20,6 +20,18 @@
           "type": "number",
           "title": "The size of the holding represented by this position",
           "description": "The amount of the holding, e.g. a number of shares"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Position Identifiers",
+          "description": "One or more identifiers that refer to the position in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the position"
         }
       },
       "required": [

--- a/schemas/context/tradeList.schema.json
+++ b/schemas/context/tradeList.schema.json
@@ -18,7 +18,20 @@
           },
           "title": "List of Trades",
           "description": "An array of trade contexts that forms the list."
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Trade List Identifiers",
+          "description": "One or more identifiers that refer to the trade list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "description": "An optional human-readable name for the trade list"
         }
+
       },
       "required": [
         "type",

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -442,9 +442,16 @@ export interface ContactListObject {
      * An array of contact contexts that forms the list.
      */
     contacts: ContactElement[];
-    type:     "fdc3.contactList";
-    id?:      { [key: string]: any };
-    name?:    string;
+    /**
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the contact list
+     */
+    name?: string;
+    type:  "fdc3.contactList";
     [property: string]: any;
 }
 
@@ -457,9 +464,12 @@ export interface ContactElement {
     /**
      * Identifiers that relate to the Contact represented by this context
      */
-    id:    PurpleContactIdentifiers;
-    type:  "fdc3.contact";
+    id: PurpleContactIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     */
     name?: string;
+    type:  "fdc3.contact";
     [property: string]: any;
 }
 
@@ -773,7 +783,12 @@ export interface OrganizationObject {
      */
     market?: OrganizationMarket;
     type:    TentacledInteractionType;
-    name?:   string;
+    /**
+     * An optional human-readable name for the organization
+     *
+     * An optional human-readable name for the contact
+     */
+    name?: string;
     [property: string]: any;
 }
 
@@ -875,9 +890,12 @@ export interface Contact {
     /**
      * Identifiers that relate to the Contact represented by this context
      */
-    id:    FluffyContactIdentifiers;
-    type:  "fdc3.contact";
+    id: FluffyContactIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     */
     name?: string;
+    type:  "fdc3.contact";
     [property: string]: any;
 }
 
@@ -908,9 +926,16 @@ export interface ContactList {
      * An array of contact contexts that forms the list.
      */
     contacts: ContactElement[];
-    type:     "fdc3.contactList";
-    id?:      { [key: string]: any };
-    name?:    string;
+    /**
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the contact list
+     */
+    name?: string;
+    type:  "fdc3.contactList";
     [property: string]: any;
 }
 
@@ -986,9 +1011,12 @@ export interface Context {
  * applications.
  */
 export interface Country {
-    id:    CountryID;
-    type:  "fdc3.country";
+    id: CountryID;
+    /**
+     * An optional human-readable name for the country
+     */
     name?: string;
+    type:  "fdc3.country";
     [property: string]: any;
 }
 
@@ -1092,10 +1120,18 @@ export interface Email {
 export interface EmailRecipients {
     /**
      * Identifiers that relate to the Contact represented by this context
+     *
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
      */
-    id?:   EmailRecipientsID;
-    type:  EmailRecipientsType;
+    id?: ContactTIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     *
+     * An optional human-readable summary of the contact list
+     */
     name?: string;
+    type:  EmailRecipientsType;
     /**
      * An array of contact contexts that forms the list.
      */
@@ -1105,8 +1141,11 @@ export interface EmailRecipients {
 
 /**
  * Identifiers that relate to the Contact represented by this context
+ *
+ * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+ * Specific key names for systems are expected to be standardized in future.
  */
-export interface EmailRecipientsID {
+export interface ContactTIdentifiers {
     /**
      * The email address for the contact
      */
@@ -1256,12 +1295,19 @@ export interface PurpleMarket {
  */
 export interface InstrumentList {
     /**
+     * One or more identifiers that refer to the instrument list in an OMS, EMS or related
+     * system. Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
      * An array of instrument contexts that forms the list.
      */
     instruments: InstrumentElement[];
-    type:        "fdc3.instrumentList";
-    id?:         { [key: string]: any };
-    name?:       string;
+    /**
+     * An optional human-readable summary of the instrument list
+     */
+    name?: string;
+    type:  "fdc3.instrumentList";
     [property: string]: any;
 }
 
@@ -1561,12 +1607,19 @@ export interface ProductObject {
  */
 export interface OrderList {
     /**
+     * One or more identifiers that refer to the order list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the order list
+     */
+    name?: string;
+    /**
      * An array of order contexts that forms the list.
      */
     orders: OrderElement[];
     type:   "fdc3.orderList";
-    id?:    { [key: string]: any };
-    name?:  string;
     [property: string]: any;
 }
 
@@ -1627,9 +1680,12 @@ export interface Organization {
     /**
      * Identifiers for the organization, at least one must be provided.
      */
-    id:    OrganizationIdentifiers;
-    type:  "fdc3.organization";
+    id: OrganizationIdentifiers;
+    /**
+     * An optional human-readable name for the organization
+     */
     name?: string;
+    type:  "fdc3.organization";
     [property: string]: any;
 }
 
@@ -1679,12 +1735,19 @@ export interface OrganizationIdentifiers {
  */
 export interface Portfolio {
     /**
+     * One or more identifiers that refer to the portfolio in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable name for the portfolio
+     */
+    name?: string;
+    /**
      * The List of Positions which make up the Portfolio
      */
     positions: PositionElement[];
     type:      "fdc3.portfolio";
-    id?:       { [key: string]: any };
-    name?:     string;
     [property: string]: any;
 }
 
@@ -1706,11 +1769,18 @@ export interface PositionElement {
     /**
      * The amount of the holding, e.g. a number of shares
      */
-    holding:    number;
+    holding: number;
+    /**
+     * One or more identifiers that refer to the position in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?:        { [key: string]: string };
     instrument: InstrumentElement;
-    type:       "fdc3.position";
-    id?:        { [key: string]: any };
-    name?:      string;
+    /**
+     * An optional human-readable name for the position
+     */
+    name?: string;
+    type:  "fdc3.position";
     [property: string]: any;
 }
 
@@ -1746,11 +1816,18 @@ export interface Position {
     /**
      * The amount of the holding, e.g. a number of shares
      */
-    holding:    number;
+    holding: number;
+    /**
+     * One or more identifiers that refer to the position in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?:        { [key: string]: string };
     instrument: InstrumentElement;
-    type:       "fdc3.position";
-    id?:        { [key: string]: any };
-    name?:      string;
+    /**
+     * An optional human-readable name for the position
+     */
+    name?: string;
+    type:  "fdc3.position";
     [property: string]: any;
 }
 
@@ -1880,12 +1957,19 @@ export interface Trade {
  */
 export interface TradeList {
     /**
+     * One or more identifiers that refer to the trade list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable name for the trade list
+     */
+    name?: string;
+    /**
      * An array of trade contexts that forms the list.
      */
     trades: TradeElement[];
     type:   "fdc3.tradeList";
-    id?:    { [key: string]: any };
-    name?:  string;
     [property: string]: any;
 }
 
@@ -2450,14 +2534,14 @@ const typeMap: any = {
     ], "any"),
     "ContactListObject": o([
         { json: "contacts", js: "contacts", typ: a(r("ContactElement")) },
-        { json: "type", js: "type", typ: r("ContactListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactListType") },
     ], "any"),
     "ContactElement": o([
         { json: "id", js: "id", typ: r("PurpleContactIdentifiers") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("FluffyInteractionType") },
     ], "any"),
     "PurpleContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2543,8 +2627,8 @@ const typeMap: any = {
     ], "any"),
     "Contact": o([
         { json: "id", js: "id", typ: r("FluffyContactIdentifiers") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("FluffyInteractionType") },
     ], "any"),
     "FluffyContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2552,9 +2636,9 @@ const typeMap: any = {
     ], "any"),
     "ContactList": o([
         { json: "contacts", js: "contacts", typ: a(r("ContactElement")) },
-        { json: "type", js: "type", typ: r("ContactListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactListType") },
     ], "any"),
     "Context": o([
         { json: "id", js: "id", typ: u(undefined, m("any")) },
@@ -2563,8 +2647,8 @@ const typeMap: any = {
     ], "any"),
     "Country": o([
         { json: "id", js: "id", typ: r("CountryID") },
-        { json: "type", js: "type", typ: r("CountryType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("CountryType") },
     ], "any"),
     "CountryID": o([
         { json: "COUNTRY_ISOALPHA2", js: "COUNTRY_ISOALPHA2", typ: u(undefined, "") },
@@ -2589,12 +2673,12 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "EmailRecipients": o([
-        { json: "id", js: "id", typ: u(undefined, r("EmailRecipientsID")) },
-        { json: "type", js: "type", typ: r("EmailRecipientsType") },
+        { json: "id", js: "id", typ: u(undefined, r("ContactTIdentifiers")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("EmailRecipientsType") },
         { json: "contacts", js: "contacts", typ: u(undefined, a(r("ContactElement"))) },
     ], "any"),
-    "EmailRecipientsID": o([
+    "ContactTIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
     ], "any"),
@@ -2622,10 +2706,10 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "InstrumentList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instruments", js: "instruments", typ: a(r("InstrumentElement")) },
-        { json: "type", js: "type", typ: r("InstrumentListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentListType") },
     ], "any"),
     "Interaction": o([
         { json: "description", js: "description", typ: "" },
@@ -2689,10 +2773,10 @@ const typeMap: any = {
         { json: "type", js: "type", typ: r("ProductType") },
     ], "any"),
     "OrderList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "orders", js: "orders", typ: a(r("OrderElement")) },
         { json: "type", js: "type", typ: r("OrderListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "OrderElement": o([
         { json: "details", js: "details", typ: u(undefined, r("FluffyOrderDetails")) },
@@ -2705,8 +2789,8 @@ const typeMap: any = {
     ], "any"),
     "Organization": o([
         { json: "id", js: "id", typ: r("OrganizationIdentifiers") },
-        { json: "type", js: "type", typ: r("StickyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("StickyInteractionType") },
     ], "any"),
     "OrganizationIdentifiers": o([
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
@@ -2714,24 +2798,24 @@ const typeMap: any = {
         { json: "PERMID", js: "PERMID", typ: u(undefined, "") },
     ], "any"),
     "Portfolio": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "positions", js: "positions", typ: a(r("PositionElement")) },
         { json: "type", js: "type", typ: r("PortfolioType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "PositionElement": o([
         { json: "holding", js: "holding", typ: 3.14 },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instrument", js: "instrument", typ: r("InstrumentElement") },
-        { json: "type", js: "type", typ: r("PositionType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("PositionType") },
     ], "any"),
     "Position": o([
         { json: "holding", js: "holding", typ: 3.14 },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instrument", js: "instrument", typ: r("InstrumentElement") },
-        { json: "type", js: "type", typ: r("PositionType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("PositionType") },
     ], "any"),
     "Product": o([
         { json: "id", js: "id", typ: m("") },
@@ -2753,10 +2837,10 @@ const typeMap: any = {
         { json: "type", js: "type", typ: r("TradeType") },
     ], "any"),
     "TradeList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "trades", js: "trades", typ: a(r("TradeElement")) },
         { json: "type", js: "type", typ: r("TradeListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "TradeElement": o([
         { json: "id", js: "id", typ: m("") },

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -236,8 +236,11 @@ export interface InstrumentElement {
      * `id` field that is not globally unique.
      */
     market?: SearchCriteriaMarket;
-    type:    "fdc3.instrument";
-    name?:   string;
+    /**
+     * An optional human-readable name for the instrument
+     */
+    name?: string;
+    type:  "fdc3.instrument";
     [property: string]: any;
 }
 
@@ -785,13 +788,15 @@ export interface SearchCriteria {
      * `id` field that is not globally unique.
      */
     market?: SearchCriteriaMarket;
-    type:    SearchCriteriaType;
     /**
+     * An optional human-readable name for the instrument
+     *
      * An optional human-readable name for the contact
      *
      * An optional human-readable name for the organization
      */
     name?: string;
+    type:  SearchCriteriaType;
     [property: string]: any;
 }
 
@@ -1201,8 +1206,11 @@ export interface Instrument {
      * `id` field that is not globally unique.
      */
     market?: PurpleMarket;
-    type:    "fdc3.instrument";
-    name?:   string;
+    /**
+     * An optional human-readable name for the instrument
+     */
+    name?: string;
+    type:  "fdc3.instrument";
     [property: string]: any;
 }
 
@@ -2499,8 +2507,8 @@ const typeMap: any = {
     "InstrumentElement": o([
         { json: "id", js: "id", typ: r("PurpleInstrumentIdentifiers") },
         { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
-        { json: "type", js: "type", typ: r("InstrumentType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentType") },
     ], "any"),
     "PurpleInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2612,8 +2620,8 @@ const typeMap: any = {
     "SearchCriteria": o([
         { json: "id", js: "id", typ: r("Identifiers") },
         { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
-        { json: "type", js: "type", typ: r("SearchCriteriaType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("SearchCriteriaType") },
     ], "any"),
     "Identifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2688,8 +2696,8 @@ const typeMap: any = {
     "Instrument": o([
         { json: "id", js: "id", typ: r("FluffyInstrumentIdentifiers") },
         { json: "market", js: "market", typ: u(undefined, r("PurpleMarket")) },
-        { json: "type", js: "type", typ: r("InstrumentType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentType") },
     ], "any"),
     "FluffyInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -235,7 +235,7 @@ export interface InstrumentElement {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: OrganizationMarket;
+    market?: SearchCriteriaMarket;
     type:    "fdc3.instrument";
     name?:   string;
     [property: string]: any;
@@ -301,7 +301,7 @@ export interface PurpleInstrumentIdentifiers {
  * interoperability between disparate data sources. This is especially useful when using an
  * `id` field that is not globally unique.
  */
-export interface OrganizationMarket {
+export interface SearchCriteriaMarket {
     /**
      * <https://www.bloomberg.com/>
      */
@@ -731,7 +731,7 @@ export interface ChatSearchCriteria {
      *
      * Empty search criteria can be supported to allow resetting of filters.
      */
-    criteria: Array<OrganizationObject | string>;
+    criteria: SearchCriteria[];
     type:     "fdc3.chat.searchCriteria";
     id?:      { [key: string]: any };
     name?:    string;
@@ -739,23 +739,26 @@ export interface ChatSearchCriteria {
 }
 
 /**
+ * An individual criteria against which to match chat messages, based on an FDC3 context or
+ * free-text string.
+ *
  * financial instrument that relates to the definition of this product
  *
  *
  *
  * A financial instrument from any asset class.
  *
+ * The contact that initiated the interaction
+ *
+ * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
+ *
  * An entity that can be used when referencing private companies and other organizations
  * where a specific instrument is not available or desired e.g. CRM and News workflows.
  *
  * It is valid to include extra properties and metadata as part of the organization payload,
  * but the minimum requirement is for at least one specified identifier to be provided.
- *
- * The contact that initiated the interaction
- *
- * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface OrganizationObject {
+export interface SearchCriteria {
     /**
      * Any combination of instrument identifiers can be used together to resolve ambiguity, or
      * for a better match. Not all applications will use the same instrument identifiers, which
@@ -771,9 +774,9 @@ export interface OrganizationObject {
      * fields, define a property that makes it clear what the value represents. Doing so will
      * make interpretation easier for the developers of target applications.
      *
-     * Identifiers for the organization, at least one must be provided.
-     *
      * Identifiers that relate to the Contact represented by this context
+     *
+     * Identifiers for the organization, at least one must be provided.
      */
     id: Identifiers;
     /**
@@ -781,12 +784,12 @@ export interface OrganizationObject {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: OrganizationMarket;
-    type:    TentacledInteractionType;
+    market?: SearchCriteriaMarket;
+    type:    SearchCriteriaType;
     /**
-     * An optional human-readable name for the organization
-     *
      * An optional human-readable name for the contact
+     *
+     * An optional human-readable name for the organization
      */
     name?: string;
     [property: string]: any;
@@ -807,9 +810,9 @@ export interface OrganizationObject {
  * fields, define a property that makes it clear what the value represents. Doing so will
  * make interpretation easier for the developers of target applications.
  *
- * Identifiers for the organization, at least one must be provided.
- *
  * Identifiers that relate to the Contact represented by this context
+ *
+ * Identifiers for the organization, at least one must be provided.
  */
 export interface Identifiers {
     /**
@@ -823,9 +826,9 @@ export interface Identifiers {
     /**
      * <https://www.factset.com/>
      *
-     * FactSet Permanent Identifier representing the organization
-     *
      * FactSet Permanent Identifier representing the contact
+     *
+     * FactSet Permanent Identifier representing the organization
      */
     FDS_ID?: string;
     /**
@@ -855,16 +858,16 @@ export interface Identifiers {
      */
     ticker?: string;
     /**
+     * The email address for the contact
+     */
+    email?: string;
+    /**
      * The Legal Entity Identifier (LEI) is a 20-character, alpha-numeric code based on the ISO
      * 17442 standard developed by the International Organization for Standardization (ISO). It
      * connects to key reference information that enables clear and unique identification of
      * legal entities participating in financial transactions.
      */
     LEI?: string;
-    /**
-     * The email address for the contact
-     */
-    email?: string;
     [property: string]: any;
 }
 
@@ -874,7 +877,7 @@ export interface Identifiers {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export type TentacledInteractionType = "fdc3.instrument" | "fdc3.organization" | "fdc3.contact";
+export type SearchCriteriaType = "fdc3.instrument" | "fdc3.contact" | "fdc3.organization";
 
 /**
  * Free text to be used for a keyword search
@@ -2495,8 +2498,8 @@ const typeMap: any = {
     ], "any"),
     "InstrumentElement": o([
         { json: "id", js: "id", typ: r("PurpleInstrumentIdentifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
-        { json: "type", js: "type", typ: r("PurpleInteractionType") },
+        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
+        { json: "type", js: "type", typ: r("InstrumentType") },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "PurpleInstrumentIdentifiers": o([
@@ -2510,7 +2513,7 @@ const typeMap: any = {
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
     ], "any"),
-    "OrganizationMarket": o([
+    "SearchCriteriaMarket": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
         { json: "COUNTRY_ISOALPHA2", js: "COUNTRY_ISOALPHA2", typ: u(undefined, "") },
         { json: "MIC", js: "MIC", typ: u(undefined, "") },
@@ -2541,7 +2544,7 @@ const typeMap: any = {
     "ContactElement": o([
         { json: "id", js: "id", typ: r("PurpleContactIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
+        { json: "type", js: "type", typ: r("ContactType") },
     ], "any"),
     "PurpleContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2601,15 +2604,15 @@ const typeMap: any = {
         { json: "url", js: "url", typ: u(undefined, "") },
     ], "any"),
     "ChatSearchCriteria": o([
-        { json: "criteria", js: "criteria", typ: a(u(r("OrganizationObject"), "")) },
+        { json: "criteria", js: "criteria", typ: a(r("SearchCriteria")) },
         { json: "type", js: "type", typ: r("ChatSearchCriteriaType") },
         { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
-    "OrganizationObject": o([
+    "SearchCriteria": o([
         { json: "id", js: "id", typ: r("Identifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
-        { json: "type", js: "type", typ: r("TentacledInteractionType") },
+        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
+        { json: "type", js: "type", typ: r("SearchCriteriaType") },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "Identifiers": o([
@@ -2622,13 +2625,13 @@ const typeMap: any = {
         { json: "RIC", js: "RIC", typ: u(undefined, "") },
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
-        { json: "LEI", js: "LEI", typ: u(undefined, "") },
         { json: "email", js: "email", typ: u(undefined, "") },
+        { json: "LEI", js: "LEI", typ: u(undefined, "") },
     ], "any"),
     "Contact": o([
         { json: "id", js: "id", typ: r("FluffyContactIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
+        { json: "type", js: "type", typ: r("ContactType") },
     ], "any"),
     "FluffyContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2685,7 +2688,7 @@ const typeMap: any = {
     "Instrument": o([
         { json: "id", js: "id", typ: r("FluffyInstrumentIdentifiers") },
         { json: "market", js: "market", typ: u(undefined, r("PurpleMarket")) },
-        { json: "type", js: "type", typ: r("PurpleInteractionType") },
+        { json: "type", js: "type", typ: r("InstrumentType") },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "FluffyInstrumentIdentifiers": o([
@@ -2790,7 +2793,7 @@ const typeMap: any = {
     "Organization": o([
         { json: "id", js: "id", typ: r("OrganizationIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("StickyInteractionType") },
+        { json: "type", js: "type", typ: r("OrganizationType") },
     ], "any"),
     "OrganizationIdentifiers": o([
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
@@ -2868,7 +2871,7 @@ const typeMap: any = {
     "ActionType": [
         "fdc3.action",
     ],
-    "PurpleInteractionType": [
+    "InstrumentType": [
         "fdc3.instrument",
     ],
     "TimeRangeType": [
@@ -2889,7 +2892,7 @@ const typeMap: any = {
     "ChartType": [
         "fdc3.chart",
     ],
-    "FluffyInteractionType": [
+    "ContactType": [
         "fdc3.contact",
     ],
     "ContactListType": [
@@ -2911,7 +2914,7 @@ const typeMap: any = {
     "ChatMessageType": [
         "fdc3.chat.message",
     ],
-    "TentacledInteractionType": [
+    "SearchCriteriaType": [
         "fdc3.contact",
         "fdc3.instrument",
         "fdc3.organization",
@@ -2950,7 +2953,7 @@ const typeMap: any = {
     "OrderListType": [
         "fdc3.orderList",
     ],
-    "StickyInteractionType": [
+    "OrganizationType": [
         "fdc3.organization",
     ],
     "PositionType": [


### PR DESCRIPTION
Added the optional `id` and `name` fields which are documented on the FINOS site but currently missing from `OrderList`, `InstrumentList`, `ContactList` and `Contact` (name only) json schema docs.

See:

- [OrderList](https://fdc3.finos.org/docs/context/ref/OrderList)
- [InstrumentList](https://fdc3.finos.org/docs/context/ref/InstrumentList)
- [ContactList](https://fdc3.finos.org/docs/context/ref/ContactList)
- [Contact](https://fdc3.finos.org/docs/context/ref/Contact)