### PR TITLE
Fix CSL link in meeting templates so it renders the markdown file

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion-group.md
+++ b/.github/ISSUE_TEMPLATE/discussion-group.md
@@ -51,7 +51,7 @@ Thursday DD MMM yyyy - 10am (US eastern timezone EDT/EST) / 3pm (London, GMT/BST
 
 Please click the following links at the start of the meeting if you have not done so previously.
 
- - [View the CSL](https://raw.githubusercontent.com/finos/FDC3/main/LICENSE.md)
+ - [View the CSL](https://github.com/finos/FDC3/blob/main/LICENSE.md)
  - [View the GOVERNANCE of the Project](https://github.com/finos/FDC3/blob/main/GOVERNANCE.md)
  - [Click here to start a PR](https://github.com/finos/FDC3/edit/main/NOTICES.md). 
    - Edit the page to add your details.

--- a/.github/ISSUE_TEMPLATE/general-meeting.md
+++ b/.github/ISSUE_TEMPLATE/general-meeting.md
@@ -42,7 +42,7 @@ DD MMM yyyy - 10am EST / 3pm GMT
 
 Please click the following links at the start of the meeting if you have not done so previously.
 
-- [View the CSL](https://raw.githubusercontent.com/finos/FDC3/main/LICENSE.md)
+- [View the CSL](https://github.com/finos/FDC3/blob/main/LICENSE.md)
 - [View the GOVERNANCE of the Project](https://github.com/finos/FDC3/blob/main/GOVERNANCE.md)
 - [Click here to start a PR](https://github.com/finos/FDC3/edit/main/NOTICES.md). 
   - Edit the page to add your details.

--- a/.github/ISSUE_TEMPLATE/standard-wg-meeting.md
+++ b/.github/ISSUE_TEMPLATE/standard-wg-meeting.md
@@ -43,7 +43,7 @@ Thursday DD MMM yyyy - 10am (US eastern timezone EDT/EST) / 3pm (London, GMT/BST
 
  Please click the following links at the start of the meeting if you have not done so previously.
 
- - [View the CSL](https://raw.githubusercontent.com/finos/FDC3/main/LICENSE.md)
+ - [View the CSL]([https://raw.githubusercontent.com/finos/FDC3/main/LICENSE.md](https://github.com/finos/FDC3/blob/main/LICENSE.md))
  - [View the GOVERNANCE of the Project](https://github.com/finos/FDC3/blob/main/GOVERNANCE.md)
  - [Click here to start a PR](https://github.com/finos/FDC3/edit/main/NOTICES.md). 
    - Edit the page to add your details.

--- a/.github/ISSUE_TEMPLATE/standard-wg-meeting.md
+++ b/.github/ISSUE_TEMPLATE/standard-wg-meeting.md
@@ -43,7 +43,7 @@ Thursday DD MMM yyyy - 10am (US eastern timezone EDT/EST) / 3pm (London, GMT/BST
 
  Please click the following links at the start of the meeting if you have not done so previously.
 
- - [View the CSL]([https://raw.githubusercontent.com/finos/FDC3/main/LICENSE.md](https://github.com/finos/FDC3/blob/main/LICENSE.md))
+ - [View the CSL](https://github.com/finos/FDC3/blob/main/LICENSE.md)
  - [View the GOVERNANCE of the Project](https://github.com/finos/FDC3/blob/main/GOVERNANCE.md)
  - [Click here to start a PR](https://github.com/finos/FDC3/edit/main/NOTICES.md). 
    - Edit the page to add your details.


### PR DESCRIPTION
Links were showing raw markdown - its much easier to read when rendered