### PR TITLE
Correct inconsistent casing of fdc3.timeRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Added clarification that `id` field values SHOULD always be strings to context schema definition (a restriction that can't easily be represented in the generated types). ([#1149](https://github.com/finos/FDC3/pull/1149))
-* Added requirement that Standard versions SHOULD avoid the use unions in context and API definitions wherever possible as these can be hard 
- to replicate and MUST avoid unions of primitive types as these can be impossible to replicate in other languages. ([#120](https://github.com/finos/FDC3/pull/1200))
+* Added requirement that Standard versions SHOULD avoid the use unions in context and API definitions wherever possible as these can be hard to replicate and MUST avoid unions of primitive types as these can be impossible to replicate in other languages. ([#120](https://github.com/finos/FDC3/pull/1200))
 
 ### Changed
 
@@ -20,6 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 * Added missing `desktopAgent` field to ImplementationMetadata objects returned for all agents connect to a DesktopAgent bridge in Connection Step 6 connectAgentsUpdate messages and refined the schema used to collect this info in step 3 handshake. ([#1177](https://github.com/finos/FDC3/pull/1177))
 * Removed the `version` field from `IntentResolution` as there are no version fields for intents in the FDC3 API definitions and hence the field has no purpose. ([#1170](https://github.com/finos/FDC3/pull/1170))
+
+## [npm v2.1.1] - 2024-06-28
+
+### Fixed
+
+* Corrected inconsistent camel-casing of the `fdc3.timeRange` context type which appeared as `fdc3.timerange` in a number of places. ([#1240][https://github.com/finos/FDC3/pull/1240])
 
 ## [FDC3 Standard 2.1](https://github.com/finos/FDC3/compare/v2.0..v2.1) - 2023-09-13
 
@@ -105,7 +110,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added a recommended set of user channel definitions to the API docs and typescript sources ([#727](https://github.com/finos/FDC3/pull/727))
 * Added the optional exposure of originating app metadata to messages received via `addContextListener` and `addIntentListener` via the new `ContextMetadata` type. ([#725](https://github.com/finos/FDC3/pull/725))
 * Added the current app's `AppMetadata` to the `ImplementationMetadata` returned by `fdc3.getInfo()` allowing an app to retrieve its own metadata, according to the Desktop Agent ([#726](https://github.com/finos/FDC3/pull/726))
-* Added a context type representing a range of time (`fdc3.timerange`). ([#706](https://github.com/finos/FDC3/pull/706))
+* Added a context type representing a range of time (`fdc3.timeRange`). ([#706](https://github.com/finos/FDC3/pull/706))
 * Added a context type representing a Currency (`fdc3.currency`). ([#708](https://github.com/finos/FDC3/pull/708))
 * Added a context type representing the price and value of a holding (`fdc3.valuation`). ([#709](https://github.com/finos/FDC3/pull/709))
 * Added a context type representing a Chart (`fdc3.chart`). ([#715](https://github.com/finos/FDC3/pull/715))

--- a/docs/context/ref/Chart.md
+++ b/docs/context/ref/Chart.md
@@ -29,7 +29,7 @@ In addition to handling requests to plot charts, a charting application may use 
 |------------------|-----------------|----------|----------------------|
 | `type`           | string          | Yes      | `'fdc3.chart'`     |
 | `instruments`    | Instrument[]  | Yes      | <pre>[<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "AAPL"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;},<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "MSFT"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;}<br/>]</pre> |
-| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timerange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
+| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timeRange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
 | `style`    | string  | No       | one of: `'line'`, `'bar'`, `'stacked-bar'`, `'mountain'`, `'candle'`, `'pie'`, `'scatter'`, `'histogram'`, `'heatmap'`, `'custom'`      |
 | `otherConfig`* | array  | No |  `[ {/* additional config context objects */} ]`  |
 

--- a/docs/context/ref/TimeRange.md
+++ b/docs/context/ref/TimeRange.md
@@ -29,7 +29,7 @@ Notes:
 
 ## Type
 
-`fdc3.timerange`
+`fdc3.timeRange`
 
 ## Schema
 

--- a/docs/context/spec.md
+++ b/docs/context/spec.md
@@ -253,7 +253,7 @@ The following are standard FDC3 context types:
 - [`fdc3.portfolio`](ref/Portfolio) ([schema](/schemas/next/context/portfolio.schema.json))
 - [`fdc3.position`](ref/Position) ([schema](/schemas/next/context/position.schema.json))
 - [`fdc3.nothing`](ref/Nothing) ([schema](/schemas/next/context/nothing.schema.json))
-- [`fdc3.timerange`](ref/TimeRange) ([schema](/schemas/next/context/timerange.schema.json))
+- [`fdc3.timeRange`](ref/TimeRange) ([schema](/schemas/next/context/timerange.schema.json))
 - [`fdc3.transactionResult`](ref/TransactionResult) ([schema](/schemas/next/context/transactionresult.schema.json))
 - [`fdc3.valuation`](ref/Valuation) ([schema](/schemas/next/context/valuation.schema.json))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "Fintech Open Source Foundation (FINOS)",
   "homepage": "https://fdc3.finos.org",
   "repository": {

--- a/schemas/context/timerange.schema.json
+++ b/schemas/context/timerange.schema.json
@@ -8,7 +8,7 @@
     {
       "properties": {
         "type": {
-          "const": "fdc3.timerange"
+          "const": "fdc3.timeRange"
         },
         "startTime": {
           "type": "string",

--- a/src/context/ContextType.ts
+++ b/src/context/ContextType.ts
@@ -26,7 +26,7 @@ export type StandardContextType =
   | 'fdc3.portfolio'
   | 'fdc3.position'
   | 'fdc3.nothing'
-  | 'fdc3.timerange'
+  | 'fdc3.timeRange'
   | 'fdc3.transactionResult'
   | 'fdc3.valuation';
 
@@ -67,7 +67,7 @@ export enum ContextTypes {
   Portfolio = 'fdc3.portfolio',
   Position = 'fdc3.position',
   ChatSearchCriteria = 'fdc3.chat.searchCriteria',
-  TimeRange = 'fdc3.timerange',
+  TimeRange = 'fdc3.timeRange',
   TransactionResult = 'fdc3.transactionResult',
   Valuation = 'fdc3.valuation',
 }

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -375,7 +375,7 @@ export interface TimeRangeObject {
      * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
      */
     startTime?: Date;
-    type:       "fdc3.timerange";
+    type:       "fdc3.timeRange";
     id?:        { [key: string]: any };
     name?:      string;
     [property: string]: any;
@@ -1826,7 +1826,7 @@ export interface TimeRange {
      * 8601-1:2019](https://www.iso.org/standard/70907.html) with a timezone indicator.
      */
     startTime?: Date;
-    type:       "fdc3.timerange";
+    type:       "fdc3.timeRange";
     id?:        { [key: string]: any };
     name?:      string;
     [property: string]: any;
@@ -2788,7 +2788,7 @@ const typeMap: any = {
         "fdc3.instrument",
     ],
     "TimeRangeType": [
-        "fdc3.timerange",
+        "fdc3.timeRange",
     ],
     "ChartStyle": [
         "bar",

--- a/src/internal/contextConfiguration.ts
+++ b/src/internal/contextConfiguration.ts
@@ -21,7 +21,7 @@ const STANDARD_CONTEXT_TYPES = exhaustiveStringTuple<StandardContextType>()(
   'fdc3.portfolio',
   'fdc3.position',
   'fdc3.nothing',
-  'fdc3.timerange',
+  'fdc3.timeRange',
   'fdc3.transactionResult',
   'fdc3.valuation'
 );

--- a/test/Methods.test.ts
+++ b/test/Methods.test.ts
@@ -478,7 +478,7 @@ describe('test version comparison functions', () => {
     expect(isStandardContextType('fdc3.portfolio')).toBe(true);
     expect(isStandardContextType('fdc3.position')).toBe(true);
     expect(isStandardContextType('fdc3.nothing')).toBe(true);
-    expect(isStandardContextType('fdc3.timerange')).toBe(true);
+    expect(isStandardContextType('fdc3.timeRange')).toBe(true);
     expect(isStandardContextType('fdc3.transactionResult')).toBe(true);
     expect(isStandardContextType('fdc3.valuation')).toBe(true);
   });

--- a/website/static/schemas/2.0/timerange.schema.json
+++ b/website/static/schemas/2.0/timerange.schema.json
@@ -16,7 +16,7 @@
     }
   ],
   "properties": {
-    "type": { "const": "fdc3.timerange" },
+    "type": { "const": "fdc3.timeRange" },
     "startTime": { "type": "string", "format": "date-time" },
     "endTime":  {"type": "string", "format": "date-time" }
   },

--- a/website/static/schemas/2.1/context/timerange.schema.json
+++ b/website/static/schemas/2.1/context/timerange.schema.json
@@ -8,7 +8,7 @@
     {
       "properties": {
         "type": {
-          "const": "fdc3.timerange"
+          "const": "fdc3.timeRange"
         },
         "startTime": {
           "type": "string",

--- a/website/static/schemas/next/context/timerange.schema.json
+++ b/website/static/schemas/next/context/timerange.schema.json
@@ -8,7 +8,7 @@
     {
       "properties": {
         "type": {
-          "const": "fdc3.timerange"
+          "const": "fdc3.timeRange"
         },
         "startTime": {
           "type": "string",

--- a/website/versioned_docs/version-1.0/context/ref/Chart.md
+++ b/website/versioned_docs/version-1.0/context/ref/Chart.md
@@ -28,7 +28,7 @@ https://fdc3.finos.org/schemas/next/chart.schema.json
 |------------------|-----------------|----------|----------------------|
 | `type`           | string          | Yes      | `'fdc3.chart'`     |
 | `instruments`    | Instrument[]  | Yes      | <pre>[<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "AAPL"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;},<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "MSFT"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;}<br/>]</pre> |
-| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timerange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
+| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timeRange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
 | `style`    | string  | No       | one of: `'line'`, `'bar'`, `'stacked-bar'`, `'mountain'`, `'candle'`, `'pie'`, `'scatter'`, `'histogram'`, `'heatmap'`, `'custom'`      |
 | `otherConfig`* | object  | No |  `{ /* unstandardized additional config */}`  |
 

--- a/website/versioned_docs/version-1.0/context/ref/TimeRange.md
+++ b/website/versioned_docs/version-1.0/context/ref/TimeRange.md
@@ -28,7 +28,7 @@ Notes:
 
 ## Type
 
-`fdc3.timerange`
+`fdc3.timeRange`
 
 ## Schema
 

--- a/website/versioned_docs/version-1.0/context/spec.md
+++ b/website/versioned_docs/version-1.0/context/spec.md
@@ -169,7 +169,7 @@ The following are standard FDC3 context types:
 * [`fdc3.portfolio`](ref/Portfolio) ([schema](/schemas/next/context/portfolio.schema.json))
 * [`fdc3.position`](ref/Position) ([schema](/schemas/next/context/position.schema.json))
 * [`fdc3.nothing`](ref/Nothing) ([schema](/schemas/next/context/nothing.schema.json))
-* [`fdc3.timerange`](ref/TimeRange) ([schema](/schemas/next/context/timerange.schema.json))
+* [`fdc3.timeRange`](ref/TimeRange) ([schema](/schemas/next/context/timerange.schema.json))
 * [`fdc3.valuation`](ref/Valuation) ([schema](/schemas/next/context/valuation.schema.json))
 
 **Note:** The below examples show how the base context data interface can be used to define specific context data objects.

--- a/website/versioned_docs/version-2.0/context/ref/Chart.md
+++ b/website/versioned_docs/version-2.0/context/ref/Chart.md
@@ -29,7 +29,7 @@ https://fdc3.finos.org/schemas/2.0/chart.schema.json
 |------------------|-----------------|----------|----------------------|
 | `type`           | string          | Yes      | `'fdc3.chart'`     |
 | `instruments`    | Instrument[]  | Yes      | <pre>[<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "AAPL"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;},<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "MSFT"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;}<br/>]</pre> |
-| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timerange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
+| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timeRange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
 | `style`    | string  | No       | one of: `'line'`, `'bar'`, `'stacked-bar'`, `'mountain'`, `'candle'`, `'pie'`, `'scatter'`, `'histogram'`, `'heatmap'`, `'custom'`      |
 | `otherConfig`* | object  | No |  `{ /* unstandardized additional config */}`  |
 

--- a/website/versioned_docs/version-2.0/context/ref/TimeRange.md
+++ b/website/versioned_docs/version-2.0/context/ref/TimeRange.md
@@ -29,7 +29,7 @@ Notes:
 
 ## Type
 
-`fdc3.timerange`
+`fdc3.timeRange`
 
 ## Schema
 

--- a/website/versioned_docs/version-2.0/context/spec.md
+++ b/website/versioned_docs/version-2.0/context/spec.md
@@ -172,7 +172,7 @@ The following are standard FDC3 context types:
 * [`fdc3.portfolio`](ref/Portfolio) ([schema](/schemas/2.0/portfolio.schema.json))
 * [`fdc3.position`](ref/Position) ([schema](/schemas/2.0/position.schema.json))
 * [`fdc3.nothing`](ref/Nothing) ([schema](/schemas/2.0/nothing.schema.json))
-* [`fdc3.timerange`](ref/TimeRange) ([schema](/schemas/2.0/timerange.schema.json))
+* [`fdc3.timeRange`](ref/TimeRange) ([schema](/schemas/2.0/timerange.schema.json))
 * [`fdc3.valuation`](ref/Valuation) ([schema](/schemas/2.0/valuation.schema.json))
 
 :::note

--- a/website/versioned_docs/version-2.1/context/ref/Chart.md
+++ b/website/versioned_docs/version-2.1/context/ref/Chart.md
@@ -29,7 +29,7 @@ In addition to handling requests to plot charts, a charting application may use 
 |------------------|-----------------|----------|----------------------|
 | `type`           | string          | Yes      | `'fdc3.chart'`     |
 | `instruments`    | Instrument[]  | Yes      | <pre>[<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "AAPL"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;},<br/>&emsp;&emsp;{<br/>&emsp;&emsp;&emsp;&emsp;"type": "fdc3.instrument",<br/>&emsp;&emsp;&emsp;&emsp;"id": {<br/>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;"ticker": "MSFT"<br/>&emsp;&emsp;&emsp;&emsp;}<br/>&emsp;&emsp;}<br/>]</pre> |
-| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timerange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
+| `range` | TimeRange  | No       | <pre>{<br/>&emsp;&emsp;"type": "fdc3.timeRange",<br/>&emsp;&emsp;"startTime": "2022-03-30T15:44:44+00:00",<br/>&emsp;&emsp;"endTime": "2022-04-30T23:59:59+00:00"<br/>}</pre>            |
 | `style`    | string  | No       | one of: `'line'`, `'bar'`, `'stacked-bar'`, `'mountain'`, `'candle'`, `'pie'`, `'scatter'`, `'histogram'`, `'heatmap'`, `'custom'`      |
 | `otherConfig`* | array  | No |  `[ {/* additional config context objects */} ]`  |
 

--- a/website/versioned_docs/version-2.1/context/ref/TimeRange.md
+++ b/website/versioned_docs/version-2.1/context/ref/TimeRange.md
@@ -29,7 +29,7 @@ Notes:
 
 ## Type
 
-`fdc3.timerange`
+`fdc3.timeRange`
 
 ## Schema
 

--- a/website/versioned_docs/version-2.1/context/spec.md
+++ b/website/versioned_docs/version-2.1/context/spec.md
@@ -218,7 +218,7 @@ The following are standard FDC3 context types:
 - [`fdc3.portfolio`](ref/Portfolio) ([schema](/schemas/2.1/context/portfolio.schema.json))
 - [`fdc3.position`](ref/Position) ([schema](/schemas/2.1/context/position.schema.json))
 - [`fdc3.nothing`](ref/Nothing) ([schema](/schemas/2.1/context/nothing.schema.json))
-- [`fdc3.timerange`](ref/TimeRange) ([schema](/schemas/2.1/context/timerange.schema.json))
+- [`fdc3.timeRange`](ref/TimeRange) ([schema](/schemas/2.1/context/timerange.schema.json))
 - [`fdc3.transactionResult`](ref/TransactionResult) ([schema](/schemas/2.1/context/transactionresult.schema.json))
 - [`fdc3.valuation`](ref/Valuation) ([schema](/schemas/2.1/context/valuation.schema.json))
 


### PR DESCRIPTION
The `fdc3.timeRange` context type is inconsistently cased in the FDC3 docs and codebase, sometimes appearing as `fdc3.timerange`. This PR corrects it such that it appears as `fdc3.timeRange` in all cases.

Once approved the commit from this PR will need to be cherry-picked into a release/2.1.1 branch to release a corrected version of the 2.1 npm module.