### PR TITLE
Correcting a syntax error in the TransactionResult Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 * Corrected inconsistent camel-casing of the `fdc3.timeRange` context type which appeared as `fdc3.timerange` in a number of places. ([#1240][https://github.com/finos/FDC3/pull/1240])
+* Corrected an error in the `fdc3.TransactionResult` schema which resulted in the `message` property being omitted from the generated TypeScript types for it. ([#1251][https://github.com/finos/FDC3/pull/1251])
 
 ## [FDC3 Standard 2.1](https://github.com/finos/FDC3/compare/v2.0..v2.1) - 2023-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-* Corrected inconsistent camel-casing of the `fdc3.timeRange` context type which appeared as `fdc3.timerange` in a number of places. ([#1240][https://github.com/finos/FDC3/pull/1240])
-* Corrected an error in the `fdc3.TransactionResult` schema which resulted in the `message` property being omitted from the generated TypeScript types for it. ([#1251][https://github.com/finos/FDC3/pull/1251])
+* Corrected inconsistent camel-casing of the `fdc3.timeRange` context type which appeared as `fdc3.timerange` in a number of places. ([#1240](https://github.com/finos/FDC3/pull/1240))
+* Corrected an error in the `fdc3.TransactionResult` schema which resulted in the `message` property being omitted from the generated TypeScript types for it. ([#1251](https://github.com/finos/FDC3/pull/1251))
 
 ## [FDC3 Standard 2.1](https://github.com/finos/FDC3/compare/v2.0..v2.1) - 2023-09-13
 

--- a/schemas/context/transactionresult.schema.json
+++ b/schemas/context/transactionresult.schema.json
@@ -26,12 +26,12 @@
           "$ref": "context.schema.json#",
           "title": "Transaction Result Context",
           "description": "A context object returned by the transaction, possibly with updated data."
+        },
+        "message": {
+          "type": "string",
+          "title": "Transaction Message",
+          "description": "A human readable message describing the outcome of the transaction."
         }
-      },
-      "message": {
-        "type": "string",
-        "title": "Transaction Message",
-        "description": "A human readable message describing the outcome of the transaction."
       },
       "required": [
         "type",

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -1939,6 +1939,10 @@ export interface TransactionResult {
      */
     context?: ContextElement;
     /**
+     * A human readable message describing the outcome of the transaction.
+     */
+    message?: string;
+    /**
      * The status of the transaction being reported.
      */
     status: TransactionStatus;
@@ -2766,6 +2770,7 @@ const typeMap: any = {
     ], "any"),
     "TransactionResult": o([
         { json: "context", js: "context", typ: u(undefined, r("ContextElement")) },
+        { json: "message", js: "message", typ: u(undefined, "") },
         { json: "status", js: "status", typ: r("TransactionStatus") },
         { json: "type", js: "type", typ: r("TransactionResultType") },
         { json: "id", js: "id", typ: u(undefined, m("any")) },


### PR DESCRIPTION
There is an error in the TransactionResult schema:  https://github.com/finos/FDC3/blob/6d2f9fa0a57e998d55f8fb7d1bae7200970a8b16/schemas/context/transactionresult.schema.json#L31-L35

The `message` property has slipped outside the `properties` element and didn't make it into generated code: https://github.com/finos/FDC3/blob/6d2f9fa0a57e998d55f8fb7d1bae7200970a8b16/src/context/ContextTypes.ts#L1930-L1949) 
or docs in the context docs generation PR (#1151) - it is in the schema examples and the existing docs).