### PR TITLE
Revert timerange changes in 2.0

### DIFF
--- a/website/static/schemas/2.0/timerange.schema.json
+++ b/website/static/schemas/2.0/timerange.schema.json
@@ -16,7 +16,7 @@
     }
   ],
   "properties": {
-    "type": { "const": "fdc3.timeRange" },
+    "type": { "const": "fdc3.timerange" },
     "startTime": { "type": "string", "format": "date-time" },
     "endTime":  {"type": "string", "format": "date-time" }
   },

--- a/website/versioned_docs/version-2.0/context/ref/Chart.md
+++ b/website/versioned_docs/version-2.0/context/ref/Chart.md
@@ -25,6 +25,12 @@ https://fdc3.finos.org/schemas/2.0/chart.schema.json
 
 ## Details
 
+:::warning
+
+The `fdc3.timeRange` context type is inconsistently used in FDC3 2.0, occasionally appearing as `fdc3.timerange`. This has been corrected in FDC3 2.1 to always use the camel case form `fdc3.timeRange`.
+
+:::
+
 | Property         | Type            | Required | Example Value        |
 |------------------|-----------------|----------|----------------------|
 | `type`           | string          | Yes      | `'fdc3.chart'`     |

--- a/website/versioned_docs/version-2.0/context/ref/TimeRange.md
+++ b/website/versioned_docs/version-2.0/context/ref/TimeRange.md
@@ -31,6 +31,12 @@ Notes:
 
 `fdc3.timeRange`
 
+:::warning
+
+The `fdc3.timeRange` context type is inconsistently used in FDC3 2.0, occasionally appearing as `fdc3.timerange`. This has been corrected in FDC3 2.1 to always use the camel-case form `fdc3.timeRange`.
+
+:::
+
 ## Schema
 
 https://fdc3.finos.org/schemas/2.0/timerange.schema.json


### PR DESCRIPTION
The fdc3.timerange type was corrected to fdc3.timeRange in 2.1, however the PR mistakenly changed the 2.0 schema. This PR reverts the change and adds a warning message in the 2.0 version of the docs highlighting the inconsistency.

![image](https://github.com/finos/FDC3/assets/1701764/efc017da-4648-4440-bfad-868fba96b8c7)
