### PR TITLE
Fix build and publish workflow on main

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,8 @@ on:
       - release/**
     paths-ignore:
       - '.github/workflows/docusaurus.yml'
+permissions:
+  contents: read
 jobs:
 # JOB to run change detection
   changes:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,8 +13,6 @@ on:
       - release/**
     paths-ignore:
       - '.github/workflows/docusaurus.yml'
-      - 'docs/**'
-      - 'website/**'
   pull_request:
     types: [opened, reopened, edited, ready_for_review]
     branches:
@@ -22,15 +20,34 @@ on:
       - release/*
     paths-ignore:
       - '.github/workflows/docusaurus.yml'
-      - 'docs/**'
-      - 'website/**'
-permissions:
-  contents: read
-
 jobs:
+# JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from the filter step
+    outputs:
+      builtFiles: ${{ steps.filter.outputs.builtFiles }}
+    steps:
+    # For pull requests it's not necessary to checkout the code
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          builtFiles:
+            - '.eslint*'
+            - 'src/**'
+            - 'schemas/**'
+            - 'package-lock.json'
+            - 'package.json'
+            - 'rollup.config.js'
+            - 's2tQuicktypeUtil.js'
+            - 'tsconfig.json'
+            
   package-build:
     name: Build on Node ${{ matrix.node }} and ${{ matrix.os }}
-
+    needs: changes
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,28 +56,34 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
+        uses: actions/checkout@v4
 
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 
       - name: Install dependencies
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
         uses: bahmutov/npm-install@2509f13e8485d88340a789a3f7ca11aaac47c9fc #v1.8.36
 
       - name: Lint
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
         run: npm run lint
 
       - name: Test
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
         run:  npm run test --ci --coverage --maxWorkers=2
 
       - name: Build
+        if: ${{ needs.changes.outputs.builtFiles == 'true' }}
         run:  npm run build
 
   package-publish:
-    if: ${{ github.event_name == 'push' }}
-    needs: package-build
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.builtFiles == 'true'}}
+    needs: [changes,package-build]
     name: Publish package to ${{ matrix.name }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,7 +31,7 @@ jobs:
       builtFiles: ${{ steps.filter.outputs.builtFiles }}
     steps:
     # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
       id: filter
       with:
         filters: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -30,8 +30,8 @@ jobs:
     outputs:
       builtFiles: ${{ steps.filter.outputs.builtFiles }}
     steps:
-    # For pull requests it's not necessary to checkout the code
-    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
       id: filter
       with:
         filters: |
@@ -58,11 +58,11 @@ jobs:
     steps:
       - name: Checkout repo
         if: ${{ needs.changes.outputs.builtFiles == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Use Node ${{ matrix.node }}
         if: ${{ needs.changes.outputs.builtFiles == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,7 +17,7 @@ on:
     types: [opened, reopened, edited, ready_for_review]
     branches:
       - main
-      - release/*
+      - release/**
     paths-ignore:
       - '.github/workflows/docusaurus.yml'
 jobs:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,6 +44,7 @@ jobs:
             - 'rollup.config.js'
             - 's2tQuicktypeUtil.js'
             - 'tsconfig.json'
+            - '.github/workflows/package.yml'
             
   package-build:
     name: Build on Node ${{ matrix.node }} and ${{ matrix.os }}
@@ -80,6 +81,11 @@ jobs:
       - name: Build
         if: ${{ needs.changes.outputs.builtFiles == 'true' }}
         run:  npm run build
+
+      - name: Checkout repo
+        if: ${{ needs.changes.outputs.builtFiles == 'false' }}
+        run: 'echo "Build steps skipped as no relevant changes were detected"'
+
 
   package-publish:
     if: ${{ github.event_name == 'push' && needs.changes.outputs.builtFiles == 'true'}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -118,25 +118,14 @@ jobs:
     - name: Check package version
       id: check-version
       uses: tehpsalmist/npm-publish-status-action@deb911186cfe5134094f49183364da10a986e4e7
-      with:
-        node-version: 20
-        registry-url: ${{ matrix.registry }}
         
-    # Disabled when switching from PostHog/check-package-version as the new lib 
-    #   just tells you if your version exists or not 
-    # - name: Package version info
-    #   run: |
-    #     echo "Committed version: ${{ steps.check-version.outputs.committed-version }}"
-    #     echo "Published version: ${{ steps.check-version.published-version }}"
-    #     echo "Is version new: ${{ steps.check-version.outputs.is-new-version }}"
-
     - name: Report already published status
       if: steps.check-version.outputs.exists == '1' 
-      run: 'echo "package version already exists in registry ${{ matrix.registry }}"'
+      run: 'echo "package version already exists in the NPM registry"'
       
     - name: Report not yet published status
       if: steps.check-version.outputs.exists == '0' 
-      run: 'echo "package version does not exist in registry ${{ matrix.registry }}, publishing..."'
+      run: 'echo "package version does not exist in the NPM registry, publishing..."'
       
     - name: Install dependencies
       if: steps.check-version.outputs.exists == '0' 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -89,7 +89,10 @@ jobs:
     - name: Check package version
       id: check-version
       uses: tehpsalmist/npm-publish-status-action@deb911186cfe5134094f49183364da10a986e4e7
-
+      with:
+        node-version: 20
+        registry-url: ${{ matrix.registry }}
+        
     # Disabled when switching from PostHog/check-package-version as the new lib 
     #   just tells you if your version exists or not 
     # - name: Package version info
@@ -100,11 +103,11 @@ jobs:
 
     - name: Report already published status
       if: steps.check-version.outputs.exists == '1' 
-      run: 'echo "package version already exists on npm registry"'
+      run: 'echo "package version already exists in registry ${{ matrix.registry }}"'
       
     - name: Report not yet published status
       if: steps.check-version.outputs.exists == '0' 
-      run: 'echo "package version does not exist on npm registry, publishing..."'
+      run: 'echo "package version does not exist in registry ${{ matrix.registry }}, publishing..."'
       
     - name: Install dependencies
       if: steps.check-version.outputs.exists == '0' 


### PR DESCRIPTION
Updates the package workflow to allow the build tasks to be used as status checks, and to ensure that the publishing workflow checks the status in each package manager repository correctly (instead of always checking NPM)