### PR TITLE
Use Pascal case for Chat context type titles

### DIFF
--- a/docs/context/ref/ChatMessage.md
+++ b/docs/context/ref/ChatMessage.md
@@ -1,10 +1,10 @@
 ---
-title: Chat Message
-sidebar_label: Chat Message
+title: ChatMessage
+sidebar_label: ChatMessage
 
 ---
 
-# Chat Message
+# ChatMessage
 
 A context representing a chat message. Typically used to send the message or to pre-populate a message for sending.
 
@@ -21,7 +21,7 @@ A context representing a chat message. Typically used to send the message or to 
 <details>
   <summary><code>chatRoom</code> <strong>(required)</strong></summary>
 
-**type**: [Chat Room](ChatRoom)
+**type**: [ChatRoom](ChatRoom)
 
 </details>
 

--- a/docs/context/ref/ChatRoom.md
+++ b/docs/context/ref/ChatRoom.md
@@ -1,10 +1,10 @@
 ---
-title: Chat Room
-sidebar_label: Chat Room
+title: ChatRoom
+sidebar_label: ChatRoom
 
 ---
 
-# Chat Room
+# ChatRoom
 
 Reference to the chat room which could be used to send a message to the room
 

--- a/docs/context/ref/ChatSearchCriteria.md
+++ b/docs/context/ref/ChatSearchCriteria.md
@@ -1,10 +1,10 @@
 ---
-title: Chat Search Criteria
-sidebar_label: Chat Search Criteria
+title: ChatSearchCriteria
+sidebar_label: ChatSearchCriteria
 
 ---
 
-# Chat Search Criteria
+# ChatSearchCriteria
 
 A context type that represents a simple search criterion, based on a list of other context objects, that can be used to search or filter messages in a chat application.
 

--- a/schemas/context/chatMessage.schema.json
+++ b/schemas/context/chatMessage.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatMessage.schema.json",
   "type": "object",
-  "title": "Chat Message",
+  "title": "ChatMessage",
   "description": "A context representing a chat message. Typically used to send the message or to pre-populate a message for sending.",
   "allOf": [{
       "type": "object",

--- a/schemas/context/chatRoom.schema.json
+++ b/schemas/context/chatRoom.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatRoom.schema.json",
   "type": "object",
-  "title": "Chat Room",
+  "title": "ChatRoom",
   "description": "Reference to the chat room which could be used to send a message to the room",
   "allOf": [{
     "type": "object",

--- a/schemas/context/chatSearchCriteria.schema.json
+++ b/schemas/context/chatSearchCriteria.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatSearchCriteria.schema.json",
   "type": "object",
-  "title": "Chat Search Criteria",
+  "title": "ChatSearchCriteria",
   "description": "A context type that represents a simple search criterion, based on a list of other context objects, that can be used to search or filter messages in a chat application.",
   "allOf": [
     {

--- a/website/static/schemas/next/context/chatMessage.schema.json
+++ b/website/static/schemas/next/context/chatMessage.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatMessage.schema.json",
   "type": "object",
-  "title": "Chat Message",
+  "title": "ChatMessage",
   "description": "A context representing a chat message. Typically used to send the message or to pre-populate a message for sending.",
   "allOf": [{
       "type": "object",

--- a/website/static/schemas/next/context/chatRoom.schema.json
+++ b/website/static/schemas/next/context/chatRoom.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatRoom.schema.json",
   "type": "object",
-  "title": "Chat Room",
+  "title": "ChatRoom",
   "description": "Reference to the chat room which could be used to send a message to the room",
   "allOf": [{
     "type": "object",

--- a/website/static/schemas/next/context/chatSearchCriteria.schema.json
+++ b/website/static/schemas/next/context/chatSearchCriteria.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://fdc3.finos.org/schemas/next/context/chatSearchCriteria.schema.json",
   "type": "object",
-  "title": "Chat Search Criteria",
+  "title": "ChatSearchCriteria",
   "description": "A context type that represents a simple search criterion, based on a list of other context objects, that can be used to search or filter messages in a chat application.",
   "allOf": [
     {


### PR DESCRIPTION
@bingenito THis will fix the titles/sidebar labels of the generated Chat context docs to match the current pages