### PR TITLE
Fix rendering of links in instrument docs + typo in experimental

### DIFF
--- a/docs/context/ref/Instrument.md
+++ b/docs/context/ref/Instrument.md
@@ -30,7 +30,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.bloomberg.com/\>
+https://www.bloomberg.com/
 
 </details>
 
@@ -39,7 +39,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.cusip.com/\>
+https://www.cusip.com/
 
 </details>
 
@@ -48,7 +48,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.factset.com/\>
+https://www.factset.com/
 
 </details>
 
@@ -57,7 +57,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.openfigi.com/\>
+https://www.openfigi.com/
 
 </details>
 
@@ -66,7 +66,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.isin.org/\>
+https://www.isin.org/
 
 </details>
 
@@ -75,7 +75,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://permid.org/\>
+https://permid.org/
 
 </details>
 
@@ -84,7 +84,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
- <https://www.refinitiv.com/\>
+https://www.refinitiv.com/
 
 </details>
 
@@ -93,7 +93,7 @@ A financial instrument from any asset class.
 
 **type**: `string`
 
-<https://www.lseg.com/sedol\>
+https://www.lseg.com/sedol
 
 </details>
 
@@ -127,7 +127,7 @@ If the identifier you want to share is not a ticker or one of the other standard
 
 **type**: `string`
 
-<https://en.wikipedia.org/wiki/Market_Identifier_Code\>
+https://en.wikipedia.org/wiki/Market_Identifier_Code
 
 </details>
 
@@ -145,7 +145,7 @@ Human readable market name
 
 **type**: `string`
 
-<https://www.iso.org/iso-3166-country-codes.html\>
+https://www.iso.org/iso-3166-country-codes.html
 
 </details>
 
@@ -154,7 +154,7 @@ Human readable market name
 
 **type**: `string`
 
-<https://www.bloomberg.com/\>
+https://www.bloomberg.com/
 
 </details>
 

--- a/docs/context/ref/Order.md
+++ b/docs/context/ref/Order.md
@@ -6,7 +6,7 @@ sidebar_label: Order
 
 # Order
 
-[@experiemental](/docs/fdc3-compliance#experimental-features) context type representing an order. To be used with OMS and EMS systems.
+[@experimental](/docs/fdc3-compliance#experimental-features) context type representing an order. To be used with OMS and EMS systems.
 
 This type currently only defines a required `id` field, which should provide a reference to the order in one or more systems, an optional human readable `name` field to be used to summarize the order and an optional `details` field that may be used to provide additional detail about the order, including a context representing a `product`, which may be extended with arbitrary properties. The `details.product` field is currently typed as a unspecified Context type, but both `details` and `details.product` are expected to be standardized in future.
 

--- a/docs/context/ref/OrderList.md
+++ b/docs/context/ref/OrderList.md
@@ -6,7 +6,7 @@ sidebar_label: OrderList
 
 # OrderList
 
-[@experiemental](/docs/fdc3-compliance#experimental-features) A list of orders. Use this type for use cases that require not just a single order, but multiple.
+[@experimental](/docs/fdc3-compliance#experimental-features) A list of orders. Use this type for use cases that require not just a single order, but multiple.
 
 The OrderList schema does not explicitly include identifiers in the id section, as there is not a common standard for such identifiers. Applications can, however, populate this part of the contract with custom identifiers if so desired.
 

--- a/docs/context/ref/Product.md
+++ b/docs/context/ref/Product.md
@@ -6,7 +6,7 @@ sidebar_label: Product
 
 # Product
 
-[@experiemental](/docs/fdc3-compliance#experimental-features) context type representing a tradable product. To be used with OMS and EMS systems.
+[@experimental](/docs/fdc3-compliance#experimental-features) context type representing a tradable product. To be used with OMS and EMS systems.
 
 This type is currently only loosely defined as an extensible context object, with an optional instrument field.
 

--- a/docs/context/ref/Trade.md
+++ b/docs/context/ref/Trade.md
@@ -6,7 +6,7 @@ sidebar_label: Trade
 
 # Trade
 
-[@experiemental](/docs/fdc3-compliance#experimental-features) context type representing a trade. To be used with execution systems.
+[@experimental](/docs/fdc3-compliance#experimental-features) context type representing a trade. To be used with execution systems.
 
 This type currently only defines a required `id` field, which should provide a reference to the trade in one or more systems, an optional human readable `name` field to be used to summarize the trade and a required `product` field that may be used to provide additional detail about the trade, which is currently typed as a unspecified Context type, but `product` is expected to be standardized in future.
 

--- a/docs/context/ref/TradeList.md
+++ b/docs/context/ref/TradeList.md
@@ -6,7 +6,7 @@ sidebar_label: TradeList
 
 # TradeList
 
-[@experiemental](/docs/fdc3-compliance#experimental-features) A list of trades. Use this type for use cases that require not just a single trade, but multiple.
+[@experimental](/docs/fdc3-compliance#experimental-features) A list of trades. Use this type for use cases that require not just a single trade, but multiple.
 
 The TradeList schema does not explicitly include identifiers in the id section, as there is not a common standard for such identifiers. Applications can, however, populate this part of the contract with custom identifiers if so desired.
 

--- a/schemas/context/instrument.schema.json
+++ b/schemas/context/instrument.schema.json
@@ -19,42 +19,42 @@
             "BBG": {
               "type": "string",
               "title": "Bloomberg security",
-              "description": "<https://www.bloomberg.com/>"
+              "description": "https://www.bloomberg.com/"
             },
             "CUSIP": {
               "type": "string",
               "title": "CUSIP",
-              "description": "<https://www.cusip.com/>"
+              "description": "https://www.cusip.com/"
             },
             "FDS_ID": {
               "type": "string",
               "title": "FactSet Permanent Security Identifier",
-              "description": "<https://www.factset.com/>"
+              "description": "https://www.factset.com/"
             },
             "FIGI": {
               "type": "string",
               "title": "Open FIGI",
-              "description": "<https://www.openfigi.com/>"
+              "description": "https://www.openfigi.com/"
             },
             "ISIN": {
               "type": "string",
               "title": "ISIN",
-              "description": "<https://www.isin.org/>"
+              "description": "https://www.isin.org/"
             },
             "PERMID": {
               "type": "string",
               "title": "Refinitiv PERMID",
-              "description": "<https://permid.org/>"
+              "description": "https://permid.org/"
             },
             "RIC": {
               "type": "string",
               "title": "Refinitiv Identification Code",
-              "description": " <https://www.refinitiv.com/>"
+              "description": "https://www.refinitiv.com/"
             },
             "SEDOL": {
               "type": "string",
               "title": "SEDOL",
-              "description": "<https://www.lseg.com/sedol>"
+              "description": "https://www.lseg.com/sedol"
             },
             "ticker": {
               "type": "string",
@@ -70,7 +70,7 @@
             "MIC": {
               "type": "string",
               "title": "Market Identifier Code",
-              "description": "<https://en.wikipedia.org/wiki/Market_Identifier_Code>"
+              "description": "https://en.wikipedia.org/wiki/Market_Identifier_Code"
             },
             "name": {
               "type": "string",
@@ -80,12 +80,12 @@
             "COUNTRY_ISOALPHA2": {
               "type": "string",
               "title": "Country ISO Code",
-              "description": "<https://www.iso.org/iso-3166-country-codes.html>"
+              "description": "https://www.iso.org/iso-3166-country-codes.html"
             },
             "BBG": {
               "type": "string",
               "title": "Bloomberg Market Identifier",
-              "description": "<https://www.bloomberg.com/>"
+              "description": "https://www.bloomberg.com/"
             }
           },
           "unevaluatedProperties": {

--- a/website/schema2Markdown.js
+++ b/website/schema2Markdown.js
@@ -62,7 +62,7 @@ function processProperty(propertyName, propertyDetails, required, currentSchemaF
     }
 
     if (propertyDetails.description != null) {
-        markdownContent += `${escape(propertyDetails.description)}\n\n`;
+        markdownContent += `${escapeExperimental(propertyDetails.description)}\n\n`;
     }
 
     if (propertyDetails.examples) {
@@ -160,7 +160,7 @@ function generateObjectMD(schema, objectName, schemaFolderName, filePath) {
     let markdownContent = `# ${title}\n\n`;
 
     if (schema.description != null) {
-        markdownContent += `${escape(schema.description)}\n\n`; 
+        markdownContent += `${escapeExperimental(schema.description)}\n\n`; 
     }
 
     //If the schema has a top level enum (e.g. API error schemas) then it needs rendering here.
@@ -228,8 +228,8 @@ function generateObjectMD(schema, objectName, schemaFolderName, filePath) {
     }
 }
 
-function escape(text) {
-    return text.replace(/>/g, '\\>').replace(/@experimental/g, '[@experiemental](/docs/fdc3-compliance#experimental-features)');
+function escapeExperimental(text) {
+    return text.replace(/@experimental/g, '[@experimental](/docs/fdc3-compliance#experimental-features)');
 }
 
 function generateFrontMatter(title, description) {


### PR DESCRIPTION
Links in generated content were being escaped incorrectly and picking up a trailing slash:
![image](https://github.com/user-attachments/assets/971cb069-e08e-4112-81e0-97c4840c3e2b)

A typo was also introduced by the escape function:
![image](https://github.com/user-attachments/assets/fa62cb2d-21ed-4bbe-993a-57b1ee110181)


This quick PR fixes both
