### PR TITLE
Small bug fix to stop 2.1 DAs being flagged when running the 2.0 version (as its the same)

### DIFF
--- a/toolbox/fdc3-workbench/src/components/Header.tsx
+++ b/toolbox/fdc3-workbench/src/components/Header.tsx
@@ -166,7 +166,7 @@ export const Header = (props: { fdc3Available: boolean }) => {
 								<tr>
 									<th scope="row">FDC3 Version</th>
 									{appInfo?.fdc3Version ? (
-										chosenVersion === appInfo.fdc3Version ? (
+										chosenVersion === appInfo.fdc3Version || chosenVersion === "2.0" && appInfo.fdc3Version == "2.1" ? (
 											<td>{appInfo.fdc3Version}</td>
 										) : (
 											<td className={classes.warningText}>

--- a/toolbox/fdc3-workbench/src/components/Header.tsx
+++ b/toolbox/fdc3-workbench/src/components/Header.tsx
@@ -166,7 +166,7 @@ export const Header = (props: { fdc3Available: boolean }) => {
 								<tr>
 									<th scope="row">FDC3 Version</th>
 									{appInfo?.fdc3Version ? (
-										chosenVersion === appInfo.fdc3Version || chosenVersion === "2.0" && appInfo.fdc3Version == "2.1" ? (
+										((chosenVersion === appInfo.fdc3Version) || (chosenVersion === "2.0" && appInfo.fdc3Version === "2.1")) ? (
 											<td>{appInfo.fdc3Version}</td>
 										) : (
 											<td className={classes.warningText}>


### PR DESCRIPTION
At present DAs that report version 2.1 are flagged as mismatch on version in the fdc3-workbench, when 2.0 and 2.1 API specs are the same - which is acknowledged in teh version selector already:

![image](https://github.com/user-attachments/assets/972ed56b-9374-4d7f-b64e-930b88e11d53)

After the fix:

![image](https://github.com/user-attachments/assets/cbaae323-dfab-42f3-89e8-4e63ab926299)

