### PR TITLE
update google analytics tracking id

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,8 +37,9 @@ module.exports={
         "theme": {
           "customCss": "./src/css/customTheme.css"
         },
-        "googleAnalytics": {
-          "trackingID": "UA-89349362-8"
+        "gtag": {
+          "trackingID": "G-EY9BQJ55YQ",
+          "anonymizeIP": true,
         }
       }
     ]


### PR DESCRIPTION
FINOS marketing would like to update the Google Analytics tracking ID to use gtag. 