### PR TITLE
Add missing id/name fields to context schema docs

### DIFF
--- a/docs/api/ref/DesktopAgent.md
+++ b/docs/api/ref/DesktopAgent.md
@@ -14,7 +14,7 @@ An FDC3 Desktop Agent is a desktop component (or aggregate of components) that s
 
 A Desktop Agent can be connected to one or more App Directories and will use directories for application identity and discovery. Typically, a Desktop Agent will contain the proprietary logic of a given platform, handling functionality like explicit application interop workflows where security, consistency, and implementation requirements are proprietary.
 
-For details of how implementations of the `DesktopAgent` are made available to applications please see [Supported Platforms](supported-platforms).
+For details of how implementations of the `DesktopAgent` are made available to applications please see [Supported Platforms](../supported-platforms).
 
 <Tabs groupId="lang">
 <TabItem value="ts" label="TypeScript/JavaScript">

--- a/docs/api/spec.md
+++ b/docs/api/spec.md
@@ -57,7 +57,7 @@ FDC3 and the Desktop Agent API it defines are intended to be independent of part
 
 Specifically, the use of ['unions'](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types) of primitive values in API type and metadata objects, or function parameters SHOULD be avoided as they often cannot be replicated in other languages. Unions of more complex types (such as specific [Context](../context/spec#the-context-interface) Types) may be used where a suitable interface is available or can be created to allow the required polymorphism in languages other than TypeScript.
 
-For implementation details relating to particular languages, and how to access the API in those languages, please see [Supported Platforms](supported-platforms).
+For implementation details relating to particular languages, and how to access the API in those languages, please see [Supported Platforms](./supported-platforms).
 
 ### Standards vs. Implementation
 
@@ -90,8 +90,8 @@ There is currently no method of discovering all the apps supported by a Desktop 
 
 An FDC3 Standard compliant Desktop Agent implementation **MUST**:
 
-- Provide the FDC3 API to web applications via a global accessible as [`window.fdc3`](support-platforms#web).
-- Provide a global [`fdc3Ready`](support-platforms#web) event to web applications that is fired when the API is ready for use.
+- Provide the FDC3 API to web applications via a global accessible as [`window.fdc3`](./supported-platforms#web).
+- Provide a global [`fdc3Ready`](./supported-platforms#web) event to web applications that is fired when the API is ready for use.
 - Provide a method of resolving ambiguous intents (i.e. those that might be resolved by multiple applications) or unspecified intents (calls to `raiseIntentForContext` that return multiple options), such as a resolver UI.
   - Intent resolution MUST take into account any specified input or return context types
   - Requests for resolution to apps returning a channel MUST include any apps that are registered as returning a channel with a specific type.

--- a/docs/api/supported-platforms.md
+++ b/docs/api/supported-platforms.md
@@ -29,7 +29,7 @@ if (window.fdc3) {
 }
 ```
 
-Since FDC3 is typically available to the whole web application, Desktop Agents are expected to make the [`DesktopAgent`](DesktopAgent) interface available at a global level.
+Since FDC3 is typically available to the whole web application, Desktop Agents are expected to make the [`DesktopAgent`](ref/DesktopAgent) interface available at a global level.
 
 The global `window.fdc3` should only be available after the API is ready to use. To prevent the API from being used before it is ready, implementors should provide an `fdc3Ready` event.
 
@@ -58,7 +58,7 @@ if (window.fdc3) {
 
 #### 2. NPM Wrapper
 
-FDC3 offers the [`@finos/fdc3` npm package](https://www.npmjs.com/package/@finos/fdc3) that can be used by web applications to target operations from the [API Specification](api/spec) in a consistent way. Each FDC3-compliant desktop agent that the application runs in, can then provide an implementation of the FDC3 API operations.
+FDC3 offers the [`@finos/fdc3` npm package](https://www.npmjs.com/package/@finos/fdc3) that can be used by web applications to target operations from the [API Specification](./spec) in a consistent way. Each FDC3-compliant desktop agent that the application runs in, can then provide an implementation of the FDC3 API operations.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -118,7 +118,7 @@ For a .NET application to be FDC3-enabled, it needs to run in the context of a p
 
 #### Usage
 
-FDC3 offers the [`Finos.Fdc3` NuGet package](https://www.nuget.org/packages/Finos.Fdc3) that can be used by .NET applications to target operations from the [API Specification](api/spec) in a consistent way. Each FDC3-compliant desktop agent that the application runs in, can then provide an implementation of the FDC3 API operations.
+FDC3 offers the [`Finos.Fdc3` NuGet package](https://www.nuget.org/packages/Finos.Fdc3) that can be used by .NET applications to target operations from the [API Specification](./spec) in a consistent way. Each FDC3-compliant desktop agent that the application runs in, can then provide an implementation of the FDC3 API operations.
 
 
 ## Hybrid

--- a/docs/context/ref/Action.md
+++ b/docs/context/ref/Action.md
@@ -45,6 +45,7 @@ Optional Intent to raise to perform the actions. Should reference an intent type
 
 **type**: [Context](/docs/next/context/spec#the-context-interface)
 
+
 A context object with which the action will be performed
 
 </details>

--- a/docs/context/ref/Chart.md
+++ b/docs/context/ref/Chart.md
@@ -79,6 +79,7 @@ The type of chart that should be plotted
 
 **type**: [Context](/docs/next/context/spec#the-context-interface)
 
+
 </details>
 
 It is common for charts to support other configuration, such as indicators, annotations etc., which do not have standardized formats, but may be included in the `otherConfig` array as context objects.

--- a/docs/context/ref/ChatInitSettings.md
+++ b/docs/context/ref/ChatInitSettings.md
@@ -41,12 +41,8 @@ Contacts to add to the chat
 
 **One of:**
 
-**type**: `string`
-
-
-**type**: [Message](Message)
-
-
+- **type**: `string`
+- **type**: [Message](Message)
 
 An initial message to post in the chat when created.
 

--- a/docs/context/ref/ChatRoom.md
+++ b/docs/context/ref/ChatRoom.md
@@ -32,6 +32,13 @@ The name of the service that hosts the chat
 
 **type**: `object`
 
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
 Identifier(s) for the chat - currently unstandardized
 
 </details>

--- a/docs/context/ref/ChatSearchCriteria.md
+++ b/docs/context/ref/ChatSearchCriteria.md
@@ -26,18 +26,17 @@ A context type that represents a simple search criterion, based on a list of oth
 <details>
   <summary><code>Items</code></summary>
 
-**Any of:**
+  <summary><code>Search Criteria</code></summary>
 
-**type**: [Instrument](Instrument)
+**One of:**
 
+- **type**: [Instrument](Instrument)
+- **type**: [Organization](Organization)
+- **type**: [Contact](Contact)
+- **type**: `string`
 
-**type**: [Organization](Organization)
+An individual criteria against which to match chat messages, based on an FDC3 context or free-text string.
 
-
-**type**: [Contact](Contact)
-
-
-**type**: `string`
 
 
 

--- a/docs/context/ref/Contact.md
+++ b/docs/context/ref/Contact.md
@@ -47,6 +47,15 @@ Identifiers that relate to the Contact represented by this context
 
 </details>
 
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the contact
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/ContactList.md
+++ b/docs/context/ref/ContactList.md
@@ -21,6 +21,31 @@ The contact list schema does not explicitly include identifiers in the `id` sect
 ## Properties
 
 <details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the contact list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable summary of the contact list
+
+</details>
+
+<details>
   <summary><code>contacts</code> <strong>(required)</strong></summary>
 
 **type**: `array`

--- a/docs/context/ref/Country.md
+++ b/docs/context/ref/Country.md
@@ -71,6 +71,15 @@ Three-letter ISO country code. Deprecated in FDC3 2.0 in favour of the version p
 
 </details>
 
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the country
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/Email.md
+++ b/docs/context/ref/Email.md
@@ -23,12 +23,8 @@ A collection of information to be used to initiate an email with a Contact or Co
 
 **One of:**
 
-**type**: [Contact](Contact)
-
-
-**type**: [ContactList](ContactList)
-
-
+- **type**: [Contact](Contact)
+- **type**: [ContactList](ContactList)
 
 One or more recipients for the email.
 

--- a/docs/context/ref/Instrument.md
+++ b/docs/context/ref/Instrument.md
@@ -116,6 +116,15 @@ If the identifier you want to share is not a ticker or one of the other standard
 </details>
 
 <details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the instrument
+
+</details>
+
+<details>
   <summary><code>market</code></summary>
 
 **type**: `object`

--- a/docs/context/ref/InstrumentList.md
+++ b/docs/context/ref/InstrumentList.md
@@ -21,6 +21,31 @@ The instrument list schema does not explicitly include identifiers in the `id` s
 ## Properties
 
 <details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the instrument list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable summary of the instrument list
+
+</details>
+
+<details>
   <summary><code>instruments</code> <strong>(required)</strong></summary>
 
 **type**: `array`

--- a/docs/context/ref/Interaction.md
+++ b/docs/context/ref/Interaction.md
@@ -79,16 +79,12 @@ The time range over which the interaction occurred
 
 **One of:**
 
-**type**: `string` with values:
+- **type**: `string` with values:
 - `Instant Message`,
 - `Email`,
 - `Call`,
 - `Meeting`
-
-
-**type**: `string`
-
-
+- **type**: `string`
 
 `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or `'Meeting'` although other string values are permitted.
 

--- a/docs/context/ref/Message.md
+++ b/docs/context/ref/Message.md
@@ -57,12 +57,8 @@ A map of string mime-type to string content
 
 **Any of:**
 
-**type**: [Action](Action)
-
-
-**type**: `object`
-
-
+- **type**: [Action](Action)
+- **type**: `object`
 
 </details>
 

--- a/docs/context/ref/OrderList.md
+++ b/docs/context/ref/OrderList.md
@@ -21,6 +21,31 @@ The OrderList schema does not explicitly include identifiers in the id section, 
 ## Properties
 
 <details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the order list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable summary of the order list
+
+</details>
+
+<details>
   <summary><code>orders</code> <strong>(required)</strong></summary>
 
 **type**: `array`

--- a/docs/context/ref/Organization.md
+++ b/docs/context/ref/Organization.md
@@ -58,6 +58,15 @@ Identifiers for the organization, at least one must be provided.
 
 </details>
 
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name of the organization
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/Portfolio.md
+++ b/docs/context/ref/Portfolio.md
@@ -40,6 +40,31 @@ The List of Positions which make up the Portfolio
 
 </details>
 
+<details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the portfolio in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the portfolio
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/Position.md
+++ b/docs/context/ref/Position.md
@@ -42,6 +42,31 @@ The amount of the holding, e.g. a number of shares
 
 </details>
 
+<details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the position in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the position
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/Product.md
+++ b/docs/context/ref/Product.md
@@ -52,7 +52,7 @@ A human-readable summary of the product.
 
 **type**: [Instrument](Instrument)
 
- financial instrument that relates to the definition of this product
+A financial instrument that relates to the definition of this product
 
 </details>
 

--- a/docs/context/ref/TradeList.md
+++ b/docs/context/ref/TradeList.md
@@ -36,6 +36,31 @@ An array of trade contexts that forms the list.
 
 </details>
 
+<details>
+  <summary><code>id</code></summary>
+
+**type**: `object`
+
+<details>
+  <summary><code>Additional Properties</code></summary>
+
+**type**: `string`
+
+</details>
+
+One or more identifiers that refer to the trade list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.
+
+</details>
+
+<details>
+  <summary><code>name</code></summary>
+
+**type**: `string`
+
+An optional human-readable name for the trade list
+
+</details>
+
 ## Example
 
 ```json

--- a/docs/context/ref/TransactionResult.md
+++ b/docs/context/ref/TransactionResult.md
@@ -36,6 +36,7 @@ The status of the transaction being reported.
 
 **type**: [Context](/docs/next/context/spec#the-context-interface)
 
+
 A context object returned by the transaction, possibly with updated data.
 
 </details>

--- a/docs/fdc3-intro.md
+++ b/docs/fdc3-intro.md
@@ -44,7 +44,7 @@ FDC3 is hosted within, and governed by the policies of, the [Fintech Open Source
 
 ## Where should I go next?
 
-- Have a look at the [supported platforms](supported-platforms) or [common use cases](use-cases/overview).
+- Have a look at the [API's supported platforms](api/supported-platforms) or [common use cases](use-cases/overview).
 - Visit FDC3 [on GitHub](https://github.com/finos/FDC3).
 - Download and install our [npm package](https://www.npmjs.com/package/@finos/fdc3).
 - Try out an FDC3-compliant implementation, e.g. this [browser extension](https://github.com/finos/fdc3-desktop-agent).

--- a/docs/fdc3-standard.md
+++ b/docs/fdc3-standard.md
@@ -33,7 +33,6 @@ For more details on FDC3's versioning, deprecation and experimental features pol
 - [Compliance information](fdc3-compliance)
 - [Glossary](fdc3-glossary)
 - [References](references)
-- [Supported Platforms](supported-platforms)
 - [API Part](api/spec)
 - [Intents Part](intents/spec)
 - [Context Data Part](context/spec)

--- a/schemas/context/chatRoom.schema.json
+++ b/schemas/context/chatRoom.schema.json
@@ -16,7 +16,10 @@
       "id": { 
         "title": "Chat room id",
         "description": "Identifier(s) for the chat - currently unstandardized",
-        "type": "object"
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "url": { 
         "title": "Chat URL",

--- a/schemas/context/chatSearchCriteria.schema.json
+++ b/schemas/context/chatSearchCriteria.schema.json
@@ -12,26 +12,11 @@
           "const": "fdc3.chat.searchCriteria"
         },
         "criteria": {
-          "title": "Criteria array",
+          "title": "Search Criteria array",
           "description": "An array of criteria that should match chats returned from by a search.\n\n⚠️ Operators (and/or/not) are not defined in `fdc3.chat.searchCriteria`. It is up to the application that processes the FDC3 Intent to choose and apply the operators between the criteria.\n\nEmpty search criteria can be supported to allow resetting of filters.",
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "instrument.schema.json#"
-              },
-              {
-                "$ref": "organization.schema.json#"
-              },
-              {
-                "$ref": "contact.schema.json#"
-              },
-              {
-                "type": "string",
-                "title": "Free text",
-                "description": "Free text to be used for a keyword search"
-              }
-            ]
+            "$ref": "#/$defs/SearchCriteria"
           }
         }
       },
@@ -41,6 +26,28 @@
     },
     { "$ref": "context.schema.json#/definitions/BaseContext" }
   ],
+  "$defs": {
+    "SearchCriteria": {
+      "title": "Search Criteria",
+      "description": "An individual criteria against which to match chat messages, based on an FDC3 context or free-text string.",
+      "oneOf": [
+        {
+          "$ref": "instrument.schema.json#"
+        },
+        {
+          "$ref": "organization.schema.json#"
+        },
+        {
+          "$ref": "contact.schema.json#"
+        },
+        {
+          "type": "string",
+          "title": "Free text",
+          "description": "Free text to be used for a keyword search"
+        }
+      ]
+    }
+  },
   "examples": [
     {
       "type": "fdc3.chat.searchCriteria",

--- a/schemas/context/contact.schema.json
+++ b/schemas/context/contact.schema.json
@@ -28,6 +28,11 @@
               "description": "FactSet Permanent Identifier representing the contact"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the contact"
         }
       },
       "required": [

--- a/schemas/context/contactList.schema.json
+++ b/schemas/context/contactList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.contactList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Contact List Identifiers",
+          "description": "One or more identifiers that refer to the contact list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the contact list"
+        },
         "contacts": {
           "type": "array",
           "title": "List of Contacts",

--- a/schemas/context/country.schema.json
+++ b/schemas/context/country.schema.json
@@ -37,6 +37,11 @@
               "deprecated": true
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the country"
         }
       },
       "required": [

--- a/schemas/context/instrument.schema.json
+++ b/schemas/context/instrument.schema.json
@@ -63,6 +63,11 @@
             }
           }
         },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the instrument"
+        },
         "market": {
           "description": "The `market` map can be used to further specify the instrument and help achieve interoperability between disparate data sources. This is especially useful when using an `id` field that is not globally unique.",
           "type": "object",

--- a/schemas/context/instrumentList.schema.json
+++ b/schemas/context/instrumentList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.instrumentList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Instrument List Identifiers",
+          "description": "One or more identifiers that refer to the instrument list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the instrument list"
+        },
         "instruments": {
           "type": "array",
           "title": "List of instruments",

--- a/schemas/context/orderList.schema.json
+++ b/schemas/context/orderList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.orderList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Order List Identifiers",
+          "description": "One or more identifiers that refer to the order list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the order list"
+        },
         "orders": {
           "type": "array",
           "items": {

--- a/schemas/context/organization.schema.json
+++ b/schemas/context/organization.schema.json
@@ -33,6 +33,11 @@
               "description": "FactSet Permanent Identifier representing the organization"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name of the organization"
         }
       },
       "required": [

--- a/schemas/context/portfolio.schema.json
+++ b/schemas/context/portfolio.schema.json
@@ -18,6 +18,19 @@
           },
           "title": "Portfolio positions",
           "description": "The List of Positions which make up the Portfolio"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Portfolio Identifiers",
+          "description": "One or more identifiers that refer to the portfolio in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the portfolio"
         }
       },
       "required": [

--- a/schemas/context/position.schema.json
+++ b/schemas/context/position.schema.json
@@ -20,6 +20,19 @@
           "type": "number",
           "title": "The size of the holding represented by this position",
           "description": "The amount of the holding, e.g. a number of shares"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Position Identifiers",
+          "description": "One or more identifiers that refer to the position in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the position"
         }
       },
       "required": [

--- a/schemas/context/product.schema.json
+++ b/schemas/context/product.schema.json
@@ -27,7 +27,7 @@
 				"instrument": {
 					"$ref": "instrument.schema.json",
 					"title": "Product Instrument",
-					"description": " financial instrument that relates to the definition of this product"
+					"description": "A financial instrument that relates to the definition of this product"
 				}
 			},
 			"required": [

--- a/schemas/context/tradeList.schema.json
+++ b/schemas/context/tradeList.schema.json
@@ -12,12 +12,25 @@
           "const": "fdc3.tradeList"
         },
         "trades": {
+          "title": "List of Trades",
+          "description": "An array of trade contexts that forms the list.",
           "type": "array",
           "items": {
             "$ref": "trade.schema.json#"
-          },
-          "title": "List of Trades",
-          "description": "An array of trade contexts that forms the list."
+          }
+        },
+        "id": {
+          "title": "Trade List Identifiers",
+          "description": "One or more identifiers that refer to the trade list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the trade list"
         }
       },
       "required": [

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -235,9 +235,12 @@ export interface InstrumentElement {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: OrganizationMarket;
-    type:    "fdc3.instrument";
-    name?:   string;
+    market?: SearchCriteriaMarket;
+    /**
+     * An optional human-readable name for the instrument
+     */
+    name?: string;
+    type:  "fdc3.instrument";
     [property: string]: any;
 }
 
@@ -301,7 +304,7 @@ export interface PurpleInstrumentIdentifiers {
  * interoperability between disparate data sources. This is especially useful when using an
  * `id` field that is not globally unique.
  */
-export interface OrganizationMarket {
+export interface SearchCriteriaMarket {
     /**
      * https://www.bloomberg.com/
      */
@@ -442,9 +445,16 @@ export interface ContactListObject {
      * An array of contact contexts that forms the list.
      */
     contacts: ContactElement[];
-    type:     "fdc3.contactList";
-    id?:      { [key: string]: any };
-    name?:    string;
+    /**
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the contact list
+     */
+    name?: string;
+    type:  "fdc3.contactList";
     [property: string]: any;
 }
 
@@ -457,9 +467,12 @@ export interface ContactElement {
     /**
      * Identifiers that relate to the Contact represented by this context
      */
-    id:    PurpleContactIdentifiers;
-    type:  "fdc3.contact";
+    id: PurpleContactIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     */
     name?: string;
+    type:  "fdc3.contact";
     [property: string]: any;
 }
 
@@ -721,7 +734,7 @@ export interface ChatSearchCriteria {
      *
      * Empty search criteria can be supported to allow resetting of filters.
      */
-    criteria: Array<OrganizationObject | string>;
+    criteria: SearchCriteria[];
     type:     "fdc3.chat.searchCriteria";
     id?:      { [key: string]: any };
     name?:    string;
@@ -729,23 +742,26 @@ export interface ChatSearchCriteria {
 }
 
 /**
+ * An individual criteria against which to match chat messages, based on an FDC3 context or
+ * free-text string.
+ *
  * financial instrument that relates to the definition of this product
  *
  *
  *
  * A financial instrument from any asset class.
  *
+ * The contact that initiated the interaction
+ *
+ * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
+ *
  * An entity that can be used when referencing private companies and other organizations
  * where a specific instrument is not available or desired e.g. CRM and News workflows.
  *
  * It is valid to include extra properties and metadata as part of the organization payload,
  * but the minimum requirement is for at least one specified identifier to be provided.
- *
- * The contact that initiated the interaction
- *
- * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface OrganizationObject {
+export interface SearchCriteria {
     /**
      * Any combination of instrument identifiers can be used together to resolve ambiguity, or
      * for a better match. Not all applications will use the same instrument identifiers, which
@@ -761,9 +777,9 @@ export interface OrganizationObject {
      * fields, define a property that makes it clear what the value represents. Doing so will
      * make interpretation easier for the developers of target applications.
      *
-     * Identifiers for the organization, at least one must be provided.
-     *
      * Identifiers that relate to the Contact represented by this context
+     *
+     * Identifiers for the organization, at least one must be provided.
      */
     id: Identifiers;
     /**
@@ -771,9 +787,16 @@ export interface OrganizationObject {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: OrganizationMarket;
-    type:    TentacledInteractionType;
-    name?:   string;
+    market?: SearchCriteriaMarket;
+    /**
+     * An optional human-readable name for the instrument
+     *
+     * An optional human-readable name for the contact
+     *
+     * An optional human-readable name of the organization
+     */
+    name?: string;
+    type:  SearchCriteriaType;
     [property: string]: any;
 }
 
@@ -792,9 +815,9 @@ export interface OrganizationObject {
  * fields, define a property that makes it clear what the value represents. Doing so will
  * make interpretation easier for the developers of target applications.
  *
- * Identifiers for the organization, at least one must be provided.
- *
  * Identifiers that relate to the Contact represented by this context
+ *
+ * Identifiers for the organization, at least one must be provided.
  */
 export interface Identifiers {
     /**
@@ -808,9 +831,9 @@ export interface Identifiers {
     /**
      * https://www.factset.com/
      *
-     * FactSet Permanent Identifier representing the organization
-     *
      * FactSet Permanent Identifier representing the contact
+     *
+     * FactSet Permanent Identifier representing the organization
      */
     FDS_ID?: string;
     /**
@@ -840,16 +863,16 @@ export interface Identifiers {
      */
     ticker?: string;
     /**
+     * The email address for the contact
+     */
+    email?: string;
+    /**
      * The Legal Entity Identifier (LEI) is a 20-character, alpha-numeric code based on the ISO
      * 17442 standard developed by the International Organization for Standardization (ISO). It
      * connects to key reference information that enables clear and unique identification of
      * legal entities participating in financial transactions.
      */
     LEI?: string;
-    /**
-     * The email address for the contact
-     */
-    email?: string;
     [property: string]: any;
 }
 
@@ -859,7 +882,7 @@ export interface Identifiers {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export type TentacledInteractionType = "fdc3.instrument" | "fdc3.organization" | "fdc3.contact";
+export type SearchCriteriaType = "fdc3.instrument" | "fdc3.contact" | "fdc3.organization";
 
 /**
  * Free text to be used for a keyword search
@@ -875,9 +898,12 @@ export interface Contact {
     /**
      * Identifiers that relate to the Contact represented by this context
      */
-    id:    FluffyContactIdentifiers;
-    type:  "fdc3.contact";
+    id: FluffyContactIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     */
     name?: string;
+    type:  "fdc3.contact";
     [property: string]: any;
 }
 
@@ -908,9 +934,16 @@ export interface ContactList {
      * An array of contact contexts that forms the list.
      */
     contacts: ContactElement[];
-    type:     "fdc3.contactList";
-    id?:      { [key: string]: any };
-    name?:    string;
+    /**
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the contact list
+     */
+    name?: string;
+    type:  "fdc3.contactList";
     [property: string]: any;
 }
 
@@ -986,9 +1019,12 @@ export interface Context {
  * applications.
  */
 export interface Country {
-    id:    CountryID;
-    type:  "fdc3.country";
+    id: CountryID;
+    /**
+     * An optional human-readable name for the country
+     */
     name?: string;
+    type:  "fdc3.country";
     [property: string]: any;
 }
 
@@ -1092,10 +1128,18 @@ export interface Email {
 export interface EmailRecipients {
     /**
      * Identifiers that relate to the Contact represented by this context
+     *
+     * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
      */
-    id?:   EmailRecipientsID;
-    type:  EmailRecipientsType;
+    id?: ContactTIdentifiers;
+    /**
+     * An optional human-readable name for the contact
+     *
+     * An optional human-readable summary of the contact list
+     */
     name?: string;
+    type:  EmailRecipientsType;
     /**
      * An array of contact contexts that forms the list.
      */
@@ -1105,8 +1149,11 @@ export interface EmailRecipients {
 
 /**
  * Identifiers that relate to the Contact represented by this context
+ *
+ * One or more identifiers that refer to the contact list in an OMS, EMS or related system.
+ * Specific key names for systems are expected to be standardized in future.
  */
-export interface EmailRecipientsID {
+export interface ContactTIdentifiers {
     /**
      * The email address for the contact
      */
@@ -1159,8 +1206,11 @@ export interface Instrument {
      * `id` field that is not globally unique.
      */
     market?: PurpleMarket;
-    type:    "fdc3.instrument";
-    name?:   string;
+    /**
+     * An optional human-readable name for the instrument
+     */
+    name?: string;
+    type:  "fdc3.instrument";
     [property: string]: any;
 }
 
@@ -1256,12 +1306,19 @@ export interface PurpleMarket {
  */
 export interface InstrumentList {
     /**
+     * One or more identifiers that refer to the instrument list in an OMS, EMS or related
+     * system. Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
      * An array of instrument contexts that forms the list.
      */
     instruments: InstrumentElement[];
-    type:        "fdc3.instrumentList";
-    id?:         { [key: string]: any };
-    name?:       string;
+    /**
+     * An optional human-readable summary of the instrument list
+     */
+    name?: string;
+    type:  "fdc3.instrumentList";
     [property: string]: any;
 }
 
@@ -1561,12 +1618,19 @@ export interface ProductObject {
  */
 export interface OrderList {
     /**
+     * One or more identifiers that refer to the order list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable summary of the order list
+     */
+    name?: string;
+    /**
      * An array of order contexts that forms the list.
      */
     orders: OrderElement[];
     type:   "fdc3.orderList";
-    id?:    { [key: string]: any };
-    name?:  string;
     [property: string]: any;
 }
 
@@ -1627,9 +1691,12 @@ export interface Organization {
     /**
      * Identifiers for the organization, at least one must be provided.
      */
-    id:    OrganizationIdentifiers;
-    type:  "fdc3.organization";
+    id: OrganizationIdentifiers;
+    /**
+     * An optional human-readable name of the organization
+     */
     name?: string;
+    type:  "fdc3.organization";
     [property: string]: any;
 }
 
@@ -1679,12 +1746,19 @@ export interface OrganizationIdentifiers {
  */
 export interface Portfolio {
     /**
+     * One or more identifiers that refer to the portfolio in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable name for the portfolio
+     */
+    name?: string;
+    /**
      * The List of Positions which make up the Portfolio
      */
     positions: PositionElement[];
     type:      "fdc3.portfolio";
-    id?:       { [key: string]: any };
-    name?:     string;
     [property: string]: any;
 }
 
@@ -1706,11 +1780,18 @@ export interface PositionElement {
     /**
      * The amount of the holding, e.g. a number of shares
      */
-    holding:    number;
+    holding: number;
+    /**
+     * One or more identifiers that refer to the position in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?:        { [key: string]: string };
     instrument: InstrumentElement;
-    type:       "fdc3.position";
-    id?:        { [key: string]: any };
-    name?:      string;
+    /**
+     * An optional human-readable name for the position
+     */
+    name?: string;
+    type:  "fdc3.position";
     [property: string]: any;
 }
 
@@ -1746,11 +1827,18 @@ export interface Position {
     /**
      * The amount of the holding, e.g. a number of shares
      */
-    holding:    number;
+    holding: number;
+    /**
+     * One or more identifiers that refer to the position in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?:        { [key: string]: string };
     instrument: InstrumentElement;
-    type:       "fdc3.position";
-    id?:        { [key: string]: any };
-    name?:      string;
+    /**
+     * An optional human-readable name for the position
+     */
+    name?: string;
+    type:  "fdc3.position";
     [property: string]: any;
 }
 
@@ -1880,12 +1968,19 @@ export interface Trade {
  */
 export interface TradeList {
     /**
+     * One or more identifiers that refer to the trade list in an OMS, EMS or related system.
+     * Specific key names for systems are expected to be standardized in future.
+     */
+    id?: { [key: string]: string };
+    /**
+     * An optional human-readable name for the trade list
+     */
+    name?: string;
+    /**
      * An array of trade contexts that forms the list.
      */
     trades: TradeElement[];
     type:   "fdc3.tradeList";
-    id?:    { [key: string]: any };
-    name?:  string;
     [property: string]: any;
 }
 
@@ -2415,9 +2510,9 @@ const typeMap: any = {
     ], "any"),
     "InstrumentElement": o([
         { json: "id", js: "id", typ: r("PurpleInstrumentIdentifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
-        { json: "type", js: "type", typ: r("PurpleInteractionType") },
+        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentType") },
     ], "any"),
     "PurpleInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2430,7 +2525,7 @@ const typeMap: any = {
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
     ], "any"),
-    "OrganizationMarket": o([
+    "SearchCriteriaMarket": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
         { json: "COUNTRY_ISOALPHA2", js: "COUNTRY_ISOALPHA2", typ: u(undefined, "") },
         { json: "MIC", js: "MIC", typ: u(undefined, "") },
@@ -2454,14 +2549,14 @@ const typeMap: any = {
     ], "any"),
     "ContactListObject": o([
         { json: "contacts", js: "contacts", typ: a(r("ContactElement")) },
-        { json: "type", js: "type", typ: r("ContactListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactListType") },
     ], "any"),
     "ContactElement": o([
         { json: "id", js: "id", typ: r("PurpleContactIdentifiers") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactType") },
     ], "any"),
     "PurpleContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2521,16 +2616,16 @@ const typeMap: any = {
         { json: "url", js: "url", typ: u(undefined, "") },
     ], "any"),
     "ChatSearchCriteria": o([
-        { json: "criteria", js: "criteria", typ: a(u(r("OrganizationObject"), "")) },
+        { json: "criteria", js: "criteria", typ: a(r("SearchCriteria")) },
         { json: "type", js: "type", typ: r("ChatSearchCriteriaType") },
         { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
-    "OrganizationObject": o([
+    "SearchCriteria": o([
         { json: "id", js: "id", typ: r("Identifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
-        { json: "type", js: "type", typ: r("TentacledInteractionType") },
+        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("SearchCriteriaType") },
     ], "any"),
     "Identifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2542,13 +2637,13 @@ const typeMap: any = {
         { json: "RIC", js: "RIC", typ: u(undefined, "") },
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
-        { json: "LEI", js: "LEI", typ: u(undefined, "") },
         { json: "email", js: "email", typ: u(undefined, "") },
+        { json: "LEI", js: "LEI", typ: u(undefined, "") },
     ], "any"),
     "Contact": o([
         { json: "id", js: "id", typ: r("FluffyContactIdentifiers") },
-        { json: "type", js: "type", typ: r("FluffyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactType") },
     ], "any"),
     "FluffyContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2556,9 +2651,9 @@ const typeMap: any = {
     ], "any"),
     "ContactList": o([
         { json: "contacts", js: "contacts", typ: a(r("ContactElement")) },
-        { json: "type", js: "type", typ: r("ContactListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("ContactListType") },
     ], "any"),
     "Context": o([
         { json: "id", js: "id", typ: u(undefined, m("any")) },
@@ -2567,8 +2662,8 @@ const typeMap: any = {
     ], "any"),
     "Country": o([
         { json: "id", js: "id", typ: r("CountryID") },
-        { json: "type", js: "type", typ: r("CountryType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("CountryType") },
     ], "any"),
     "CountryID": o([
         { json: "COUNTRY_ISOALPHA2", js: "COUNTRY_ISOALPHA2", typ: u(undefined, "") },
@@ -2593,20 +2688,20 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "EmailRecipients": o([
-        { json: "id", js: "id", typ: u(undefined, r("EmailRecipientsID")) },
-        { json: "type", js: "type", typ: r("EmailRecipientsType") },
+        { json: "id", js: "id", typ: u(undefined, r("ContactTIdentifiers")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("EmailRecipientsType") },
         { json: "contacts", js: "contacts", typ: u(undefined, a(r("ContactElement"))) },
     ], "any"),
-    "EmailRecipientsID": o([
+    "ContactTIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
     ], "any"),
     "Instrument": o([
         { json: "id", js: "id", typ: r("FluffyInstrumentIdentifiers") },
         { json: "market", js: "market", typ: u(undefined, r("PurpleMarket")) },
-        { json: "type", js: "type", typ: r("PurpleInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentType") },
     ], "any"),
     "FluffyInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2626,10 +2721,10 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "InstrumentList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instruments", js: "instruments", typ: a(r("InstrumentElement")) },
-        { json: "type", js: "type", typ: r("InstrumentListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("InstrumentListType") },
     ], "any"),
     "Interaction": o([
         { json: "description", js: "description", typ: "" },
@@ -2693,10 +2788,10 @@ const typeMap: any = {
         { json: "type", js: "type", typ: r("ProductType") },
     ], "any"),
     "OrderList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "orders", js: "orders", typ: a(r("OrderElement")) },
         { json: "type", js: "type", typ: r("OrderListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "OrderElement": o([
         { json: "details", js: "details", typ: u(undefined, r("FluffyOrderDetails")) },
@@ -2709,8 +2804,8 @@ const typeMap: any = {
     ], "any"),
     "Organization": o([
         { json: "id", js: "id", typ: r("OrganizationIdentifiers") },
-        { json: "type", js: "type", typ: r("StickyInteractionType") },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("OrganizationType") },
     ], "any"),
     "OrganizationIdentifiers": o([
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
@@ -2718,24 +2813,24 @@ const typeMap: any = {
         { json: "PERMID", js: "PERMID", typ: u(undefined, "") },
     ], "any"),
     "Portfolio": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "positions", js: "positions", typ: a(r("PositionElement")) },
         { json: "type", js: "type", typ: r("PortfolioType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "PositionElement": o([
         { json: "holding", js: "holding", typ: 3.14 },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instrument", js: "instrument", typ: r("InstrumentElement") },
-        { json: "type", js: "type", typ: r("PositionType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("PositionType") },
     ], "any"),
     "Position": o([
         { json: "holding", js: "holding", typ: 3.14 },
+        { json: "id", js: "id", typ: u(undefined, m("")) },
         { json: "instrument", js: "instrument", typ: r("InstrumentElement") },
-        { json: "type", js: "type", typ: r("PositionType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: r("PositionType") },
     ], "any"),
     "Product": o([
         { json: "id", js: "id", typ: m("") },
@@ -2757,10 +2852,10 @@ const typeMap: any = {
         { json: "type", js: "type", typ: r("TradeType") },
     ], "any"),
     "TradeList": o([
+        { json: "id", js: "id", typ: u(undefined, m("")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
         { json: "trades", js: "trades", typ: a(r("TradeElement")) },
         { json: "type", js: "type", typ: r("TradeListType") },
-        { json: "id", js: "id", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "TradeElement": o([
         { json: "id", js: "id", typ: m("") },
@@ -2789,7 +2884,7 @@ const typeMap: any = {
     "ActionType": [
         "fdc3.action",
     ],
-    "PurpleInteractionType": [
+    "InstrumentType": [
         "fdc3.instrument",
     ],
     "TimeRangeType": [
@@ -2810,7 +2905,7 @@ const typeMap: any = {
     "ChartType": [
         "fdc3.chart",
     ],
-    "FluffyInteractionType": [
+    "ContactType": [
         "fdc3.contact",
     ],
     "ContactListType": [
@@ -2832,7 +2927,7 @@ const typeMap: any = {
     "ChatMessageType": [
         "fdc3.chat.message",
     ],
-    "TentacledInteractionType": [
+    "SearchCriteriaType": [
         "fdc3.contact",
         "fdc3.instrument",
         "fdc3.organization",
@@ -2871,7 +2966,7 @@ const typeMap: any = {
     "OrderListType": [
         "fdc3.orderList",
     ],
-    "StickyInteractionType": [
+    "OrganizationType": [
         "fdc3.organization",
     ],
     "PositionType": [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -144,7 +144,7 @@ module.exports={
             },
             {
               "label": "Supported Platforms",
-              "to": "docs/api/supported-platforms"
+              "to": "/docs/next/api/supported-platforms"
             },
             {
               "label": "API Reference",

--- a/website/static/schemas/next/context/chatRoom.schema.json
+++ b/website/static/schemas/next/context/chatRoom.schema.json
@@ -16,7 +16,10 @@
       "id": { 
         "title": "Chat room id",
         "description": "Identifier(s) for the chat - currently unstandardized",
-        "type": "object"
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
       },
       "url": { 
         "title": "Chat URL",

--- a/website/static/schemas/next/context/chatSearchCriteria.schema.json
+++ b/website/static/schemas/next/context/chatSearchCriteria.schema.json
@@ -12,26 +12,11 @@
           "const": "fdc3.chat.searchCriteria"
         },
         "criteria": {
-          "title": "Criteria array",
+          "title": "Search Criteria array",
           "description": "An array of criteria that should match chats returned from by a search.\n\n⚠️ Operators (and/or/not) are not defined in `fdc3.chat.searchCriteria`. It is up to the application that processes the FDC3 Intent to choose and apply the operators between the criteria.\n\nEmpty search criteria can be supported to allow resetting of filters.",
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "instrument.schema.json#"
-              },
-              {
-                "$ref": "organization.schema.json#"
-              },
-              {
-                "$ref": "contact.schema.json#"
-              },
-              {
-                "type": "string",
-                "title": "Free text",
-                "description": "Free text to be used for a keyword search"
-              }
-            ]
+            "$ref": "#/$defs/SearchCriteria"
           }
         }
       },
@@ -41,6 +26,29 @@
     },
     { "$ref": "context.schema.json#/definitions/BaseContext" }
   ],
+  "$defs": {
+    "SearchCriteria": {
+      "type": "object",
+      "title": "Search Criteria",
+      "description": "An individual criteria against which to match chat messages, based on an FDC3 context or free-text string.",
+      "oneOf": [
+        {
+          "$ref": "instrument.schema.json#"
+        },
+        {
+          "$ref": "organization.schema.json#"
+        },
+        {
+          "$ref": "contact.schema.json#"
+        },
+        {
+          "type": "string",
+          "title": "Free text",
+          "description": "Free text to be used for a keyword search"
+        }
+      ]
+    }
+  },
   "examples": [
     {
       "type": "fdc3.chat.searchCriteria",

--- a/website/static/schemas/next/context/contact.schema.json
+++ b/website/static/schemas/next/context/contact.schema.json
@@ -28,6 +28,11 @@
               "description": "FactSet Permanent Identifier representing the contact"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the contact"
         }
       },
       "required": [

--- a/website/static/schemas/next/context/contactList.schema.json
+++ b/website/static/schemas/next/context/contactList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.contactList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Contact List Identifiers",
+          "description": "One or more identifiers that refer to the contact list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the contact list"
+        },
         "contacts": {
           "type": "array",
           "title": "List of Contacts",

--- a/website/static/schemas/next/context/country.schema.json
+++ b/website/static/schemas/next/context/country.schema.json
@@ -37,6 +37,11 @@
               "deprecated": true
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the country"
         }
       },
       "required": [

--- a/website/static/schemas/next/context/instrument.schema.json
+++ b/website/static/schemas/next/context/instrument.schema.json
@@ -19,42 +19,42 @@
             "BBG": {
               "type": "string",
               "title": "Bloomberg security",
-              "description": "<https://www.bloomberg.com/>"
+              "description": "https://www.bloomberg.com/"
             },
             "CUSIP": {
               "type": "string",
               "title": "CUSIP",
-              "description": "<https://www.cusip.com/>"
+              "description": "https://www.cusip.com/"
             },
             "FDS_ID": {
               "type": "string",
               "title": "FactSet Permanent Security Identifier",
-              "description": "<https://www.factset.com/>"
+              "description": "https://www.factset.com/"
             },
             "FIGI": {
               "type": "string",
               "title": "Open FIGI",
-              "description": "<https://www.openfigi.com/>"
+              "description": "https://www.openfigi.com/"
             },
             "ISIN": {
               "type": "string",
               "title": "ISIN",
-              "description": "<https://www.isin.org/>"
+              "description": "https://www.isin.org/"
             },
             "PERMID": {
               "type": "string",
               "title": "Refinitiv PERMID",
-              "description": "<https://permid.org/>"
+              "description": "https://permid.org/"
             },
             "RIC": {
               "type": "string",
               "title": "Refinitiv Identification Code",
-              "description": " <https://www.refinitiv.com/>"
+              "description": "https://www.refinitiv.com/"
             },
             "SEDOL": {
               "type": "string",
               "title": "SEDOL",
-              "description": "<https://www.lseg.com/sedol>"
+              "description": "https://www.lseg.com/sedol"
             },
             "ticker": {
               "type": "string",
@@ -63,6 +63,11 @@
             }
           }
         },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the instrument"
+        },
         "market": {
           "description": "The `market` map can be used to further specify the instrument and help achieve interoperability between disparate data sources. This is especially useful when using an `id` field that is not globally unique.",
           "type": "object",
@@ -70,7 +75,7 @@
             "MIC": {
               "type": "string",
               "title": "Market Identifier Code",
-              "description": "<https://en.wikipedia.org/wiki/Market_Identifier_Code>"
+              "description": "https://en.wikipedia.org/wiki/Market_Identifier_Code"
             },
             "name": {
               "type": "string",
@@ -80,12 +85,12 @@
             "COUNTRY_ISOALPHA2": {
               "type": "string",
               "title": "Country ISO Code",
-              "description": "<https://www.iso.org/iso-3166-country-codes.html>"
+              "description": "https://www.iso.org/iso-3166-country-codes.html"
             },
             "BBG": {
               "type": "string",
               "title": "Bloomberg Market Identifier",
-              "description": "<https://www.bloomberg.com/>"
+              "description": "https://www.bloomberg.com/"
             }
           },
           "unevaluatedProperties": {

--- a/website/static/schemas/next/context/instrumentList.schema.json
+++ b/website/static/schemas/next/context/instrumentList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.instrumentList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Instrument List Identifiers",
+          "description": "One or more identifiers that refer to the instrument list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the instrument list"
+        },
         "instruments": {
           "type": "array",
           "title": "List of instruments",

--- a/website/static/schemas/next/context/orderList.schema.json
+++ b/website/static/schemas/next/context/orderList.schema.json
@@ -11,6 +11,19 @@
         "type": {
           "const": "fdc3.orderList"
         },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Order List Identifiers",
+          "description": "One or more identifiers that refer to the order list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable summary of the order list"
+        },
         "orders": {
           "type": "array",
           "items": {

--- a/website/static/schemas/next/context/organization.schema.json
+++ b/website/static/schemas/next/context/organization.schema.json
@@ -33,6 +33,11 @@
               "description": "FactSet Permanent Identifier representing the organization"
             }
           }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name of the organization"
         }
       },
       "required": [

--- a/website/static/schemas/next/context/portfolio.schema.json
+++ b/website/static/schemas/next/context/portfolio.schema.json
@@ -18,6 +18,19 @@
           },
           "title": "Portfolio positions",
           "description": "The List of Positions which make up the Portfolio"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Portfolio Identifiers",
+          "description": "One or more identifiers that refer to the portfolio in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the portfolio"
         }
       },
       "required": [

--- a/website/static/schemas/next/context/position.schema.json
+++ b/website/static/schemas/next/context/position.schema.json
@@ -20,6 +20,19 @@
           "type": "number",
           "title": "The size of the holding represented by this position",
           "description": "The amount of the holding, e.g. a number of shares"
+        },
+        "id": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Position Identifiers",
+          "description": "One or more identifiers that refer to the position in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future."
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the position"
         }
       },
       "required": [

--- a/website/static/schemas/next/context/tradeList.schema.json
+++ b/website/static/schemas/next/context/tradeList.schema.json
@@ -12,12 +12,25 @@
           "const": "fdc3.tradeList"
         },
         "trades": {
+          "title": "List of Trades",
+          "description": "An array of trade contexts that forms the list.",
           "type": "array",
           "items": {
             "$ref": "trade.schema.json#"
-          },
-          "title": "List of Trades",
-          "description": "An array of trade contexts that forms the list."
+          }
+        },
+        "id": {
+          "title": "Trade List Identifiers",
+          "description": "One or more identifiers that refer to the trade list in an OMS, EMS or related system. Specific key names for systems are expected to be standardized in future.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "An optional human-readable name for the trade list"
         }
       },
       "required": [


### PR DESCRIPTION
supersedes #1233

Adds missing id and name fields from the context base schema to context schemas that use them (but don't define sub-properties) so that they show up in documentation correctly, in the following types:

- Contact
- ContactList
- Country
- InstrumentList
- OrderList
- Organization
- Portfolio
- Position
- TradeList

Also fixes:
- Rendering of internal references (e.g. internal $refs to $defs or definitions used in a schema), which was broken in ChatSearchCriteria (which defines a SearchCriteria element).
- Bulleting of polymorphic array items (oneOf, anyOf etc.)
- A number of broken links that have slipped through in other PRs which docusaurus reports on a manual build