### PR TITLE
Set explicit background colours for website

### DIFF
--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -1,4 +1,12 @@
 
+html[data-theme='light'] {
+    background-color: white;
+}
+
+html[data-theme='dark'] {
+    background-color: black;
+}
+
 @font-face {
     src: url("/fonts/Electrolize-Regular.ttf");
     font-family: 'Electrolize'

--- a/website/src/css/customTheme.css
+++ b/website/src/css/customTheme.css
@@ -1,10 +1,10 @@
 
 html[data-theme='light'] {
-    background-color: white;
+    background-color: #FFFFFF;
 }
 
 html[data-theme='dark'] {
-    background-color: black;
+    background-color: #1B1B1B;
 }
 
 @font-face {


### PR DESCRIPTION
The website doesn't currently explicitly set background colors - rather it assume the browser's default background is white (which is a user preference in some browsers, while many electron-based products use a dark background by default - leaving the page impossible to read).

This PR sets an explicit background colour for each mode (dark and light)

