### PR TITLE
Make window.fdc3 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+* `window.fdc3` is now an optional property and may or may not be defined.
 * `Listener.unsubscribe()` was made async (the return type was changed from `void` to `Promise<void>`) for consistency with the rest of the API. ([#1305](https://github.com/finos/FDC3/pull/1305))
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-* `window.fdc3` is now an optional property and may or may not be defined.
+* `window.fdc3` is now an optional property and may or may not be defined. Applications should use `getAgent()` is now the recommended way of retrieving a reference to the FDC3 API. ([#1386](https://github.com/finos/FDC3/pull/1386))
 * `Listener.unsubscribe()` was made async (the return type was changed from `void` to `Promise<void>`) for consistency with the rest of the API. ([#1305](https://github.com/finos/FDC3/pull/1305))
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-* `window.fdc3` is now an optional property and may or may not be defined. Applications should use `getAgent()` is now the recommended way of retrieving a reference to the FDC3 API. ([#1386](https://github.com/finos/FDC3/pull/1386))
+* `window.fdc3` is now an optional property and may or may not be defined. Applications should now use `getAgent()` as the recommended way of retrieving a reference to the FDC3 API. ([#1386](https://github.com/finos/FDC3/pull/1386))
 * `Listener.unsubscribe()` was made async (the return type was changed from `void` to `Promise<void>`) for consistency with the rest of the API. ([#1305](https://github.com/finos/FDC3/pull/1305))
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))

--- a/src/api/DesktopAgent.ts
+++ b/src/api/DesktopAgent.ts
@@ -13,7 +13,6 @@ import { ImplementationMetadata } from './ImplementationMetadata';
 import { PrivateChannel } from './PrivateChannel';
 import { AppIdentifier } from './AppIdentifier';
 import { AppMetadata } from './AppMetadata';
-import { DesktopAgentDetails } from './GetAgent';
 import { Intent } from '../intents/Intents';
 import { ContextType } from '../context/ContextType';
 import { EventHandler, FDC3EventTypes } from './Events';

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -207,7 +207,7 @@ export interface Chart {
 }
 
 /**
- * financial instrument that relates to the definition of this product
+ * A financial instrument that relates to the definition of this product
  *
  *
  *
@@ -235,7 +235,7 @@ export interface InstrumentElement {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: SearchCriteriaMarket;
+    market?: OrganizationMarket;
     /**
      * An optional human-readable name for the instrument
      */
@@ -304,7 +304,7 @@ export interface PurpleInstrumentIdentifiers {
  * interoperability between disparate data sources. This is especially useful when using an
  * `id` field that is not globally unique.
  */
-export interface SearchCriteriaMarket {
+export interface OrganizationMarket {
     /**
      * https://www.bloomberg.com/
      */
@@ -663,7 +663,7 @@ export interface ChatRoomObject {
     /**
      * Identifier(s) for the chat - currently unstandardized
      */
-    id: { [key: string]: any };
+    id: { [key: string]: string };
     /**
      * Display name for the chat room
      */
@@ -702,7 +702,7 @@ export interface ChatRoom {
     /**
      * Identifier(s) for the chat - currently unstandardized
      */
-    id: { [key: string]: any };
+    id: { [key: string]: string };
     /**
      * Display name for the chat room
      */
@@ -734,7 +734,7 @@ export interface ChatSearchCriteria {
      *
      * Empty search criteria can be supported to allow resetting of filters.
      */
-    criteria: SearchCriteria[];
+    criteria: Array<OrganizationObject | string>;
     type:     "fdc3.chat.searchCriteria";
     id?:      { [key: string]: any };
     name?:    string;
@@ -742,26 +742,23 @@ export interface ChatSearchCriteria {
 }
 
 /**
- * An individual criteria against which to match chat messages, based on an FDC3 context or
- * free-text string.
- *
- * financial instrument that relates to the definition of this product
+ * A financial instrument that relates to the definition of this product
  *
  *
  *
  * A financial instrument from any asset class.
- *
- * The contact that initiated the interaction
- *
- * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  *
  * An entity that can be used when referencing private companies and other organizations
  * where a specific instrument is not available or desired e.g. CRM and News workflows.
  *
  * It is valid to include extra properties and metadata as part of the organization payload,
  * but the minimum requirement is for at least one specified identifier to be provided.
+ *
+ * The contact that initiated the interaction
+ *
+ * A person contact that can be engaged with through email, calling, messaging, CMS, etc.
  */
-export interface SearchCriteria {
+export interface OrganizationObject {
     /**
      * Any combination of instrument identifiers can be used together to resolve ambiguity, or
      * for a better match. Not all applications will use the same instrument identifiers, which
@@ -777,9 +774,9 @@ export interface SearchCriteria {
      * fields, define a property that makes it clear what the value represents. Doing so will
      * make interpretation easier for the developers of target applications.
      *
-     * Identifiers that relate to the Contact represented by this context
-     *
      * Identifiers for the organization, at least one must be provided.
+     *
+     * Identifiers that relate to the Contact represented by this context
      */
     id: Identifiers;
     /**
@@ -787,16 +784,16 @@ export interface SearchCriteria {
      * interoperability between disparate data sources. This is especially useful when using an
      * `id` field that is not globally unique.
      */
-    market?: SearchCriteriaMarket;
+    market?: OrganizationMarket;
     /**
      * An optional human-readable name for the instrument
      *
-     * An optional human-readable name for the contact
-     *
      * An optional human-readable name of the organization
+     *
+     * An optional human-readable name for the contact
      */
     name?: string;
-    type:  SearchCriteriaType;
+    type:  TentacledInteractionType;
     [property: string]: any;
 }
 
@@ -815,9 +812,9 @@ export interface SearchCriteria {
  * fields, define a property that makes it clear what the value represents. Doing so will
  * make interpretation easier for the developers of target applications.
  *
- * Identifiers that relate to the Contact represented by this context
- *
  * Identifiers for the organization, at least one must be provided.
+ *
+ * Identifiers that relate to the Contact represented by this context
  */
 export interface Identifiers {
     /**
@@ -831,9 +828,9 @@ export interface Identifiers {
     /**
      * https://www.factset.com/
      *
-     * FactSet Permanent Identifier representing the contact
-     *
      * FactSet Permanent Identifier representing the organization
+     *
+     * FactSet Permanent Identifier representing the contact
      */
     FDS_ID?: string;
     /**
@@ -863,16 +860,16 @@ export interface Identifiers {
      */
     ticker?: string;
     /**
-     * The email address for the contact
-     */
-    email?: string;
-    /**
      * The Legal Entity Identifier (LEI) is a 20-character, alpha-numeric code based on the ISO
      * 17442 standard developed by the International Organization for Standardization (ISO). It
      * connects to key reference information that enables clear and unique identification of
      * legal entities participating in financial transactions.
      */
     LEI?: string;
+    /**
+     * The email address for the contact
+     */
+    email?: string;
     [property: string]: any;
 }
 
@@ -882,7 +879,7 @@ export interface Identifiers {
  * `interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or
  * `'Meeting'` although other string values are permitted.
  */
-export type SearchCriteriaType = "fdc3.instrument" | "fdc3.contact" | "fdc3.organization";
+export type TentacledInteractionType = "fdc3.instrument" | "fdc3.organization" | "fdc3.contact";
 
 /**
  * Free text to be used for a keyword search
@@ -1583,7 +1580,7 @@ export interface ProductObject {
      */
     id: { [key: string]: string };
     /**
-     * financial instrument that relates to the definition of this product
+     * A financial instrument that relates to the definition of this product
      */
     instrument?: InstrumentElement;
     /**
@@ -1860,7 +1857,7 @@ export interface Product {
      */
     id: { [key: string]: string };
     /**
-     * financial instrument that relates to the definition of this product
+     * A financial instrument that relates to the definition of this product
      */
     instrument?: InstrumentElement;
     /**
@@ -2510,9 +2507,9 @@ const typeMap: any = {
     ], "any"),
     "InstrumentElement": o([
         { json: "id", js: "id", typ: r("PurpleInstrumentIdentifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
+        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("InstrumentType") },
+        { json: "type", js: "type", typ: r("PurpleInteractionType") },
     ], "any"),
     "PurpleInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2525,7 +2522,7 @@ const typeMap: any = {
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
     ], "any"),
-    "SearchCriteriaMarket": o([
+    "OrganizationMarket": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
         { json: "COUNTRY_ISOALPHA2", js: "COUNTRY_ISOALPHA2", typ: u(undefined, "") },
         { json: "MIC", js: "MIC", typ: u(undefined, "") },
@@ -2556,7 +2553,7 @@ const typeMap: any = {
     "ContactElement": o([
         { json: "id", js: "id", typ: r("PurpleContactIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("ContactType") },
+        { json: "type", js: "type", typ: r("FluffyInteractionType") },
     ], "any"),
     "PurpleContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2602,30 +2599,30 @@ const typeMap: any = {
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
     "ChatRoomObject": o([
-        { json: "id", js: "id", typ: m("any") },
+        { json: "id", js: "id", typ: m("") },
         { json: "name", js: "name", typ: u(undefined, "") },
         { json: "providerName", js: "providerName", typ: "" },
         { json: "type", js: "type", typ: r("ChatRoomType") },
         { json: "url", js: "url", typ: u(undefined, "") },
     ], "any"),
     "ChatRoom": o([
-        { json: "id", js: "id", typ: m("any") },
+        { json: "id", js: "id", typ: m("") },
         { json: "name", js: "name", typ: u(undefined, "") },
         { json: "providerName", js: "providerName", typ: "" },
         { json: "type", js: "type", typ: r("ChatRoomType") },
         { json: "url", js: "url", typ: u(undefined, "") },
     ], "any"),
     "ChatSearchCriteria": o([
-        { json: "criteria", js: "criteria", typ: a(r("SearchCriteria")) },
+        { json: "criteria", js: "criteria", typ: a(u(r("OrganizationObject"), "")) },
         { json: "type", js: "type", typ: r("ChatSearchCriteriaType") },
         { json: "id", js: "id", typ: u(undefined, m("any")) },
         { json: "name", js: "name", typ: u(undefined, "") },
     ], "any"),
-    "SearchCriteria": o([
+    "OrganizationObject": o([
         { json: "id", js: "id", typ: r("Identifiers") },
-        { json: "market", js: "market", typ: u(undefined, r("SearchCriteriaMarket")) },
+        { json: "market", js: "market", typ: u(undefined, r("OrganizationMarket")) },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("SearchCriteriaType") },
+        { json: "type", js: "type", typ: r("TentacledInteractionType") },
     ], "any"),
     "Identifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2637,13 +2634,13 @@ const typeMap: any = {
         { json: "RIC", js: "RIC", typ: u(undefined, "") },
         { json: "SEDOL", js: "SEDOL", typ: u(undefined, "") },
         { json: "ticker", js: "ticker", typ: u(undefined, "") },
-        { json: "email", js: "email", typ: u(undefined, "") },
         { json: "LEI", js: "LEI", typ: u(undefined, "") },
+        { json: "email", js: "email", typ: u(undefined, "") },
     ], "any"),
     "Contact": o([
         { json: "id", js: "id", typ: r("FluffyContactIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("ContactType") },
+        { json: "type", js: "type", typ: r("FluffyInteractionType") },
     ], "any"),
     "FluffyContactIdentifiers": o([
         { json: "email", js: "email", typ: u(undefined, "") },
@@ -2701,7 +2698,7 @@ const typeMap: any = {
         { json: "id", js: "id", typ: r("FluffyInstrumentIdentifiers") },
         { json: "market", js: "market", typ: u(undefined, r("PurpleMarket")) },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("InstrumentType") },
+        { json: "type", js: "type", typ: r("PurpleInteractionType") },
     ], "any"),
     "FluffyInstrumentIdentifiers": o([
         { json: "BBG", js: "BBG", typ: u(undefined, "") },
@@ -2805,7 +2802,7 @@ const typeMap: any = {
     "Organization": o([
         { json: "id", js: "id", typ: r("OrganizationIdentifiers") },
         { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "type", js: "type", typ: r("OrganizationType") },
+        { json: "type", js: "type", typ: r("StickyInteractionType") },
     ], "any"),
     "OrganizationIdentifiers": o([
         { json: "FDS_ID", js: "FDS_ID", typ: u(undefined, "") },
@@ -2884,7 +2881,7 @@ const typeMap: any = {
     "ActionType": [
         "fdc3.action",
     ],
-    "InstrumentType": [
+    "PurpleInteractionType": [
         "fdc3.instrument",
     ],
     "TimeRangeType": [
@@ -2905,7 +2902,7 @@ const typeMap: any = {
     "ChartType": [
         "fdc3.chart",
     ],
-    "ContactType": [
+    "FluffyInteractionType": [
         "fdc3.contact",
     ],
     "ContactListType": [
@@ -2927,7 +2924,7 @@ const typeMap: any = {
     "ChatMessageType": [
         "fdc3.chat.message",
     ],
-    "SearchCriteriaType": [
+    "TentacledInteractionType": [
         "fdc3.contact",
         "fdc3.instrument",
         "fdc3.organization",
@@ -2966,7 +2963,7 @@ const typeMap: any = {
     "OrderListType": [
         "fdc3.orderList",
     ],
-    "OrganizationType": [
+    "StickyInteractionType": [
         "fdc3.organization",
     ],
     "PositionType": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * from './api/ContextMetadata';
 export * from './api/DesktopAgent';
 export * from './api/DisplayMetadata';
 export * from './api/Errors';
+export * from './api/GetAgent';
 export * from './api/Icon';
 export * from './api/Image';
 export * from './api/ImplementationMetadata';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,6 @@ export { BrowserTypes };
 
 declare global {
   interface Window {
-    fdc3: DesktopAgent;
+    fdc3?: DesktopAgent;
   }
 }


### PR DESCRIPTION
Currently `window.fdc3` is incorrectly marked as always being set. `getAgent` code will need to be able to determine if this has been set already and app code should also be able to determine if it is currently set. At the moment this is difficult due to the incorrect types.

fixes #1385 

---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.