### PR TITLE
Creating a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,15 @@
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->
 
+## Contributor License Agreement
+
+<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to have establish a CLA or ohave it acknowledged by the EasyCLA tool. -->
+
+- [ ] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.
+
 ## Review Checklist
+
+<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
 - [ ] Is a CHANGELOG.md entry included?
 - [ ] Does this PR include changes to the Desktop Agent or Channel API?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 - [ ] Is a CHANGELOG.md entry included?
 - [ ] Does this PR include changes to the Desktop Agent or Channel API?
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are normally on the API interfaces and types are usually matched to the main documentation*
+        *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Describe your change
+
+<!--- Describe your change here-->
+
+### Related Issue
+<!--- This project prefers to accept pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->
+
+## Review Checklist
+
+- [ ] Is a CHANGELOG.md entry included?
+- [ ] Were schema files (context, bridging, api) modified in this PR 
+  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+- [ ] Were changes to Desktop Agent or Channel APIs made?
+  - [ ] If yes, were both documentation (/docs) and sources updated?
+  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,13 +17,15 @@
 
 <!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
+- [ ] If a change was made to the FDC3 Standard, was an issue linked above?
 - [ ] Is a CHANGELOG.md entry included?
-- [ ] Does this PR include changes to the Desktop Agent or Channel API?
+- [ ] Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
+        *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
-  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
+  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
   - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+        *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 ## Contributor License Agreement
 
-<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to have establish a CLA or ohave it acknowledged by the EasyCLA tool. -->
+<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->
 
 - [ ] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,12 @@
 ## Review Checklist
 
 - [ ] Is a CHANGELOG.md entry included?
-- [ ] Were schema files (context, bridging, api) modified in this PR 
+- [ ] Does this PR include changes to the Desktop Agent or Channel API?
+  - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
+        *jsDoc comments are normally on the API interfaces and types are usually matched to the main documentation*
+  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
+        *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
+  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
+        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
+- [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
   - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
-- [ ] Were changes to Desktop Agent or Channel APIs made?
-  - [ ] If yes, were both documentation (/docs) and sources updated?
-  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
         *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
-        *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
+        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
-  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
         *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,9 @@
 
 - [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
 - [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
-- [ ] **API changes**: Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
-  - [ ] **Docs & Sources**: f yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
+- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
+  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
+        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
   - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,15 +17,24 @@
 
 <!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
-- [ ] If a change was made to the FDC3 Standard, was an issue linked above?
-- [ ] Is a CHANGELOG.md entry included?
-- [ ] Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
-  - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
+- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
+- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
+- [ ] **API changes**: Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
+  - [ ] **Docs & Sources**: f yes, were both documentation (/docs) and sources updated?<br/>
         *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
-  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
+  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
-  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
+  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
-- [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
-  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
-        *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*
+    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
+        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
+- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
+  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
+  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
+  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
+  - [ ] Was at least one example provided?
+  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
+        *Generated code will be found at `/src/context/ContextTypes.ts`*
+- [ ] **Intents**: Were new Intents created in this PR?
+  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
+  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?


### PR DESCRIPTION
First pass at a PR template for FDC3. Should be updated to include code locations in the fdc3-for-web-impl PR which refactors the repository.

Please note that the comments  wrapped `<!---    -->` do not render in PR pages, but are visible when creating or editing the PR description. They are provided to help explain the template to contriboutors. See: https://github.com/finos/FDC3/blob/PR-template/.github/pull_request_template.md for a preview