### PR TITLE
Updating SessionStorage data format to additionally scope data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * FDC3 apps are now encouraged to instantiate their FDC3 interface (DesktopAgent) using the `getAgent()` function provided by the `@finos/fdc3` module. This will allow apps to interoperate in either traditional Preload DAs (i.e. Electron) as well as the new Browser-Resident DAs. ([#1191](https://github.com/finos/FDC3/pull/1191))
+* SessionStorage use by `getAgent` was updated to scope the stored data by `window.name` and the app's `identityUrl`. ([#1442](https://github.com/finos/FDC3/pull/1442))
 
 ### Deprecated
 

--- a/docs/api/ref/GetAgent.md
+++ b/docs/api/ref/GetAgent.md
@@ -173,7 +173,7 @@ The data persisted is structured as an object conforming to the `SessionStorageF
 
 ```ts
 const sessionData: SessionStorageFormat = sessionStorage.get("FDC3-Desktop-Agent-Details-myWindowName");
-const agentDetails: DesktopAgentDetails = sessionStorage["myApIdentityUrl"];
+const agentDetails: DesktopAgentDetails = sessionData["myApIdentityUrl"];
 ```
 
 ### Type Definitions

--- a/docs/api/ref/GetAgent.md
+++ b/docs/api/ref/GetAgent.md
@@ -161,7 +161,7 @@ Failover functions MUST be asynchronous and MUST resolve to one of the following
 
 The `getAgent()` function uses [`SessionStorage`](https://html.spec.whatwg.org/multipage/webstorage.html) ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)) to persist information on an instance of an app and how it connected to a Desktop Agent in order to ensure a consistent connection type and `instanceId` when reconnecting after navigation or refresh events. 
 
-:::info
+:::warning
 Apps do not need to and SHOULD NOT interact with data persisted in SessionStorage by `getAgent` directly, rather it is set and used by the `getAgent()` implementation.
 :::
 
@@ -172,7 +172,7 @@ To differentiate storage for multiple iframes the name of the browsing context (
 The data persisted is structured as an object conforming to the `SessionStorageFormat` type below, with the `identityUrl` of the app used as the key (if no `identityUrl` is provided the `actualUrl` is used instead), with the value conforming to the `DesktopAgentDetails` type. Hence, the data might be retrieved as follows:
 
 ```ts
-const sessionData:SessionStorageFormat = sessionStorage.get("FDC3-Desktop-Agent-Details-myWindowName");
+const sessionData: SessionStorageFormat = sessionStorage.get("FDC3-Desktop-Agent-Details-myWindowName");
 const agentDetails: DesktopAgentDetails = sessionStorage["myApIdentityUrl"];
 ```
 

--- a/src/api/GetAgent.ts
+++ b/src/api/GetAgent.ts
@@ -44,7 +44,7 @@ export type GetAgentType = (params?: GetAgentParams) => Promise<DesktopAgent>;
  *
  * @property {number} timeoutMs Number of milliseconds to allow for an FDC3
  * implementation to be found before calling the failover function or
- * rejecting (default 750). Note that the timeout is cancelled as soon as a
+ * rejecting (default 1000). Note that the timeout is cancelled as soon as a
  * Desktop Agent is detected. There may be additional set-up steps to perform
  * which will happen outside the timeout.
  *
@@ -90,6 +90,13 @@ type GetAgentParams = {
   dontSetWindowFdc3?: boolean;
   failover?: (args: GetAgentParams) => Promise<WindowProxy | DesktopAgent>;
 };
+
+/** Type representing the format of data stored by `getAgent`
+ *  in Session Storage. */
+export type SessionStorageFormat = {
+  /** */
+  [key: string]: DesktopAgentDetails
+}
 
 /** Type representing data on the Desktop Agent that an app
  *  connected to that is persisted by the getAgent function
@@ -159,3 +166,7 @@ export enum WebDesktopAgentType {
    *  function that was passed by the application. */
   Failover = 'FAILOVER',
 }
+
+export const DESKTOP_AGENT_SESSION_STORAGE_KEY_PREFIX = 'fdc3-desktop-agent-details';
+
+export const DEFAULT_TIMEOUT_MS = 1000;

--- a/src/api/GetAgent.ts
+++ b/src/api/GetAgent.ts
@@ -92,7 +92,8 @@ type GetAgentParams = {
 };
 
 /** Type representing the format of data stored by `getAgent`
- *  in Session Storage. */
+ *  in Session Storage. The `identityUrl` of each app is used
+ *  as the key. */
 export type SessionStorageFormat = {
   /** */
   [key: string]: DesktopAgentDetails


### PR DESCRIPTION
## Describe your change

Updates the description of and types governing the use SessionStorage by getAgent to scope the data by `identityUrl` and `window.name`, thus ensuring iframes in a common window don't overwrite each others data and data for multiple different apps on teh same origin can be retained (to support navigating to a different app and then back again).

Docs preview deeplink: https://deploy-preview-1442--fdc3.netlify.app/docs/next/api/ref/GetAgent#persisted-connection-data

### Related Issue

resolves #1430 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [x] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
