### PR TITLE
Modify generate-type-predicates to only include interfaces that have …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "toolbox/fdc3-for-web/fdc3-web-impl",
         "packages/fdc3-get-agent",
         "packages/fdc3",
-        "toolbox/fdc3-for-web/demo",
         "toolbox/fdc3-for-web/reference-ui",
+        "toolbox/fdc3-for-web/demo",
         "toolbox/fdc3-workbench"
       ],
       "dependencies": {
@@ -3345,6 +3345,7 @@
     "node_modules/@kite9/fdc3-common": {
       "version": "2.2.0-beta.6",
       "integrity": "sha512-JQa8WVXWIpHQRMt9CFsxqjfrw2Rq4tVUT8R6r2cJAg1y1Ns+zmpclo/bGi3DVqFyd5PfOEbbiAER/1ll0PXb3A==",
+      "dev": true,
       "dependencies": {
         "@kite9/fdc3": "2.2.0-beta.6"
       }
@@ -3352,6 +3353,7 @@
     "node_modules/@kite9/fdc3-common/node_modules/@kite9/fdc3": {
       "version": "2.2.0-beta.6",
       "integrity": "sha512-F/fC4Ayp3uBzhBs4x5rp8n4/JSbuGaAHdrfrm/HTipDqsQKdQon4uZsNdMK6USTX1gnpFVy8luSnIddFJey12g==",
+      "dev": true,
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.14.1"
       }
@@ -3362,6 +3364,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10929,6 +10932,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/message-await": {
+      "version": "1.1.0",
+      "integrity": "sha1-co0mGvlPoxRM4inWyAXqYga5ry8=",
+      "dev": true,
+      "dependencies": {
+        "cli-cursor": "^3.1.0",
+        "log-symbols": "^4.1.0"
+      }
+    },
+    "node_modules/message-await/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/message-await/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/message-await/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/message-await/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
@@ -15689,6 +15750,7 @@
       }
     },
     "packages/fdc3": {
+      "name": "@kite9/fdc3",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15699,6 +15761,7 @@
       }
     },
     "packages/fdc3-agent-proxy": {
+      "name": "@kite9/fdc3-agent-proxy",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15733,6 +15796,7 @@
       }
     },
     "packages/fdc3-context": {
+      "name": "@kite9/fdc3-context",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -16166,6 +16230,7 @@
       }
     },
     "packages/fdc3-get-agent": {
+      "name": "@kite9/fdc3-get-agent",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16192,6 +16257,7 @@
       }
     },
     "packages/fdc3-schema": {
+      "name": "@kite9/fdc3-schema",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -16205,6 +16271,7 @@
         "eslint-plugin-jest": "28.8.3",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "globals": "^15.11.0",
+        "message-await": "^1.1.0",
         "quicktype": "23.0.78",
         "rimraf": "^6.0.1",
         "ts-jest": "29.2.5",
@@ -16626,6 +16693,7 @@
       }
     },
     "packages/fdc3-standard": {
+      "name": "@kite9/fdc3-standard",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17068,6 +17136,7 @@
       }
     },
     "packages/testing": {
+      "name": "@kite9/testing",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17101,6 +17170,7 @@
       }
     },
     "toolbox/fdc3-for-web/demo": {
+      "name": "@kite9/demo",
       "version": "2.2.0-beta.29",
       "dependencies": {
         "@kite9/fdc3": "2.2.0-beta.29",
@@ -17123,6 +17193,7 @@
       }
     },
     "toolbox/fdc3-for-web/fdc3-web-impl": {
+      "name": "@kite9/fdc3-web-impl",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17160,9 +17231,10 @@
       }
     },
     "toolbox/fdc3-for-web/reference-ui": {
+      "name": "fdc3-for-web-reference-ui",
       "version": "2.1.1",
       "dependencies": {
-        "@kite9/fdc3-common": "2.2.0-beta.6"
+        "@kite9/fdc3": "2.2.0-beta.29"
       },
       "devDependencies": {
         "typescript": "^5.3.2",

--- a/packages/fdc3-schema/code-generation/generate-type-predicates.ts
+++ b/packages/fdc3-schema/code-generation/generate-type-predicates.ts
@@ -1,62 +1,104 @@
-import { InterfaceDeclaration, MethodDeclaration, Project, SyntaxKind } from "ts-morph"
+import { InterfaceDeclaration, KindToNodeMappings, MethodDeclaration, Project, SyntaxKind, TypeAliasDeclaration } from 'ts-morph';
+import print from "message-await"
 
-// open a new project with just BrowserTypes as the only source file 
+// open a new project with just BrowserTypes as the only source file
 const project = new Project();
-const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts");
+const sourceFile = project.addSourceFileAtPath('./generated/api/BrowserTypes.ts');
 
-const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+const APP_REQUEST_MESSAGE = "AppRequestMessage"
+const AGENT_RESPONSE_MESSAGE = "AgentResponseMessage"
+const AGENT_EVENT_MESSAGE = "AgentEventMessage"
 
 /**
  * We generate the union types and remove the existing interfaces first so that we are not left with a generated type predicate for the removed base interface
  */
+writeMessageUnionTypes();
+writeTypePredicates();
 
-// get the types listed in the types union type
-// i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
-const requestMessageUnion = findUnionType("RequestMessageType");
-if(requestMessageUnion != null){
-    // Write a union type of all interfaces that have a type that extends RequestMessageType
-    writeUnionType("AppRequestMessage", requestMessageUnion);
+sourceFile.formatText();
+project.saveSync();
+
+/**
+ * Replaces the existing interfaces AppRequestMessage, AgentResponseMessage and AgentEventMessage with unions of INterfaces instead of a base type
+ */
+function writeMessageUnionTypes() {
+  const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+  writeMessageUnion(APP_REQUEST_MESSAGE, 'RequestMessageType', typeAliases);
+  writeMessageUnion(AGENT_RESPONSE_MESSAGE, 'ResponseMessageType', typeAliases);
+  writeMessageUnion(AGENT_EVENT_MESSAGE, 'EventMessageType', typeAliases);
 }
 
-const responseMessageUnion = findUnionType("ResponseMessageType");
-if(responseMessageUnion != null){
-    writeUnionType("AgentResponseMessage", responseMessageUnion);
-}
+function writeMessageUnion(unionName: string, typeUnionName: string, typeAliases: TypeAliasDeclaration[]){
+  let awaitMessage = print(`Writing ${unionName} (finding types)`, {spinner: true});
 
-const eventMessageUnion = findUnionType("EventMessageType");
-if(eventMessageUnion != null){
-    writeUnionType("AgentEventMessage", eventMessageUnion);
-}
+    // get the types listed in the types union type
+    // i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
+    const requestMessageTypeUnion = findUnionType(typeAliases, typeUnionName);
+    if (requestMessageTypeUnion != null) {
+      //remove existing type alias
+      findExisting(unionName, SyntaxKind.TypeAliasDeclaration).forEach(node => node.remove());
 
-// get a list of all conversion functions in the Convert class
-const convert = sourceFile.getClass("Convert");
-const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(func => func.getReturnType().getText() === "string");
+      awaitMessage.updateMessage(`Writing ${unionName} (writing union)`, true);
 
-
-//get a list of all interfaces in the file
-let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
-
-// generate a list of Interfaces that have an associated conversion function
-const matchedInterfaces = convertFunctions.map(func => {
-    const valueParameter = func.getParameter("value");
-
-    const matchingInterface = messageInterfaces.find(interfaceNode => {
-        return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
-    });
-
-
-    if (matchingInterface != null) {
-        return { func, matchingInterface };
+        // Write a union type of all interfaces that have a type that extends RequestMessageType
+        // i.e. export type AppRequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest;
+        writeUnionType(unionName, requestMessageTypeUnion);
     }
 
-    return undefined;
-}).filter(((value => value != null) as <T>(value: T | null | undefined) => value is T));
+    awaitMessage.complete(true, `Writing ${unionName}`);
+}
 
-// write a type predicate for each matched interface
-matchedInterfaces.forEach(matched => {
-    writePredicate(matched.matchingInterface, matched.func)
-    writeTypeConstant(matched.matchingInterface)
-});
+/**
+ * Writes type predicates for all interfaces found that have a matching convert function
+ */
+function writeTypePredicates(){
+  let awaitMessage = print(`Writing Type Predicates (finding convert functions)`, {spinner: true});
+
+    // get a list of all conversion functions in the Convert class that return a string
+    const convert = sourceFile.getClass('Convert');
+    const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(
+      func => func.getReturnType().getText() === 'string'
+    );
+
+    awaitMessage.updateMessage(`Writing Type Predicates (finding message interfaces)`, true);
+
+    //get a list of all interfaces in the file
+    let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+
+    // generate a list of Interfaces that have an associated conversion function
+    const matchedInterfaces = convertFunctions
+        .map(func => {
+            const valueParameter = func.getParameter('value');
+
+            const matchingInterface = messageInterfaces.find(interfaceNode => {
+                /// Find an interface who's name matches the type passed into the value parameter of the convert function
+                return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
+            });
+
+            if (matchingInterface != null) {
+                return { func, matchingInterface };
+            }
+
+            return undefined; 
+        })
+        .filter(isDefined);
+
+    const allFunctionDeclarations = sourceFile.getChildrenOfKind(SyntaxKind.FunctionDeclaration);
+
+    // write a type predicate for each matched interface
+    matchedInterfaces.forEach((matched, index) => {
+
+      awaitMessage.updateMessage(`Writing Type Predicates (${index}/${matchedInterfaces.length})`, true);
+
+        writeFastPredicate(matched.matchingInterface, allFunctionDeclarations);
+        writeValidPredicate(matched.matchingInterface, matched.func, allFunctionDeclarations);
+        writeTypeConstant(matched.matchingInterface);
+    });
+
+    awaitMessage.complete(true, `Writing Type Predicates`);
+}
 
 
 /**
@@ -64,40 +106,53 @@ matchedInterfaces.forEach(matched => {
  * export type NAME = "stringOne" | "stringTwo" | "stringThree";
  * and returns the string values
  * if the union type is not found returns undefined
+ * @param name
+ * @returns
+ */
+function findUnionType(typeAliases: TypeAliasDeclaration[], name: string): string[] | undefined {
+  const typeAlias = typeAliases.find(alias => {
+    const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
+
+    return identifiers[0].getText() === name;
+  });
+
+  return typeAlias
+    ?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
+    .getDescendantsOfKind(SyntaxKind.StringLiteral)
+    .map(literal => literal.getLiteralText());
+}
+
+/**
+ * Finds an existing declaration with the given type and name
  * @param name 
+ * @param kind 
  * @returns 
  */
-function findUnionType(name: string): string[] | undefined {
-    const typeAlias = typeAliases.find(alias => {
-        const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
-    
-        return identifiers[0].getText() === name;
-    
-    });
+function findExisting<T extends SyntaxKind>(name: string, kind: T, allDeclarationsOfType?: KindToNodeMappings[T][]) {
+  allDeclarationsOfType = allDeclarationsOfType ?? sourceFile.getChildrenOfKind(kind);
 
-    return typeAlias?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
-        .getDescendantsOfKind(SyntaxKind.StringLiteral)
-        .map(literal => literal.getLiteralText());
+  return sourceFile.getChildrenOfKind(kind).filter(child => {
+    const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
+
+    return identifier?.getText() === name;
+  });
 }
 
+/**
+ * Writes a type predicate for the given interface using the Convert method declaration
+ * @param matchingInterface 
+ * @param func 
+ */
+function writeValidPredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration, allFunctionDeclarations: KindToNodeMappings[SyntaxKind.FunctionDeclaration][]): void {
+  const predicateName = `isValid${matchingInterface.getName()}`;
 
+  // remove existing instances
+  findExisting(predicateName, SyntaxKind.FunctionDeclaration, allFunctionDeclarations).forEach(node => node.remove());
 
-
-function findExisting<T extends SyntaxKind>(name: string, kind: T) {
-    return sourceFile.getChildrenOfKind(kind).filter(child => {
-        const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
-
-        return identifier?.getText() === name;
-    })
-}
-
-function writePredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration): void {
-    const predicateName = `is${matchingInterface.getName()}`;
-
-    // remove existing instances
-    findExisting(predicateName, SyntaxKind.FunctionDeclaration).forEach(node => node.remove());
-
-    sourceFile.addStatements(`
+  sourceFile.addStatements(`
+/**
+ * Returns true if value is a valid ${matchingInterface.getName()}. This checks the type against the json schema for the message and will be slower
+ */ 
 export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
     try{
         Convert.${func.getName()}(value);
@@ -108,54 +163,100 @@ export function ${predicateName}(value: any): value is ${matchingInterface.getNa
 }`);
 }
 
+/**
+ * Writes a type predicate for the given interface checking just the value of the type property
+ * @param matchingInterface 
+ * @param func 
+ */
+function writeFastPredicate(matchingInterface: InterfaceDeclaration, allFunctionDeclarations: KindToNodeMappings[SyntaxKind.FunctionDeclaration][]): void {
+    const predicateName = `is${matchingInterface.getName()}`;
+  
+    // remove existing instances
+    findExisting(predicateName, SyntaxKind.FunctionDeclaration, allFunctionDeclarations).forEach(node => node.remove());
+  
+    const typePropertyValue = extractTypePropertyValue(matchingInterface);
 
-function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
-
-    const constantName = `${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE`;
-
-    //remove existing
-    findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+    if(typePropertyValue == null){
+        return;
+    }
 
     sourceFile.addStatements(`
-        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";`);
+/**
+ * Returns true if the value has a type property with value '${typePropertyValue}'. This is a fast check that does not check the format of the message
+ */ 
+export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
+    return value != null && value.type === '${typePropertyValue}';
+}`);
+  }
 
+function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
+  const constantName = `${matchingInterface
+    .getName()
+    .replaceAll(/([A-Z])/g, '_$1')
+    .toUpperCase()
+    .substring(1)}_TYPE`;
+
+  //remove existing
+  findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+
+  sourceFile.addStatements(`
+        export const ${matchingInterface
+          .getName()
+          .replaceAll(/([A-Z])/g, '_$1')
+          .toUpperCase()
+          .substring(1)}_TYPE = "${matchingInterface.getName()}";`);
 }
 
 /**
  * Writes a union type of all the interfaces that have a type property that extends the type values passed in.
  * For example:
  * export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest ...
- * @param unionName 
- * @param interfaces 
- * @param typeValues 
+ * @param unionName
+ * @param interfaces
+ * @param typeValues
  */
 function writeUnionType(unionName: string, typeValues: string[]): void {
-    // generate interfaces list again as we may have just removed some
-    const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+  // generate interfaces list again as we may have just removed some
+  const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
 
-    // look for interfaces that have a type property that extends one of the values in typeValues
-    const matchingInterfaces = unionInterfaces.filter(currentInterface => {
-        const typeProperty = currentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
-            return propertySignature.getChildrenOfKind(SyntaxKind.Identifier).find(identifier => identifier.getText() === "type") != null;
-        })[0];
+  // look for interfaces that have a type property that extends one of the values in typeValues
+  const matchingInterfaces = unionInterfaces.filter(currentInterface => {
+    const typePropertyValue = extractTypePropertyValue(currentInterface);
 
-        if(typeProperty == null){
-            return false;
-        }
+    return typeValues.some(typeValue => typeValue === typePropertyValue);
+  });
 
-        const stringLiterals = typeProperty.getDescendantsOfKind(SyntaxKind.StringLiteral)
-            .map(literal => literal.getLiteralText());
+  //remove existing Type
+  findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
 
-        return stringLiterals.some(literal => typeValues.some(typeValue => typeValue === literal));
-    })
-    
-    //remove existing Type
-    findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
-
-    sourceFile.addStatements(`
-    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(" | ")}; `);
+  sourceFile.addStatements(`
+    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(' | ')}; `);
 }
 
-sourceFile.formatText();
+/**
+ * Extract the type string constant from an interface such as
+ * interface ExampleMessage{
+ *     type: "stringConstant";
+ * }
+ * @param parentInterface 
+ * @returns 
+ */
+function extractTypePropertyValue(parentInterface: InterfaceDeclaration): string | undefined{
+    const typeProperty = parentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
+        return (
+          propertySignature
+            .getChildrenOfKind(SyntaxKind.Identifier)
+            .find(identifier => identifier.getText() === 'type') != null
+        );
+      })[0];
 
-project.saveSync();
+    return typeProperty?.getDescendantsOfKind(SyntaxKind.StringLiteral)
+        .map(literal => literal.getLiteralText())[0];
+}
+
+/**
+ * Type predicate to test that value is defined
+ */
+function isDefined<T>(value: T | null | undefined): value is T{
+    return value != null;
+}

--- a/packages/fdc3-schema/code-generation/generate-type-predicates.ts
+++ b/packages/fdc3-schema/code-generation/generate-type-predicates.ts
@@ -2,20 +2,45 @@ import { InterfaceDeclaration, MethodDeclaration, Project, SyntaxKind } from "ts
 
 // open a new project with just BrowserTypes as the only source file 
 const project = new Project();
-const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts")
+const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts");
 
-//get a list of all interfaces in the file
-const interfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+/**
+ * We generate the union types and remove the existing interfaces first so that we are not left with a generated type predicate for the removed base interface
+ */
+
+// get the types listed in the types union type
+// i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
+const requestMessageUnion = findUnionType("RequestMessageType");
+if(requestMessageUnion != null){
+    // Write a union type of all interfaces that have a type that extends RequestMessageType
+    writeUnionType("AppRequestMessage", requestMessageUnion);
+}
+
+const responseMessageUnion = findUnionType("ResponseMessageType");
+if(responseMessageUnion != null){
+    writeUnionType("AgentResponseMessage", responseMessageUnion);
+}
+
+const eventMessageUnion = findUnionType("EventMessageType");
+if(eventMessageUnion != null){
+    writeUnionType("AgentEventMessage", eventMessageUnion);
+}
 
 // get a list of all conversion functions in the Convert class
 const convert = sourceFile.getClass("Convert");
 const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(func => func.getReturnType().getText() === "string");
 
+
+//get a list of all interfaces in the file
+let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+
 // generate a list of Interfaces that have an associated conversion function
 const matchedInterfaces = convertFunctions.map(func => {
     const valueParameter = func.getParameter("value");
 
-    const matchingInterface = interfaces.find(interfaceNode => {
+    const matchingInterface = messageInterfaces.find(interfaceNode => {
         return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
     });
 
@@ -33,12 +58,44 @@ matchedInterfaces.forEach(matched => {
     writeTypeConstant(matched.matchingInterface)
 });
 
-writeUnionType("RequestMessage", interfaces, "Request");
-writeUnionType("ResponseMessage", interfaces, "Response");
-writeUnionType("EventMessage", interfaces, "Event");
+
+/**
+ * Looks for a string union type in the form:
+ * export type NAME = "stringOne" | "stringTwo" | "stringThree";
+ * and returns the string values
+ * if the union type is not found returns undefined
+ * @param name 
+ * @returns 
+ */
+function findUnionType(name: string): string[] | undefined {
+    const typeAlias = typeAliases.find(alias => {
+        const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
+    
+        return identifiers[0].getText() === name;
+    
+    });
+
+    return typeAlias?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
+        .getDescendantsOfKind(SyntaxKind.StringLiteral)
+        .map(literal => literal.getLiteralText());
+}
+
+
+
+
+function findExisting<T extends SyntaxKind>(name: string, kind: T) {
+    return sourceFile.getChildrenOfKind(kind).filter(child => {
+        const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
+
+        return identifier?.getText() === name;
+    })
+}
 
 function writePredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration): void {
     const predicateName = `is${matchingInterface.getName()}`;
+
+    // remove existing instances
+    findExisting(predicateName, SyntaxKind.FunctionDeclaration).forEach(node => node.remove());
 
     sourceFile.addStatements(`
 export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
@@ -51,22 +108,52 @@ export function ${predicateName}(value: any): value is ${matchingInterface.getNa
 }`);
 }
 
+
 function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
 
+    const constantName = `${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE`;
+
+    //remove existing
+    findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+
     sourceFile.addStatements(`
-        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";
-    `);
+        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";`);
 
 }
 
+/**
+ * Writes a union type of all the interfaces that have a type property that extends the type values passed in.
+ * For example:
+ * export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest ...
+ * @param unionName 
+ * @param interfaces 
+ * @param typeValues 
+ */
+function writeUnionType(unionName: string, typeValues: string[]): void {
+    // generate interfaces list again as we may have just removed some
+    const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
 
-function writeUnionType(unionName: string, interfaces: InterfaceDeclaration[], nameEndsWith: string): void {
-    const matchingInterfaces = interfaces
-        .map(currentInterface => currentInterface.getName())
-        .filter(interfaceName => interfaceName.length > nameEndsWith.length && interfaceName.indexOf(nameEndsWith) === interfaceName.length - nameEndsWith.length);
+    // look for interfaces that have a type property that extends one of the values in typeValues
+    const matchingInterfaces = unionInterfaces.filter(currentInterface => {
+        const typeProperty = currentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
+            return propertySignature.getChildrenOfKind(SyntaxKind.Identifier).find(identifier => identifier.getText() === "type") != null;
+        })[0];
+
+        if(typeProperty == null){
+            return false;
+        }
+
+        const stringLiterals = typeProperty.getDescendantsOfKind(SyntaxKind.StringLiteral)
+            .map(literal => literal.getLiteralText());
+
+        return stringLiterals.some(literal => typeValues.some(typeValue => typeValue === literal));
+    })
+    
+    //remove existing Type
+    findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
 
     sourceFile.addStatements(`
-    export type ${unionName} = ${matchingInterfaces.join(" | ")}; `);
+    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(" | ")}; `);
 }
 
 sourceFile.formatText();

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -958,30 +958,6 @@ export interface AddIntentListenerResponsePayload {
 export type FluffyError = "MalformedContext" | "DesktopAgentNotFound" | "ResolverUnavailable" | "IntentDeliveryFailed" | "NoAppsFound" | "ResolverTimeout" | "TargetAppUnavailable" | "TargetInstanceUnavailable" | "UserCancelledResolution";
 
 /**
- * Identifies the type of the message and it is typically set to the FDC3 function name that
- * the message relates to, e.g. 'findIntent', with 'Response' appended.
- */
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app representing an event.
- */
-export interface AgentEventMessage {
-    /**
-     * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
-     */
-    meta: AgentEventMessageMeta;
-    /**
-     * The message payload contains details of the event that the app is being notified about.
-     */
-    payload: { [key: string]: any };
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Response' appended.
-     */
-    type: EventMessageType;
-}
-
-/**
  * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
  */
 export interface AgentEventMessageMeta {
@@ -994,28 +970,6 @@ export interface AgentEventMessageMeta {
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
 export type EventMessageType = "addEventListenerEvent" | "broadcastEvent" | "channelChangedEvent" | "heartbeatEvent" | "intentEvent" | "privateChannelOnAddContextListenerEvent" | "privateChannelOnDisconnectEvent" | "privateChannelOnUnsubscribeEvent";
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app responding to an API call. If the
- * payload contains an `error` property, the request was unsuccessful.
- */
-export interface AgentResponseMessage {
-    /**
-     * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
-     */
-    meta: AgentResponseMessageMeta;
-    /**
-     * A payload for a response to an API call that will contain any return values or an `error`
-     * property containing a standardized error message indicating that the request was
-     * unsuccessful.
-     */
-    payload: AgentResponseMessageResponsePayload;
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Response' appended.
-     */
-    type: ResponseMessageType;
-}
 
 /**
  * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
@@ -1046,25 +1000,6 @@ export interface AgentResponseMessageResponsePayload {
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
 export type ResponseMessageType = "addContextListenerResponse" | "addEventListenerResponse" | "addIntentListenerResponse" | "broadcastResponse" | "contextListenerUnsubscribeResponse" | "createPrivateChannelResponse" | "eventListenerUnsubscribeResponse" | "findInstancesResponse" | "findIntentResponse" | "findIntentsByContextResponse" | "getAppMetadataResponse" | "getCurrentChannelResponse" | "getCurrentContextResponse" | "getInfoResponse" | "getOrCreateChannelResponse" | "getUserChannelsResponse" | "intentListenerUnsubscribeResponse" | "intentResultResponse" | "joinUserChannelResponse" | "leaveCurrentChannelResponse" | "openResponse" | "privateChannelAddEventListenerResponse" | "privateChannelDisconnectResponse" | "privateChannelUnsubscribeEventListenerResponse" | "raiseIntentForContextResponse" | "raiseIntentResponse" | "raiseIntentResultResponse";
-
-/**
- * A request message from an FDC3-enabled app to a Desktop Agent.
- */
-export interface AppRequestMessage {
-    /**
-     * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
-     */
-    meta: AppRequestMessageMeta;
-    /**
-     * The message payload typically contains the arguments to FDC3 API functions.
-     */
-    payload: { [key: string]: any };
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Request' appended.
-     */
-    type: RequestMessageType;
-}
 
 /**
  * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
@@ -5857,8 +5792,23 @@ const typeMap: any = {
         "raiseIntentResultResponse",
     ],
 };
+export type AppRequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest | BroadcastRequest | ContextListenerUnsubscribeRequest | CreatePrivateChannelRequest | EventListenerUnsubscribeRequest | FindInstancesRequest | FindIntentRequest | FindIntentsByContextRequest | GetAppMetadataRequest | GetCurrentChannelRequest | GetCurrentContextRequest | GetInfoRequest | GetOrCreateChannelRequest | GetUserChannelsRequest | HeartbeatAcknowledgementRequest | IntentListenerUnsubscribeRequest | IntentResultRequest | JoinUserChannelRequest | LeaveCurrentChannelRequest | OpenRequest | PrivateChannelAddEventListenerRequest | PrivateChannelDisconnectRequest | PrivateChannelUnsubscribeEventListenerRequest | RaiseIntentForContextRequest | RaiseIntentRequest;
 
+export type AgentResponseMessage = AddContextListenerResponse | AddEventListenerResponse | AddIntentListenerResponse | BroadcastResponse | ContextListenerUnsubscribeResponse | CreatePrivateChannelResponse | EventListenerUnsubscribeResponse | FindInstancesResponse | FindIntentResponse | FindIntentsByContextResponse | GetAppMetadataResponse | GetCurrentChannelResponse | GetCurrentContextResponse | GetInfoResponse | GetOrCreateChannelResponse | GetUserChannelsResponse | IntentListenerUnsubscribeResponse | IntentResultResponse | JoinUserChannelResponse | LeaveCurrentChannelResponse | OpenResponse | PrivateChannelAddEventListenerResponse | PrivateChannelDisconnectResponse | PrivateChannelUnsubscribeEventListenerResponse | RaiseIntentForContextResponse | RaiseIntentResponse | RaiseIntentResultResponse;
+
+export type AgentEventMessage = BroadcastEvent | ChannelChangedEvent | HeartbeatEvent | IntentEvent | PrivateChannelOnAddContextListenerEvent | PrivateChannelOnDisconnectEvent | PrivateChannelOnUnsubscribeEvent;
+
+/**
+ * Returns true if the value has a type property with value 'WCP1Hello'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+    return value != null && value.type === 'WCP1Hello';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol1Hello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
     try {
         Convert.webConnectionProtocol1HelloToJson(value);
         return true;
@@ -5869,7 +5819,17 @@ export function isWebConnectionProtocol1Hello(value: any): value is WebConnectio
 
 export const WEB_CONNECTION_PROTOCOL1_HELLO_TYPE = "WebConnectionProtocol1Hello";
 
+/**
+ * Returns true if the value has a type property with value 'WCP2LoadUrl'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+    return value != null && value.type === 'WCP2LoadUrl';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol2LoadURL. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
     try {
         Convert.webConnectionProtocol2LoadURLToJson(value);
         return true;
@@ -5880,7 +5840,17 @@ export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnect
 
 export const WEB_CONNECTION_PROTOCOL2_LOAD_U_R_L_TYPE = "WebConnectionProtocol2LoadURL";
 
+/**
+ * Returns true if the value has a type property with value 'WCP3Handshake'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+    return value != null && value.type === 'WCP3Handshake';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol3Handshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
     try {
         Convert.webConnectionProtocol3HandshakeToJson(value);
         return true;
@@ -5891,7 +5861,17 @@ export function isWebConnectionProtocol3Handshake(value: any): value is WebConne
 
 export const WEB_CONNECTION_PROTOCOL3_HANDSHAKE_TYPE = "WebConnectionProtocol3Handshake";
 
+/**
+ * Returns true if the value has a type property with value 'WCP4ValidateAppIdentity'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
+    return value != null && value.type === 'WCP4ValidateAppIdentity';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol4ValidateAppIdentity. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
     try {
         Convert.webConnectionProtocol4ValidateAppIdentityToJson(value);
         return true;
@@ -5902,7 +5882,17 @@ export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value i
 
 export const WEB_CONNECTION_PROTOCOL4_VALIDATE_APP_IDENTITY_TYPE = "WebConnectionProtocol4ValidateAppIdentity";
 
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityFailedResponse'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityFailedResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentityFailedResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
     try {
         Convert.webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value);
         return true;
@@ -5913,7 +5903,17 @@ export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value:
 
 export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_FAILED_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentityFailedResponse";
 
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityResponse'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentitySuccessResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
     try {
         Convert.webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value);
         return true;
@@ -5924,7 +5924,17 @@ export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value
 
 export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_SUCCESS_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentitySuccessResponse";
 
+/**
+ * Returns true if the value has a type property with value 'WCP6Goodbye'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+    return value != null && value.type === 'WCP6Goodbye';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol6Goodbye. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
     try {
         Convert.webConnectionProtocol6GoodbyeToJson(value);
         return true;
@@ -5935,7 +5945,10 @@ export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnect
 
 export const WEB_CONNECTION_PROTOCOL6_GOODBYE_TYPE = "WebConnectionProtocol6Goodbye";
 
-export function isWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
+/**
+ * Returns true if value is a valid WebConnectionProtocolMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
     try {
         Convert.webConnectionProtocolMessageToJson(value);
         return true;
@@ -5946,7 +5959,17 @@ export function isWebConnectionProtocolMessage(value: any): value is WebConnecti
 
 export const WEB_CONNECTION_PROTOCOL_MESSAGE_TYPE = "WebConnectionProtocolMessage";
 
+/**
+ * Returns true if the value has a type property with value 'addContextListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddContextListenerRequest(value: any): value is AddContextListenerRequest {
+    return value != null && value.type === 'addContextListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerRequest(value: any): value is AddContextListenerRequest {
     try {
         Convert.addContextListenerRequestToJson(value);
         return true;
@@ -5957,7 +5980,17 @@ export function isAddContextListenerRequest(value: any): value is AddContextList
 
 export const ADD_CONTEXT_LISTENER_REQUEST_TYPE = "AddContextListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addContextListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddContextListenerResponse(value: any): value is AddContextListenerResponse {
+    return value != null && value.type === 'addContextListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerResponse(value: any): value is AddContextListenerResponse {
     try {
         Convert.addContextListenerResponseToJson(value);
         return true;
@@ -5968,7 +6001,17 @@ export function isAddContextListenerResponse(value: any): value is AddContextLis
 
 export const ADD_CONTEXT_LISTENER_RESPONSE_TYPE = "AddContextListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'addEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddEventListenerRequest(value: any): value is AddEventListenerRequest {
+    return value != null && value.type === 'addEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerRequest(value: any): value is AddEventListenerRequest {
     try {
         Convert.addEventListenerRequestToJson(value);
         return true;
@@ -5979,7 +6022,17 @@ export function isAddEventListenerRequest(value: any): value is AddEventListener
 
 export const ADD_EVENT_LISTENER_REQUEST_TYPE = "AddEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddEventListenerResponse(value: any): value is AddEventListenerResponse {
+    return value != null && value.type === 'addEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerResponse(value: any): value is AddEventListenerResponse {
     try {
         Convert.addEventListenerResponseToJson(value);
         return true;
@@ -5990,7 +6043,17 @@ export function isAddEventListenerResponse(value: any): value is AddEventListene
 
 export const ADD_EVENT_LISTENER_RESPONSE_TYPE = "AddEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
+    return value != null && value.type === 'addIntentListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
     try {
         Convert.addIntentListenerRequestToJson(value);
         return true;
@@ -6001,7 +6064,17 @@ export function isAddIntentListenerRequest(value: any): value is AddIntentListen
 
 export const ADD_INTENT_LISTENER_REQUEST_TYPE = "AddIntentListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
+    return value != null && value.type === 'addIntentListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
     try {
         Convert.addIntentListenerResponseToJson(value);
         return true;
@@ -6012,40 +6085,17 @@ export function isAddIntentListenerResponse(value: any): value is AddIntentListe
 
 export const ADD_INTENT_LISTENER_RESPONSE_TYPE = "AddIntentListenerResponse";
 
-export function isAgentEventMessage(value: any): value is AgentEventMessage {
-    try {
-        Convert.agentEventMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const AGENT_EVENT_MESSAGE_TYPE = "AgentEventMessage";
-
-export function isAgentResponseMessage(value: any): value is AgentResponseMessage {
-    try {
-        Convert.agentResponseMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const AGENT_RESPONSE_MESSAGE_TYPE = "AgentResponseMessage";
-
-export function isAppRequestMessage(value: any): value is AppRequestMessage {
-    try {
-        Convert.appRequestMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const APP_REQUEST_MESSAGE_TYPE = "AppRequestMessage";
-
+/**
+ * Returns true if the value has a type property with value 'broadcastEvent'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastEvent(value: any): value is BroadcastEvent {
+    return value != null && value.type === 'broadcastEvent';
+}
+
+/**
+ * Returns true if value is a valid BroadcastEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastEvent(value: any): value is BroadcastEvent {
     try {
         Convert.broadcastEventToJson(value);
         return true;
@@ -6056,7 +6106,17 @@ export function isBroadcastEvent(value: any): value is BroadcastEvent {
 
 export const BROADCAST_EVENT_TYPE = "BroadcastEvent";
 
+/**
+ * Returns true if the value has a type property with value 'broadcastRequest'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastRequest(value: any): value is BroadcastRequest {
+    return value != null && value.type === 'broadcastRequest';
+}
+
+/**
+ * Returns true if value is a valid BroadcastRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastRequest(value: any): value is BroadcastRequest {
     try {
         Convert.broadcastRequestToJson(value);
         return true;
@@ -6067,7 +6127,17 @@ export function isBroadcastRequest(value: any): value is BroadcastRequest {
 
 export const BROADCAST_REQUEST_TYPE = "BroadcastRequest";
 
+/**
+ * Returns true if the value has a type property with value 'broadcastResponse'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastResponse(value: any): value is BroadcastResponse {
+    return value != null && value.type === 'broadcastResponse';
+}
+
+/**
+ * Returns true if value is a valid BroadcastResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastResponse(value: any): value is BroadcastResponse {
     try {
         Convert.broadcastResponseToJson(value);
         return true;
@@ -6078,7 +6148,17 @@ export function isBroadcastResponse(value: any): value is BroadcastResponse {
 
 export const BROADCAST_RESPONSE_TYPE = "BroadcastResponse";
 
+/**
+ * Returns true if the value has a type property with value 'channelChangedEvent'. This is a fast check that does not check the format of the message
+ */
 export function isChannelChangedEvent(value: any): value is ChannelChangedEvent {
+    return value != null && value.type === 'channelChangedEvent';
+}
+
+/**
+ * Returns true if value is a valid ChannelChangedEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidChannelChangedEvent(value: any): value is ChannelChangedEvent {
     try {
         Convert.channelChangedEventToJson(value);
         return true;
@@ -6089,7 +6169,17 @@ export function isChannelChangedEvent(value: any): value is ChannelChangedEvent 
 
 export const CHANNEL_CHANGED_EVENT_TYPE = "ChannelChangedEvent";
 
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
+    return value != null && value.type === 'contextListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
     try {
         Convert.contextListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6100,7 +6190,17 @@ export function isContextListenerUnsubscribeRequest(value: any): value is Contex
 
 export const CONTEXT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "ContextListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
+    return value != null && value.type === 'contextListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
     try {
         Convert.contextListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6111,7 +6211,17 @@ export function isContextListenerUnsubscribeResponse(value: any): value is Conte
 
 export const CONTEXT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "ContextListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
+    return value != null && value.type === 'createPrivateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
     try {
         Convert.createPrivateChannelRequestToJson(value);
         return true;
@@ -6122,7 +6232,17 @@ export function isCreatePrivateChannelRequest(value: any): value is CreatePrivat
 
 export const CREATE_PRIVATE_CHANNEL_REQUEST_TYPE = "CreatePrivateChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
+    return value != null && value.type === 'createPrivateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
     try {
         Convert.createPrivateChannelResponseToJson(value);
         return true;
@@ -6133,7 +6253,17 @@ export function isCreatePrivateChannelResponse(value: any): value is CreatePriva
 
 export const CREATE_PRIVATE_CHANNEL_RESPONSE_TYPE = "CreatePrivateChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
+    return value != null && value.type === 'eventListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
     try {
         Convert.eventListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6144,7 +6274,17 @@ export function isEventListenerUnsubscribeRequest(value: any): value is EventLis
 
 export const EVENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "EventListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
+    return value != null && value.type === 'eventListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
     try {
         Convert.eventListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6155,7 +6295,17 @@ export function isEventListenerUnsubscribeResponse(value: any): value is EventLi
 
 export const EVENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "EventListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannelSelected'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+    return value != null && value.type === 'Fdc3UserInterfaceChannelSelected';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannelSelected. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
     try {
         Convert.fdc3UserInterfaceChannelSelectedToJson(value);
         return true;
@@ -6166,7 +6316,17 @@ export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3Use
 
 export const FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE = "Fdc3UserInterfaceChannelSelected";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannels'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
+    return value != null && value.type === 'Fdc3UserInterfaceChannels';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannels. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
     try {
         Convert.fdc3UserInterfaceChannelsToJson(value);
         return true;
@@ -6177,7 +6337,17 @@ export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterf
 
 export const FDC3_USER_INTERFACE_CHANNELS_TYPE = "Fdc3UserInterfaceChannels";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceDrag'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
+    return value != null && value.type === 'Fdc3UserInterfaceDrag';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceDrag. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
     try {
         Convert.fdc3UserInterfaceDragToJson(value);
         return true;
@@ -6188,7 +6358,17 @@ export function isFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceD
 
 export const FDC3_USER_INTERFACE_DRAG_TYPE = "Fdc3UserInterfaceDrag";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHandshake'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
+    return value != null && value.type === 'Fdc3UserInterfaceHandshake';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHandshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
     try {
         Convert.fdc3UserInterfaceHandshakeToJson(value);
         return true;
@@ -6199,7 +6379,17 @@ export function isFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInter
 
 export const FDC3_USER_INTERFACE_HANDSHAKE_TYPE = "Fdc3UserInterfaceHandshake";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHello'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
+    return value != null && value.type === 'Fdc3UserInterfaceHello';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
     try {
         Convert.fdc3UserInterfaceHelloToJson(value);
         return true;
@@ -6210,7 +6400,10 @@ export function isFdc3UserInterfaceHello(value: any): value is Fdc3UserInterface
 
 export const FDC3_USER_INTERFACE_HELLO_TYPE = "Fdc3UserInterfaceHello";
 
-export function isFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfaceMessage {
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfaceMessage {
     try {
         Convert.fdc3UserInterfaceMessageToJson(value);
         return true;
@@ -6221,7 +6414,17 @@ export function isFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_MESSAGE_TYPE = "Fdc3UserInterfaceMessage";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolve'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
+    return value != null && value.type === 'Fdc3UserInterfaceResolve';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolve. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
     try {
         Convert.fdc3UserInterfaceResolveToJson(value);
         return true;
@@ -6232,7 +6435,17 @@ export function isFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_RESOLVE_TYPE = "Fdc3UserInterfaceResolve";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolveAction'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
+    return value != null && value.type === 'Fdc3UserInterfaceResolveAction';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolveAction. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
     try {
         Convert.fdc3UserInterfaceResolveActionToJson(value);
         return true;
@@ -6243,7 +6456,17 @@ export function isFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserI
 
 export const FDC3_USER_INTERFACE_RESOLVE_ACTION_TYPE = "Fdc3UserInterfaceResolveAction";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceRestyle'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
+    return value != null && value.type === 'Fdc3UserInterfaceRestyle';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceRestyle. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
     try {
         Convert.fdc3UserInterfaceRestyleToJson(value);
         return true;
@@ -6254,7 +6477,17 @@ export function isFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_RESTYLE_TYPE = "Fdc3UserInterfaceRestyle";
 
+/**
+ * Returns true if the value has a type property with value 'findInstancesRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindInstancesRequest(value: any): value is FindInstancesRequest {
+    return value != null && value.type === 'findInstancesRequest';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesRequest(value: any): value is FindInstancesRequest {
     try {
         Convert.findInstancesRequestToJson(value);
         return true;
@@ -6265,7 +6498,17 @@ export function isFindInstancesRequest(value: any): value is FindInstancesReques
 
 export const FIND_INSTANCES_REQUEST_TYPE = "FindInstancesRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findInstancesResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindInstancesResponse(value: any): value is FindInstancesResponse {
+    return value != null && value.type === 'findInstancesResponse';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesResponse(value: any): value is FindInstancesResponse {
     try {
         Convert.findInstancesResponseToJson(value);
         return true;
@@ -6276,7 +6519,17 @@ export function isFindInstancesResponse(value: any): value is FindInstancesRespo
 
 export const FIND_INSTANCES_RESPONSE_TYPE = "FindInstancesResponse";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentRequest(value: any): value is FindIntentRequest {
+    return value != null && value.type === 'findIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentRequest(value: any): value is FindIntentRequest {
     try {
         Convert.findIntentRequestToJson(value);
         return true;
@@ -6287,7 +6540,17 @@ export function isFindIntentRequest(value: any): value is FindIntentRequest {
 
 export const FIND_INTENT_REQUEST_TYPE = "FindIntentRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentResponse(value: any): value is FindIntentResponse {
+    return value != null && value.type === 'findIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentResponse(value: any): value is FindIntentResponse {
     try {
         Convert.findIntentResponseToJson(value);
         return true;
@@ -6298,7 +6561,17 @@ export function isFindIntentResponse(value: any): value is FindIntentResponse {
 
 export const FIND_INTENT_RESPONSE_TYPE = "FindIntentResponse";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
+    return value != null && value.type === 'findIntentsByContextRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
     try {
         Convert.findIntentsByContextRequestToJson(value);
         return true;
@@ -6309,7 +6582,17 @@ export function isFindIntentsByContextRequest(value: any): value is FindIntentsB
 
 export const FIND_INTENTS_BY_CONTEXT_REQUEST_TYPE = "FindIntentsByContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
+    return value != null && value.type === 'findIntentsByContextResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
     try {
         Convert.findIntentsByContextResponseToJson(value);
         return true;
@@ -6320,7 +6603,17 @@ export function isFindIntentsByContextResponse(value: any): value is FindIntents
 
 export const FIND_INTENTS_BY_CONTEXT_RESPONSE_TYPE = "FindIntentsByContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
+    return value != null && value.type === 'getAppMetadataRequest';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
     try {
         Convert.getAppMetadataRequestToJson(value);
         return true;
@@ -6331,7 +6624,17 @@ export function isGetAppMetadataRequest(value: any): value is GetAppMetadataRequ
 
 export const GET_APP_METADATA_REQUEST_TYPE = "GetAppMetadataRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
+    return value != null && value.type === 'getAppMetadataResponse';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
     try {
         Convert.getAppMetadataResponseToJson(value);
         return true;
@@ -6342,7 +6645,17 @@ export function isGetAppMetadataResponse(value: any): value is GetAppMetadataRes
 
 export const GET_APP_METADATA_RESPONSE_TYPE = "GetAppMetadataResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
+    return value != null && value.type === 'getCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
     try {
         Convert.getCurrentChannelRequestToJson(value);
         return true;
@@ -6353,7 +6666,17 @@ export function isGetCurrentChannelRequest(value: any): value is GetCurrentChann
 
 export const GET_CURRENT_CHANNEL_REQUEST_TYPE = "GetCurrentChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
+    return value != null && value.type === 'getCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
     try {
         Convert.getCurrentChannelResponseToJson(value);
         return true;
@@ -6364,7 +6687,17 @@ export function isGetCurrentChannelResponse(value: any): value is GetCurrentChan
 
 export const GET_CURRENT_CHANNEL_RESPONSE_TYPE = "GetCurrentChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
+    return value != null && value.type === 'getCurrentContextRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
     try {
         Convert.getCurrentContextRequestToJson(value);
         return true;
@@ -6375,7 +6708,17 @@ export function isGetCurrentContextRequest(value: any): value is GetCurrentConte
 
 export const GET_CURRENT_CONTEXT_REQUEST_TYPE = "GetCurrentContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
+    return value != null && value.type === 'getCurrentContextResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
     try {
         Convert.getCurrentContextResponseToJson(value);
         return true;
@@ -6386,7 +6729,17 @@ export function isGetCurrentContextResponse(value: any): value is GetCurrentCont
 
 export const GET_CURRENT_CONTEXT_RESPONSE_TYPE = "GetCurrentContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getInfoRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetInfoRequest(value: any): value is GetInfoRequest {
+    return value != null && value.type === 'getInfoRequest';
+}
+
+/**
+ * Returns true if value is a valid GetInfoRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoRequest(value: any): value is GetInfoRequest {
     try {
         Convert.getInfoRequestToJson(value);
         return true;
@@ -6397,7 +6750,17 @@ export function isGetInfoRequest(value: any): value is GetInfoRequest {
 
 export const GET_INFO_REQUEST_TYPE = "GetInfoRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getInfoResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetInfoResponse(value: any): value is GetInfoResponse {
+    return value != null && value.type === 'getInfoResponse';
+}
+
+/**
+ * Returns true if value is a valid GetInfoResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoResponse(value: any): value is GetInfoResponse {
     try {
         Convert.getInfoResponseToJson(value);
         return true;
@@ -6408,7 +6771,17 @@ export function isGetInfoResponse(value: any): value is GetInfoResponse {
 
 export const GET_INFO_RESPONSE_TYPE = "GetInfoResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
+    return value != null && value.type === 'getOrCreateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
     try {
         Convert.getOrCreateChannelRequestToJson(value);
         return true;
@@ -6419,7 +6792,17 @@ export function isGetOrCreateChannelRequest(value: any): value is GetOrCreateCha
 
 export const GET_OR_CREATE_CHANNEL_REQUEST_TYPE = "GetOrCreateChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
+    return value != null && value.type === 'getOrCreateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
     try {
         Convert.getOrCreateChannelResponseToJson(value);
         return true;
@@ -6430,7 +6813,17 @@ export function isGetOrCreateChannelResponse(value: any): value is GetOrCreateCh
 
 export const GET_OR_CREATE_CHANNEL_RESPONSE_TYPE = "GetOrCreateChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
+    return value != null && value.type === 'getUserChannelsRequest';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
     try {
         Convert.getUserChannelsRequestToJson(value);
         return true;
@@ -6441,7 +6834,17 @@ export function isGetUserChannelsRequest(value: any): value is GetUserChannelsRe
 
 export const GET_USER_CHANNELS_REQUEST_TYPE = "GetUserChannelsRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
+    return value != null && value.type === 'getUserChannelsResponse';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
     try {
         Convert.getUserChannelsResponseToJson(value);
         return true;
@@ -6452,7 +6855,17 @@ export function isGetUserChannelsResponse(value: any): value is GetUserChannelsR
 
 export const GET_USER_CHANNELS_RESPONSE_TYPE = "GetUserChannelsResponse";
 
+/**
+ * Returns true if the value has a type property with value 'heartbeatAcknowledgementRequest'. This is a fast check that does not check the format of the message
+ */
 export function isHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
+    return value != null && value.type === 'heartbeatAcknowledgementRequest';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatAcknowledgementRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
     try {
         Convert.heartbeatAcknowledgementRequestToJson(value);
         return true;
@@ -6463,7 +6876,17 @@ export function isHeartbeatAcknowledgementRequest(value: any): value is Heartbea
 
 export const HEARTBEAT_ACKNOWLEDGEMENT_REQUEST_TYPE = "HeartbeatAcknowledgementRequest";
 
+/**
+ * Returns true if the value has a type property with value 'heartbeatEvent'. This is a fast check that does not check the format of the message
+ */
 export function isHeartbeatEvent(value: any): value is HeartbeatEvent {
+    return value != null && value.type === 'heartbeatEvent';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatEvent(value: any): value is HeartbeatEvent {
     try {
         Convert.heartbeatEventToJson(value);
         return true;
@@ -6474,7 +6897,17 @@ export function isHeartbeatEvent(value: any): value is HeartbeatEvent {
 
 export const HEARTBEAT_EVENT_TYPE = "HeartbeatEvent";
 
+/**
+ * Returns true if the value has a type property with value 'intentEvent'. This is a fast check that does not check the format of the message
+ */
 export function isIntentEvent(value: any): value is IntentEvent {
+    return value != null && value.type === 'intentEvent';
+}
+
+/**
+ * Returns true if value is a valid IntentEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentEvent(value: any): value is IntentEvent {
     try {
         Convert.intentEventToJson(value);
         return true;
@@ -6485,7 +6918,17 @@ export function isIntentEvent(value: any): value is IntentEvent {
 
 export const INTENT_EVENT_TYPE = "IntentEvent";
 
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
+    return value != null && value.type === 'intentListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
     try {
         Convert.intentListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6496,7 +6939,17 @@ export function isIntentListenerUnsubscribeRequest(value: any): value is IntentL
 
 export const INTENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "IntentListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
+    return value != null && value.type === 'intentListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
     try {
         Convert.intentListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6507,7 +6960,17 @@ export function isIntentListenerUnsubscribeResponse(value: any): value is Intent
 
 export const INTENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "IntentListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'intentResultRequest'. This is a fast check that does not check the format of the message
+ */
 export function isIntentResultRequest(value: any): value is IntentResultRequest {
+    return value != null && value.type === 'intentResultRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentResultRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultRequest(value: any): value is IntentResultRequest {
     try {
         Convert.intentResultRequestToJson(value);
         return true;
@@ -6518,7 +6981,17 @@ export function isIntentResultRequest(value: any): value is IntentResultRequest 
 
 export const INTENT_RESULT_REQUEST_TYPE = "IntentResultRequest";
 
+/**
+ * Returns true if the value has a type property with value 'intentResultResponse'. This is a fast check that does not check the format of the message
+ */
 export function isIntentResultResponse(value: any): value is IntentResultResponse {
+    return value != null && value.type === 'intentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultResponse(value: any): value is IntentResultResponse {
     try {
         Convert.intentResultResponseToJson(value);
         return true;
@@ -6529,7 +7002,17 @@ export function isIntentResultResponse(value: any): value is IntentResultRespons
 
 export const INTENT_RESULT_RESPONSE_TYPE = "IntentResultResponse";
 
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
+    return value != null && value.type === 'joinUserChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
     try {
         Convert.joinUserChannelRequestToJson(value);
         return true;
@@ -6540,7 +7023,17 @@ export function isJoinUserChannelRequest(value: any): value is JoinUserChannelRe
 
 export const JOIN_USER_CHANNEL_REQUEST_TYPE = "JoinUserChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
+    return value != null && value.type === 'joinUserChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
     try {
         Convert.joinUserChannelResponseToJson(value);
         return true;
@@ -6551,7 +7044,17 @@ export function isJoinUserChannelResponse(value: any): value is JoinUserChannelR
 
 export const JOIN_USER_CHANNEL_RESPONSE_TYPE = "JoinUserChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
+    return value != null && value.type === 'leaveCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
     try {
         Convert.leaveCurrentChannelRequestToJson(value);
         return true;
@@ -6562,7 +7065,17 @@ export function isLeaveCurrentChannelRequest(value: any): value is LeaveCurrentC
 
 export const LEAVE_CURRENT_CHANNEL_REQUEST_TYPE = "LeaveCurrentChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
+    return value != null && value.type === 'leaveCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
     try {
         Convert.leaveCurrentChannelResponseToJson(value);
         return true;
@@ -6573,7 +7086,17 @@ export function isLeaveCurrentChannelResponse(value: any): value is LeaveCurrent
 
 export const LEAVE_CURRENT_CHANNEL_RESPONSE_TYPE = "LeaveCurrentChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'openRequest'. This is a fast check that does not check the format of the message
+ */
 export function isOpenRequest(value: any): value is OpenRequest {
+    return value != null && value.type === 'openRequest';
+}
+
+/**
+ * Returns true if value is a valid OpenRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenRequest(value: any): value is OpenRequest {
     try {
         Convert.openRequestToJson(value);
         return true;
@@ -6584,7 +7107,17 @@ export function isOpenRequest(value: any): value is OpenRequest {
 
 export const OPEN_REQUEST_TYPE = "OpenRequest";
 
+/**
+ * Returns true if the value has a type property with value 'openResponse'. This is a fast check that does not check the format of the message
+ */
 export function isOpenResponse(value: any): value is OpenResponse {
+    return value != null && value.type === 'openResponse';
+}
+
+/**
+ * Returns true if value is a valid OpenResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenResponse(value: any): value is OpenResponse {
     try {
         Convert.openResponseToJson(value);
         return true;
@@ -6595,7 +7128,17 @@ export function isOpenResponse(value: any): value is OpenResponse {
 
 export const OPEN_RESPONSE_TYPE = "OpenResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelAddEventListenerRequest(value: any): value is PrivateChannelAddEventListenerRequest {
+    return value != null && value.type === 'privateChannelAddEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerRequest(value: any): value is PrivateChannelAddEventListenerRequest {
     try {
         Convert.privateChannelAddEventListenerRequestToJson(value);
         return true;
@@ -6606,7 +7149,17 @@ export function isPrivateChannelAddEventListenerRequest(value: any): value is Pr
 
 export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_REQUEST_TYPE = "PrivateChannelAddEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelAddEventListenerResponse(value: any): value is PrivateChannelAddEventListenerResponse {
+    return value != null && value.type === 'privateChannelAddEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerResponse(value: any): value is PrivateChannelAddEventListenerResponse {
     try {
         Convert.privateChannelAddEventListenerResponseToJson(value);
         return true;
@@ -6617,7 +7170,17 @@ export function isPrivateChannelAddEventListenerResponse(value: any): value is P
 
 export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_RESPONSE_TYPE = "PrivateChannelAddEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
+    return value != null && value.type === 'privateChannelDisconnectRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
     try {
         Convert.privateChannelDisconnectRequestToJson(value);
         return true;
@@ -6628,7 +7191,17 @@ export function isPrivateChannelDisconnectRequest(value: any): value is PrivateC
 
 export const PRIVATE_CHANNEL_DISCONNECT_REQUEST_TYPE = "PrivateChannelDisconnectRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
+    return value != null && value.type === 'privateChannelDisconnectResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
     try {
         Convert.privateChannelDisconnectResponseToJson(value);
         return true;
@@ -6639,7 +7212,17 @@ export function isPrivateChannelDisconnectResponse(value: any): value is Private
 
 export const PRIVATE_CHANNEL_DISCONNECT_RESPONSE_TYPE = "PrivateChannelDisconnectResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnAddContextListenerEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnAddContextListenerEvent(value: any): value is PrivateChannelOnAddContextListenerEvent {
+    return value != null && value.type === 'privateChannelOnAddContextListenerEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnAddContextListenerEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnAddContextListenerEvent(value: any): value is PrivateChannelOnAddContextListenerEvent {
     try {
         Convert.privateChannelOnAddContextListenerEventToJson(value);
         return true;
@@ -6650,7 +7233,17 @@ export function isPrivateChannelOnAddContextListenerEvent(value: any): value is 
 
 export const PRIVATE_CHANNEL_ON_ADD_CONTEXT_LISTENER_EVENT_TYPE = "PrivateChannelOnAddContextListenerEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnDisconnectEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
+    return value != null && value.type === 'privateChannelOnDisconnectEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnDisconnectEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
     try {
         Convert.privateChannelOnDisconnectEventToJson(value);
         return true;
@@ -6661,7 +7254,17 @@ export function isPrivateChannelOnDisconnectEvent(value: any): value is PrivateC
 
 export const PRIVATE_CHANNEL_ON_DISCONNECT_EVENT_TYPE = "PrivateChannelOnDisconnectEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnUnsubscribeEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
+    return value != null && value.type === 'privateChannelOnUnsubscribeEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnUnsubscribeEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
     try {
         Convert.privateChannelOnUnsubscribeEventToJson(value);
         return true;
@@ -6672,7 +7275,17 @@ export function isPrivateChannelOnUnsubscribeEvent(value: any): value is Private
 
 export const PRIVATE_CHANNEL_ON_UNSUBSCRIBE_EVENT_TYPE = "PrivateChannelOnUnsubscribeEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelUnsubscribeEventListenerRequest(value: any): value is PrivateChannelUnsubscribeEventListenerRequest {
+    return value != null && value.type === 'privateChannelUnsubscribeEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerRequest(value: any): value is PrivateChannelUnsubscribeEventListenerRequest {
     try {
         Convert.privateChannelUnsubscribeEventListenerRequestToJson(value);
         return true;
@@ -6683,7 +7296,17 @@ export function isPrivateChannelUnsubscribeEventListenerRequest(value: any): val
 
 export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_REQUEST_TYPE = "PrivateChannelUnsubscribeEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelUnsubscribeEventListenerResponse(value: any): value is PrivateChannelUnsubscribeEventListenerResponse {
+    return value != null && value.type === 'privateChannelUnsubscribeEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerResponse(value: any): value is PrivateChannelUnsubscribeEventListenerResponse {
     try {
         Convert.privateChannelUnsubscribeEventListenerResponseToJson(value);
         return true;
@@ -6694,7 +7317,17 @@ export function isPrivateChannelUnsubscribeEventListenerResponse(value: any): va
 
 export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_RESPONSE_TYPE = "PrivateChannelUnsubscribeEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
+    return value != null && value.type === 'raiseIntentForContextRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
     try {
         Convert.raiseIntentForContextRequestToJson(value);
         return true;
@@ -6705,7 +7338,17 @@ export function isRaiseIntentForContextRequest(value: any): value is RaiseIntent
 
 export const RAISE_INTENT_FOR_CONTEXT_REQUEST_TYPE = "RaiseIntentForContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
+    return value != null && value.type === 'raiseIntentForContextResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
     try {
         Convert.raiseIntentForContextResponseToJson(value);
         return true;
@@ -6716,7 +7359,17 @@ export function isRaiseIntentForContextResponse(value: any): value is RaiseInten
 
 export const RAISE_INTENT_FOR_CONTEXT_RESPONSE_TYPE = "RaiseIntentForContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentRequest'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentRequest(value: any): value is RaiseIntentRequest {
+    return value != null && value.type === 'raiseIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentRequest(value: any): value is RaiseIntentRequest {
     try {
         Convert.raiseIntentRequestToJson(value);
         return true;
@@ -6727,7 +7380,17 @@ export function isRaiseIntentRequest(value: any): value is RaiseIntentRequest {
 
 export const RAISE_INTENT_REQUEST_TYPE = "RaiseIntentRequest";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentResponse(value: any): value is RaiseIntentResponse {
+    return value != null && value.type === 'raiseIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResponse(value: any): value is RaiseIntentResponse {
     try {
         Convert.raiseIntentResponseToJson(value);
         return true;
@@ -6738,7 +7401,17 @@ export function isRaiseIntentResponse(value: any): value is RaiseIntentResponse 
 
 export const RAISE_INTENT_RESPONSE_TYPE = "RaiseIntentResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResultResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
+    return value != null && value.type === 'raiseIntentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
     try {
         Convert.raiseIntentResultResponseToJson(value);
         return true;
@@ -6747,91 +7420,4 @@ export function isRaiseIntentResultResponse(value: any): value is RaiseIntentRes
     }
 }
 
-export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";
-
-export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest | BroadcastRequest | ContextListenerUnsubscribeRequest | CreatePrivateChannelRequest | EventListenerUnsubscribeRequest | FindInstancesRequest | FindIntentRequest | FindIntentsByContextRequest | GetAppMetadataRequest | GetCurrentChannelRequest | GetCurrentContextRequest | GetInfoRequest | GetOrCreateChannelRequest | GetUserChannelsRequest | HeartbeatAcknowledgementRequest | IntentListenerUnsubscribeRequest | IntentResultRequest | JoinUserChannelRequest | LeaveCurrentChannelRequest | OpenRequest | PrivateChannelAddEventListenerRequest | PrivateChannelDisconnectRequest | PrivateChannelUnsubscribeEventListenerRequest | RaiseIntentForContextRequest | RaiseIntentRequest;
-
-export type ResponseMessage = WebConnectionProtocol5ValidateAppIdentityFailedResponse | WebConnectionProtocol5ValidateAppIdentitySuccessResponse | AddContextListenerResponse | AddEventListenerResponse | AddIntentListenerResponse | BroadcastResponse | ContextListenerUnsubscribeResponse | CreatePrivateChannelResponse | EventListenerUnsubscribeResponse | FindInstancesResponse | FindIntentResponse | FindIntentsByContextResponse | GetAppMetadataResponse | GetCurrentChannelResponse | GetCurrentContextResponse | GetInfoResponse | GetOrCreateChannelResponse | GetUserChannelsResponse | IntentListenerUnsubscribeResponse | IntentResultResponse | JoinUserChannelResponse | LeaveCurrentChannelResponse | OpenResponse | PrivateChannelAddEventListenerResponse | PrivateChannelDisconnectResponse | PrivateChannelUnsubscribeEventListenerResponse | RaiseIntentForContextResponse | RaiseIntentResponse | RaiseIntentResultResponse;
-
-export type EventMessage = BroadcastEvent | ChannelChangedEvent | HeartbeatEvent | IntentEvent | PrivateChannelOnAddContextListenerEvent | PrivateChannelOnDisconnectEvent | PrivateChannelOnUnsubscribeEvent;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";                  

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-jest": "28.8.3",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "globals": "^15.11.0",
+    "message-await": "^1.1.0",
     "quicktype": "23.0.78",
     "rimraf": "^6.0.1",
     "ts-jest": "29.2.5",


### PR DESCRIPTION
## Describe your change

Modification of the generate-type-predicates code to build unions types of interfaces not based on the interface name but based on the `type` declared in the interface. If `type` extends the `RequestMessageType` union then the interface is included in the `RequestMessage` union

### Related Issue
<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?

---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.