### PR TITLE
Correcting privateChannelAddEventListenerRequest to include null as a valid listenerType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added support for event listening outside of intent or context listnener. Added new function `addEventListener`, type `EventHandler`,  enum `FDC3EventType` and interfaces `FDC3Event` and `FDC3ChannelChangedEvent`. ([#1207](https://github.com/finos/FDC3/pull/1207))
 * Added new `CreateOrUpdateProfile` intent. ([#1359](https://github.com/finos/FDC3/pull/1359))
 
-
 ### Changed
 
 * `window.fdc3` is now an optional property and may or may not be defined. Applications should now use `getAgent()` as the recommended way of retrieving a reference to the FDC3 API. ([#1386](https://github.com/finos/FDC3/pull/1386))

--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,9 +3342,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/schemas/api/privateChannelAddEventListenerRequest.schema.json
+++ b/schemas/api/privateChannelAddEventListenerRequest.schema.json
@@ -39,7 +39,10 @@
 				"listenerType": {
 					"title": "Event listener type",
 					"description": "The type of PrivateChannel event that the listener should be applied to.",
-					"$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes"
+					"oneOf": [
+						{ "$ref": "common.schema.json#/$defs/PrivateChannelEventListenerTypes" },
+						{ "type": "null" }
+					]
 				}
 			},
 			"additionalProperties": false,

--- a/src/api/BrowserTypes.ts
+++ b/src/api/BrowserTypes.ts
@@ -1442,7 +1442,7 @@ export interface AppMetadata {
 }
 
 /**
- * Describes an Icon images that may be used to represent the application.
+ * Describes an Icon image that may be used to represent the application.
  */
 export interface Icon {
     /**
@@ -2107,7 +2107,7 @@ export interface GetCurrentContextResponsePayload {
  */
 
 /**
- * Request to retrieve information about the FDC3 Desktop Agent implementation  and the
+ * Request to retrieve information about the FDC3 Desktop Agent implementation and the
  * metadata of the calling application according to the Desktop Agent.
  *
  * A request message from an FDC3-enabled app to a Desktop Agent.
@@ -2907,7 +2907,7 @@ export interface TPayload {
     /**
      * The type of PrivateChannel event that the listener should be applied to.
      */
-    listenerType: PrivateChannelEventListenerTypes;
+    listenerType: PrivateChannelEventListenerTypes | null;
     /**
      * The Id of the PrivateChannel that the listener should be added to.
      */
@@ -2915,8 +2915,6 @@ export interface TPayload {
 }
 
 /**
- * The type of PrivateChannel event that the listener should be applied to.
- *
  * Event listener type names for Private Channel events.
  */
 export type PrivateChannelEventListenerTypes = "onAddContextListener" | "onUnsubscribe" | "onDisconnect";
@@ -5257,7 +5255,7 @@ const typeMap: any = {
         { json: "type", js: "type", typ: r("PrivateChannelAddEventListenerRequestType") },
     ], false),
     "TPayload": o([
-        { json: "listenerType", js: "listenerType", typ: r("PrivateChannelEventListenerTypes") },
+        { json: "listenerType", js: "listenerType", typ: u(r("PrivateChannelEventListenerTypes"), null) },
         { json: "privateChannelId", js: "privateChannelId", typ: "" },
     ], false),
     "PrivateChannelAddEventListenerResponse": o([

--- a/src/context/ContextTypes.ts
+++ b/src/context/ContextTypes.ts
@@ -119,7 +119,7 @@ export type ActionType = "broadcast" | "raiseIntent";
 export interface AppIdentifier {
     /**
      * The unique application identifier located within a specific application directory
-     * instance. An example of an appId might be 'app@sub.root'
+     * instance. An example of an appId might be 'app@sub.root'.
      */
     appId: string;
     /**


### PR DESCRIPTION
## Describe your change

The DesktopAgent API allows `null` as the `type` argument for [`PrivateChannel.addEventListener`](https://fdc3.finos.org/docs/next/api/ref/PrivateChannel#addeventlistener) but the `privateChannelAddEventListenerRequest` message schema intended to support that API call does not and needs to be corrected. 

### Related Issue

resolves #1445 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- N/A **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [x] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [x] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
