### PR TITLE
Modify generate-type-predicates to only include interfaces that have...

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,15 @@
 <!--- If suggesting a new feature or change, please discuss it in an issue first -->
 <!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->
 
+## Contributor License Agreement
+
+<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to have establish a CLA or ohave it acknowledged by the EasyCLA tool. -->
+
+- [ ] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.
+
 ## Review Checklist
+
+<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
 - [ ] Is a CHANGELOG.md entry included?
 - [ ] Does this PR include changes to the Desktop Agent or Channel API?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 - [ ] Is a CHANGELOG.md entry included?
 - [ ] Does this PR include changes to the Desktop Agent or Channel API?
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are normally on the API interfaces and types are usually matched to the main documentation*
+        *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Describe your change
+
+<!--- Describe your change here-->
+
+### Related Issue
+<!--- This project prefers to accept pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue first -->
+<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->
+
+## Review Checklist
+
+- [ ] Is a CHANGELOG.md entry included?
+- [ ] Were schema files (context, bridging, api) modified in this PR 
+  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+- [ ] Were changes to Desktop Agent or Channel APIs made?
+  - [ ] If yes, were both documentation (/docs) and sources updated?
+  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,13 +17,15 @@
 
 <!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
+- [ ] If a change was made to the FDC3 Standard, was an issue linked above?
 - [ ] Is a CHANGELOG.md entry included?
-- [ ] Does this PR include changes to the Desktop Agent or Channel API?
+- [ ] Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
+        *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
-  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
+  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
   - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+        *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 ## Contributor License Agreement
 
-<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to have establish a CLA or ohave it acknowledged by the EasyCLA tool. -->
+<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->
 
 - [ ] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,12 @@
 ## Review Checklist
 
 - [ ] Is a CHANGELOG.md entry included?
-- [ ] Were schema files (context, bridging, api) modified in this PR 
+- [ ] Does this PR include changes to the Desktop Agent or Channel API?
+  - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
+        *jsDoc comments are normally on the API interfaces and types are usually matched to the main documentation*
+  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
+        *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
+  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
+        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
+- [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
   - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
-- [ ] Were changes to Desktop Agent or Channel APIs made?
-  - [ ] If yes, were both documentation (/docs) and sources updated?
-  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@
   - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
         *jsDoc comments are on the API interfaces and types should be matched to the main documentation in /docs*
   - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
-        *Conformance test definitions should cover all **required**, aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
+        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,5 +27,5 @@
   - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
 - [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
-  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?
+  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
         *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,9 +19,9 @@
 
 - [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
 - [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
-- [ ] **API changes**: Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
-  - [ ] **Docs & Sources**: f yes, were both documentation (/docs) and sources updated?<br/>
-        *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
+- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
+  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
+        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
   - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
   - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,15 +17,24 @@
 
 <!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->
 
-- [ ] If a change was made to the FDC3 Standard, was an issue linked above?
-- [ ] Is a CHANGELOG.md entry included?
-- [ ] Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
-  - [ ] If yes, were both documentation (/docs) and sources updated?<br/>
+- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
+- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
+- [ ] **API changes**: Does this PR include changes to any of the FDC3 API (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
+  - [ ] **Docs & Sources**: f yes, were both documentation (/docs) and sources updated?<br/>
         *jsDoc comments are on interfaces and types should be matched to the main documentation in /docs*
-  - [ ] If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
+  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
         *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
-  - [ ] If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
+  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
         *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
-- [ ] Were schema files (Context, bridging, FDC3 for Web) modified in this PR
-  - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
-        *Generated code will be found at `/src/api/BrowserTypes.ts`,  `/src/context/ContextTypes.ts`, or `/src/bridging/BridgingTypes.ts`*
+    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
+        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
+- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
+  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
+  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
+  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
+  - [ ] Was at least one example provided?
+  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
+        *Generated code will be found at `/src/context/ContextTypes.ts`*
+- [ ] **Intents**: Were new Intents created in this PR?
+  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
+  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Typescript definitions for Desktop Agent Communication Protocol (DACP). These constitute the internal "wire protocol" that the "@finos/fdc3" library uses to communicate with Browser-Resident DAs. ([#1191](https://github.com/finos/FDC3/pull/1191))
 * Typescript definitions for Web Connection Protocol (WCP). These constitute the messages used to establish connectivity between "@finos/fdc3" and a Browser-Resident DA. ([#1191](https://github.com/finos/FDC3/pull/1191))
 * Added support for broadcast actions to the `fdc3.action` context type, allowing an Action to represent the broadcast of a specified context to an app or user channel. ([#1368](https://github.com/finos/FDC3/pull/1368))
+* Added utility functions `isStandardContextType(contextType: string)`, `isStandardIntent(intent: string)`,`getPossibleContextsForIntent(intent: StandardIntent)`. ([#1139](https://github.com/finos/FDC3/pull/1139))
+* Added support for event listening outside of intent or context listnener. Added new function `addEventListener`, type `EventHandler`,  enum `FDC3EventType` and interfaces `FDC3Event` and `FDC3ChannelChangedEvent`. ([#1207](https://github.com/finos/FDC3/pull/1207))
+* Added new `CreateOrUpdateProfile` intent. ([#1359](https://github.com/finos/FDC3/pull/1359))
+
 
 ### Changed
 
@@ -28,19 +32,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * FDC3 apps are now encouraged to instantiate their FDC3 interface (DesktopAgent) using the `getAgent()` function provided by the `@finos/fdc3` module. This will allow apps to interoperate in either traditional Preload DAs (i.e. Electron) as well as the new Browser-Resident DAs. ([#1191](https://github.com/finos/FDC3/pull/1191))
+* `Context` and `Intent` are now union type instead of enum, including in functions using intent reference changed from string to `Intent`. ([#1139](https://github.com/finos/FDC3/pull/1139))
 
 ### Deprecated
 
 * Made `IntentMetadata.displayName` optional as it is deprecated. ([#1280](https://github.com/finos/FDC3/pull/1280))
 * Deprecated `PrivateChannel`'s synchronous `onAddContextListener`, `onUnsubscribe` and `onDisconnect` functions in favour of an `async` `addEventListener` function consistent with the one added to `DesktopAgent` in #1207. ([#1305](https://github.com/finos/FDC3/pull/1305))
+* `ContextTypes` and `Intents` enums. ([#1139](https://github.com/finos/FDC3/pull/1139))
 
 ### Fixed
 
 * Spin off fileAttachment into its own schema, and correct related examples ([1255](https://github.com/finos/FDC3/issues/1255))
 * Added missing `desktopAgent` field to ImplementationMetadata objects returned for all agents connect to a DesktopAgent bridge in Connection Step 6 connectAgentsUpdate messages and refined the schema used to collect this info in step 3 handshake. ([#1177](https://github.com/finos/FDC3/pull/1177))
 * Removed the `version` field from `IntentResolution` as there are no version fields for intents in the FDC3 API definitions and hence the field has no purpose. ([#1170](https://github.com/finos/FDC3/pull/1170))
-
 * Fixed error in the Client-side example from `PrivateChannel` and `addIntentListener` by correcting `id.symbol` to `id.ticker` to align with the `fdc3.instrument` context. ([#1314](https://github.com/finos/FDC3/pull/1314))
+* Added missing `resultType` argument to `findIntent` agent request in the Bridging Schema. ([#1154](https://github.com/finos/FDC3/pull/1154)) 
+* Added missing `resultType` argument to `findIntentByContext` agent request in the Bridging Schema. ([#1212](https://github.com/finos/FDC3/pull/1212)) 
+* Added missing id and name fields from the context base schema to respective context schemas (`Contact`, `ContactList`, `Country`, `InstrumentList`, `OrderList`, `Organization`, `Portfolio`, `Position`, `TradeList`). ([#1360](https://github.com/finos/FDC3/pull/1360))
 
 ## [npm v2.1.1] - 2024-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added missing `resultType` argument to `findIntent` agent request in the Bridging Schema. ([#1154](https://github.com/finos/FDC3/pull/1154)) 
 * Added missing `resultType` argument to `findIntentByContext` agent request in the Bridging Schema. ([#1212](https://github.com/finos/FDC3/pull/1212)) 
 * Added missing id and name fields from the context base schema to respective context schemas (`Contact`, `ContactList`, `Country`, `InstrumentList`, `OrderList`, `Organization`, `Portfolio`, `Position`, `TradeList`). ([#1360](https://github.com/finos/FDC3/pull/1360))
+* Revised FDC3 charter to include well-known language from the FDC3 introduction, better describe FDC3's scope, focus on financial applications, update application types, etc. ([#1079](https://github.com/finos/FDC3/pull/1079))
 
 ## [npm v2.1.1] - 2024-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added reference materials and supported platforms information for FDC3 in .NET via the [finos/fdc3-dotnet](https://github.com/finos/fdc3-dotnet) project. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * The supported platforms page in the FDC3 documentation was moved into the API section as the information it provides all relates to FDC3 Desktop Agent API implementations. ([#1108](https://github.com/finos/FDC3/pull/1108))
 * FDC3 apps are now encouraged to instantiate their FDC3 interface (DesktopAgent) using the `getAgent()` function provided by the `@finos/fdc3` module. This will allow apps to interoperate in either traditional Preload DAs (i.e. Electron) as well as the new Browser-Resident DAs. ([#1191](https://github.com/finos/FDC3/pull/1191))
-* `Context` and `Intent` are now union type instead of enum, including in functions using intent reference changed from string to `Intent`. ([#1139](https://github.com/finos/FDC3/pull/1139))
+* `ContextType` and `Intent` (`string`) types were created for use in DesktopAgent API signatures - they are unions of standardized values and `string`, enabling autocomplete/IntelliSense in IDEs when working with the FDC3 API. ([#1139](https://github.com/finos/FDC3/pull/1139))
 
 ### Deprecated
 
 * Made `IntentMetadata.displayName` optional as it is deprecated. ([#1280](https://github.com/finos/FDC3/pull/1280))
 * Deprecated `PrivateChannel`'s synchronous `onAddContextListener`, `onUnsubscribe` and `onDisconnect` functions in favour of an `async` `addEventListener` function consistent with the one added to `DesktopAgent` in #1207. ([#1305](https://github.com/finos/FDC3/pull/1305))
-* `ContextTypes` and `Intents` enums. ([#1139](https://github.com/finos/FDC3/pull/1139))
+* The `ContextTypes` and `Intents` enums were deprecated in favour of the new ContextType and Intent unions. ([#1139](https://github.com/finos/FDC3/pull/1139))
 
 ### Fixed
 

--- a/docs/api/ref/GetAgent.md
+++ b/docs/api/ref/GetAgent.md
@@ -115,7 +115,7 @@ As web applications can navigate to or be navigated by users to different URLs a
 
 :::
 
-Finally, if there is still no Desktop Agent available, or an issue prevents connection to it, the `getAgent()` function will reject it's promise with a message from the [`AgentError`](./Errors#agenterror) enumeration.
+Finally, if there is still no Desktop Agent available, or an issue prevents connection to it, the `getAgent()` function will reject its promise with a message from the [`AgentError`](./Errors#agenterror) enumeration.
 
 ## Injected iframes for adaptors and user interfaces
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "toolbox/fdc3-for-web/fdc3-web-impl",
         "packages/fdc3-get-agent",
         "packages/fdc3",
-        "toolbox/fdc3-for-web/demo",
         "toolbox/fdc3-for-web/reference-ui",
+        "toolbox/fdc3-for-web/demo",
         "toolbox/fdc3-workbench"
       ],
       "dependencies": {
@@ -3345,6 +3345,7 @@
     "node_modules/@kite9/fdc3-common": {
       "version": "2.2.0-beta.6",
       "integrity": "sha512-JQa8WVXWIpHQRMt9CFsxqjfrw2Rq4tVUT8R6r2cJAg1y1Ns+zmpclo/bGi3DVqFyd5PfOEbbiAER/1ll0PXb3A==",
+      "dev": true,
       "dependencies": {
         "@kite9/fdc3": "2.2.0-beta.6"
       }
@@ -3352,6 +3353,7 @@
     "node_modules/@kite9/fdc3-common/node_modules/@kite9/fdc3": {
       "version": "2.2.0-beta.6",
       "integrity": "sha512-F/fC4Ayp3uBzhBs4x5rp8n4/JSbuGaAHdrfrm/HTipDqsQKdQon4uZsNdMK6USTX1gnpFVy8luSnIddFJey12g==",
+      "dev": true,
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.14.1"
       }
@@ -3362,6 +3364,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -10929,6 +10932,64 @@
         "node": ">= 8"
       }
     },
+    "node_modules/message-await": {
+      "version": "1.1.0",
+      "integrity": "sha1-co0mGvlPoxRM4inWyAXqYga5ry8=",
+      "dev": true,
+      "dependencies": {
+        "cli-cursor": "^3.1.0",
+        "log-symbols": "^4.1.0"
+      }
+    },
+    "node_modules/message-await/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/message-await/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/message-await/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/message-await/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
@@ -15689,6 +15750,7 @@
       }
     },
     "packages/fdc3": {
+      "name": "@kite9/fdc3",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15699,6 +15761,7 @@
       }
     },
     "packages/fdc3-agent-proxy": {
+      "name": "@kite9/fdc3-agent-proxy",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15733,6 +15796,7 @@
       }
     },
     "packages/fdc3-context": {
+      "name": "@kite9/fdc3-context",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -16166,6 +16230,7 @@
       }
     },
     "packages/fdc3-get-agent": {
+      "name": "@kite9/fdc3-get-agent",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16192,6 +16257,7 @@
       }
     },
     "packages/fdc3-schema": {
+      "name": "@kite9/fdc3-schema",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -16205,6 +16271,7 @@
         "eslint-plugin-jest": "28.8.3",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "globals": "^15.11.0",
+        "message-await": "^1.1.0",
         "quicktype": "23.0.78",
         "rimraf": "^6.0.1",
         "ts-jest": "29.2.5",
@@ -16626,6 +16693,7 @@
       }
     },
     "packages/fdc3-standard": {
+      "name": "@kite9/fdc3-standard",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17068,6 +17136,7 @@
       }
     },
     "packages/testing": {
+      "name": "@kite9/testing",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17101,6 +17170,7 @@
       }
     },
     "toolbox/fdc3-for-web/demo": {
+      "name": "@kite9/demo",
       "version": "2.2.0-beta.29",
       "dependencies": {
         "@kite9/fdc3": "2.2.0-beta.29",
@@ -17123,6 +17193,7 @@
       }
     },
     "toolbox/fdc3-for-web/fdc3-web-impl": {
+      "name": "@kite9/fdc3-web-impl",
       "version": "2.2.0-beta.29",
       "license": "Apache-2.0",
       "dependencies": {
@@ -17160,9 +17231,10 @@
       }
     },
     "toolbox/fdc3-for-web/reference-ui": {
+      "name": "fdc3-for-web-reference-ui",
       "version": "2.1.1",
       "dependencies": {
-        "@kite9/fdc3-common": "2.2.0-beta.6"
+        "@kite9/fdc3": "2.2.0-beta.29"
       },
       "devDependencies": {
         "typescript": "^5.3.2",

--- a/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
+++ b/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
@@ -1,204 +1,213 @@
-import { DataTable, Given, Then, When } from '@cucumber/cucumber'
+import { DataTable, Given, Then, When } from '@cucumber/cucumber';
 import { Context } from '@kite9/fdc3-context';
 import { handleResolve, matchData } from '@kite9/testing';
 import { CustomWorld } from '../world/index';
 import { BrowserTypes } from '@kite9/fdc3-schema';
 import { CHANNEL_STATE } from '@kite9/testing';
 import { ApiEvent } from '@kite9/fdc3-standard';
-import { ChannelChangedEvent, PrivateChannelOnAddContextListenerEvent } from '@kite9/fdc3-schema/generated/api/BrowserTypes';
+import {
+  ChannelChangedEvent,
+  PrivateChannelOnAddContextListenerEvent,
+} from '@kite9/fdc3-schema/generated/api/BrowserTypes';
 
-type BroadcastEvent = BrowserTypes.BroadcastEvent
-type AgentResponseMessage = BrowserTypes.AgentResponseMessage
-type ResponseMessageType = BrowserTypes.ResponseMessageType
-type PrivateChannelOnUnsubscribeEvent = BrowserTypes.PrivateChannelOnUnsubscribeEvent
-type PrivateChannelOnDisconnectEvent = BrowserTypes.PrivateChannelOnDisconnectEvent
+type BroadcastEvent = BrowserTypes.BroadcastEvent;
+type PrivateChannelOnUnsubscribeEvent = BrowserTypes.PrivateChannelOnUnsubscribeEvent;
+type PrivateChannelOnDisconnectEvent = BrowserTypes.PrivateChannelOnDisconnectEvent;
 
 const contextMap: Record<string, any> = {
-  "fdc3.instrument": {
-    "type": "fdc3.instrument",
-    "name": "Apple",
-    "id": {
-      "ticker": "AAPL"
-    }
+  'fdc3.instrument': {
+    type: 'fdc3.instrument',
+    name: 'Apple',
+    id: {
+      ticker: 'AAPL',
+    },
   },
-  "fdc3.country": {
-    "type": "fdc3.country",
-    "name": "Sweden",
-    "id": {
-      "COUNTRY_ISOALPHA2": "SE",
-      "COUNTRY_ISOALPHA3": "SWE",
-    }
+  'fdc3.country': {
+    type: 'fdc3.country',
+    name: 'Sweden',
+    id: {
+      COUNTRY_ISOALPHA2: 'SE',
+      COUNTRY_ISOALPHA3: 'SWE',
+    },
   },
-  "fdc3.unsupported": {
-    "type": "fdc3.unsupported",
-    "bogus": true
+  'fdc3.unsupported': {
+    type: 'fdc3.unsupported',
+    bogus: true,
   },
-  "fdc3.cancel-me": {
-    "type": "fdc3.cancel-me"
-  }
-}
+  'fdc3.cancel-me': {
+    type: 'fdc3.cancel-me',
+  },
+};
 
 Given('{string} is a {string} context', function (this: CustomWorld, field: string, type: string) {
   this.props[field] = contextMap[type];
-})
+});
 
-Given('{string} is a BroadcastEvent message on channel {string} with context {string}', function (this: CustomWorld, field: string, channel: string, context: string) {
-  const message = {
-    meta: {
-      ...this.messaging!!.createEventMeta(),
-    },
-    payload: {
-      "channelId": handleResolve(channel, this),
-      "context": contextMap[context]
-    },
-    type: 'broadcastEvent'
-  } as BroadcastEvent
+Given(
+  '{string} is a BroadcastEvent message on channel {string} with context {string}',
+  function (this: CustomWorld, field: string, channel: string, context: string) {
+    const message = {
+      meta: {
+        ...this.messaging!.createEventMeta(),
+      },
+      payload: {
+        channelId: handleResolve(channel, this),
+        context: contextMap[context],
+      },
+      type: 'broadcastEvent',
+    } as BroadcastEvent;
 
-  this.props[field] = message;
-})
-
-Given('{string} is a {string} message on channel {string}', function (this: CustomWorld, field: string, type: string, channel: string) {
-  const message = {
-    meta: this.messaging!!.createEventMeta(),
-    payload: {
-      privateChannelId: handleResolve(channel, this),
-    },
-    type
-  } as PrivateChannelOnDisconnectEvent
-
-  this.props[field] = message;
-})
-
-Given('{string} is a {string} message on channel {string} with listenerType as {string}', function (this: CustomWorld, field: string, type: string, channel: string, listenerType: string) {
-  const message = {
-    meta: this.messaging!!.createMeta(),
-    payload: {
-      "channelId": handleResolve(channel, this),
-      listenerType
-    },
-    type
+    this.props[field] = message;
   }
+);
 
-  this.props[field] = message;
-})
+Given(
+  '{string} is a {string} message on channel {string}',
+  function (this: CustomWorld, field: string, type: string, channel: string) {
+    const message = {
+      meta: this.messaging!.createEventMeta(),
+      payload: {
+        privateChannelId: handleResolve(channel, this),
+      },
+      type,
+    } as PrivateChannelOnDisconnectEvent;
 
-Given('{string} is a channelChangedEvent message on channel {string}', function (this: CustomWorld, field: string, channel: string) {
-  const message = {
-    meta: {
-      eventUuid: this.messaging!!.createUUID(),
-      timestamp: new Date(),
-    },
-    payload: {
-      "newChannelId": handleResolve(channel, this),
-    },
-    type: "channelChangedEvent"
-  } as ChannelChangedEvent
+    this.props[field] = message;
+  }
+);
 
-  this.props[field] = message;
-})
+Given(
+  '{string} is a {string} message on channel {string} with listenerType as {string}',
+  function (this: CustomWorld, field: string, type: string, channel: string, listenerType: string) {
+    const message = {
+      meta: this.messaging!.createMeta(),
+      payload: {
+        channelId: handleResolve(channel, this),
+        listenerType,
+      },
+      type,
+    };
 
-Given('{string} is a PrivateChannelOnUnsubscribeEvent message on channel {string} with contextType as {string}', function (this: CustomWorld, field: string, channel: string, contextType: string) {
-  const message = {
-    meta: this.messaging!!.createEventMeta(),
-    payload: {
-      privateChannelId: handleResolve(channel, this),
-      contextType
-    },
-    type: 'privateChannelOnUnsubscribeEvent'
-  } as PrivateChannelOnUnsubscribeEvent
+    this.props[field] = message;
+  }
+);
 
-  this.props[field] = message;
-})
+Given(
+  '{string} is a channelChangedEvent message on channel {string}',
+  function (this: CustomWorld, field: string, channel: string) {
+    const message = {
+      meta: {
+        eventUuid: this.messaging!.createUUID(),
+        timestamp: new Date(),
+      },
+      payload: {
+        newChannelId: handleResolve(channel, this),
+      },
+      type: 'channelChangedEvent',
+    } as ChannelChangedEvent;
 
-Given('{string} is a PrivateChannelOnAddContextListenerEvent message on channel {string} with contextType as {string}', function (this: CustomWorld, field: string, channel: string, contextType: string) {
-  const message = {
-    meta: this.messaging!!.createEventMeta(),
-    payload: {
-      privateChannelId: handleResolve(channel, this),
-      contextType
-    },
-    type: 'privateChannelOnAddContextListenerEvent'
-  } as PrivateChannelOnAddContextListenerEvent
+    this.props[field] = message;
+  }
+);
 
-  this.props[field] = message;
-})
+Given(
+  '{string} is a PrivateChannelOnUnsubscribeEvent message on channel {string} with contextType as {string}',
+  function (this: CustomWorld, field: string, channel: string, contextType: string) {
+    const message = {
+      meta: this.messaging!.createEventMeta(),
+      payload: {
+        privateChannelId: handleResolve(channel, this),
+        contextType,
+      },
+      type: 'privateChannelOnUnsubscribeEvent',
+    } as PrivateChannelOnUnsubscribeEvent;
 
-Given('{string} is a PrivateChannelOnDisconnectEvent message on channel {string}', function (this: CustomWorld, field: string, channel: string) {
-  const message = {
-    meta: this.messaging!!.createEventMeta(),
-    payload: {
-      privateChannelId: handleResolve(channel, this),
-    },
-    type: 'privateChannelOnDisconnectEvent'
-  } as PrivateChannelOnDisconnectEvent
+    this.props[field] = message;
+  }
+);
 
-  this.props[field] = message;
-})
+Given(
+  '{string} is a PrivateChannelOnAddContextListenerEvent message on channel {string} with contextType as {string}',
+  function (this: CustomWorld, field: string, channel: string, contextType: string) {
+    const message = {
+      meta: this.messaging!.createEventMeta(),
+      payload: {
+        privateChannelId: handleResolve(channel, this),
+        contextType,
+      },
+      type: 'privateChannelOnAddContextListenerEvent',
+    } as PrivateChannelOnAddContextListenerEvent;
+
+    this.props[field] = message;
+  }
+);
+
+Given(
+  '{string} is a PrivateChannelOnDisconnectEvent message on channel {string}',
+  function (this: CustomWorld, field: string, channel: string) {
+    const message = {
+      meta: this.messaging!.createEventMeta(),
+      payload: {
+        privateChannelId: handleResolve(channel, this),
+      },
+      type: 'privateChannelOnDisconnectEvent',
+    } as PrivateChannelOnDisconnectEvent;
+
+    this.props[field] = message;
+  }
+);
 
 Given('{string} pipes types to {string}', function (this: CustomWorld, typeHandlerName: string, field: string) {
-  this.props[field] = []
+  this.props[field] = [];
   this.props[typeHandlerName] = (s?: string) => {
-    this.props[field].push(s)
-  }
-})
+    this.props[field].push(s);
+  };
+});
 
 Given('{string} pipes events to {string}', function (this: CustomWorld, typeHandlerName: string, field: string) {
-  this.props[field] = []
+  this.props[field] = [];
   this.props[typeHandlerName] = (s?: ApiEvent) => {
-    this.props[field].push(s?.details)
-  }
-})
+    this.props[field].push(s?.details);
+  };
+});
 
 Given('{string} pipes context to {string}', function (this: CustomWorld, contextHandlerName: string, field: string) {
-  this.props[field] = []
+  this.props[field] = [];
   this.props[contextHandlerName] = (context: Context) => {
-    this.props[field].push(context)
-  }
-})
-
-When('messaging receives a {string} with payload:', function (this: CustomWorld, type: ResponseMessageType, docString: string) {
-  const message: AgentResponseMessage = {
-    meta: this.messaging!!.createResponseMeta(),
-    payload: JSON.parse(docString),
-    type
-  }
-
-  this.log(`Sending: ${JSON.stringify(message)}`)
-  this.messaging!!.receive(message, this.log);
+    this.props[field].push(context);
+  };
 });
 
 When('messaging receives {string}', function (this: CustomWorld, field: string) {
-  const message = handleResolve(field, this)
-  this.log(`Sending: ${JSON.stringify(message)}`)
+  const message = handleResolve(field, this);
+  this.log(`Sending: ${JSON.stringify(message)}`);
   this.messaging!!.receive(message, this.log);
 });
 
-
 Then('messaging will have posts', function (this: CustomWorld, dt: DataTable) {
   // just take the last few posts and match those
-  const matching = dt.rows().length
-  var toUse = this.messaging?.allPosts!!
+  const matching = dt.rows().length;
+  var toUse = this.messaging?.allPosts!;
   if (toUse.length > matching) {
-    toUse = toUse.slice(toUse.length - matching, toUse.length)
+    toUse = toUse.slice(toUse.length - matching, toUse.length);
   }
-  matchData(this, toUse, dt)
-})
+  matchData(this, toUse, dt);
+});
 
+Given('channel {string} has context {string}', function (this: CustomWorld, channel: string, context: string) {
+  const ctxObject = handleResolve(context, this);
+  const state = this.props[CHANNEL_STATE] ?? {};
+  this.props[CHANNEL_STATE] = state;
 
-Given("channel {string} has context {string}", function (this: CustomWorld, channel: string, context: string) {
-  const ctxObject = handleResolve(context, this)
-  const state = this.props[CHANNEL_STATE] ?? {}
-  this.props[CHANNEL_STATE] = state
-
-  const cs = state[channel] ?? []
-  cs.push(ctxObject)
-  state[channel] = cs
-})
+  const cs = state[channel] ?? [];
+  cs.push(ctxObject);
+  state[channel] = cs;
+});
 
 Given('User Channels one, two and three', function (this: CustomWorld) {
   this.props[CHANNEL_STATE] = {
-    "one": [],
-    "two": [],
-    "three": []
-  }
+    one: [],
+    two: [],
+    three: [],
+  };
 });

--- a/packages/fdc3-schema/code-generation/generate-type-predicates.ts
+++ b/packages/fdc3-schema/code-generation/generate-type-predicates.ts
@@ -1,62 +1,104 @@
-import { InterfaceDeclaration, MethodDeclaration, Project, SyntaxKind } from "ts-morph"
+import { InterfaceDeclaration, KindToNodeMappings, MethodDeclaration, Project, SyntaxKind, TypeAliasDeclaration } from 'ts-morph';
+import print from "message-await"
 
-// open a new project with just BrowserTypes as the only source file 
+// open a new project with just BrowserTypes as the only source file
 const project = new Project();
-const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts");
+const sourceFile = project.addSourceFileAtPath('./generated/api/BrowserTypes.ts');
 
-const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+const APP_REQUEST_MESSAGE = "AppRequestMessage"
+const AGENT_RESPONSE_MESSAGE = "AgentResponseMessage"
+const AGENT_EVENT_MESSAGE = "AgentEventMessage"
 
 /**
  * We generate the union types and remove the existing interfaces first so that we are not left with a generated type predicate for the removed base interface
  */
+writeMessageUnionTypes();
+writeTypePredicates();
 
-// get the types listed in the types union type
-// i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
-const requestMessageUnion = findUnionType("RequestMessageType");
-if(requestMessageUnion != null){
-    // Write a union type of all interfaces that have a type that extends RequestMessageType
-    writeUnionType("AppRequestMessage", requestMessageUnion);
+sourceFile.formatText();
+project.saveSync();
+
+/**
+ * Replaces the existing interfaces AppRequestMessage, AgentResponseMessage and AgentEventMessage with unions of INterfaces instead of a base type
+ */
+function writeMessageUnionTypes() {
+  const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+  writeMessageUnion(APP_REQUEST_MESSAGE, 'RequestMessageType', typeAliases);
+  writeMessageUnion(AGENT_RESPONSE_MESSAGE, 'ResponseMessageType', typeAliases);
+  writeMessageUnion(AGENT_EVENT_MESSAGE, 'EventMessageType', typeAliases);
 }
 
-const responseMessageUnion = findUnionType("ResponseMessageType");
-if(responseMessageUnion != null){
-    writeUnionType("AgentResponseMessage", responseMessageUnion);
-}
+function writeMessageUnion(unionName: string, typeUnionName: string, typeAliases: TypeAliasDeclaration[]){
+  let awaitMessage = print(`Writing ${unionName} (finding types)`, {spinner: true});
 
-const eventMessageUnion = findUnionType("EventMessageType");
-if(eventMessageUnion != null){
-    writeUnionType("AgentEventMessage", eventMessageUnion);
-}
+    // get the types listed in the types union type
+    // i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
+    const requestMessageTypeUnion = findUnionType(typeAliases, typeUnionName);
+    if (requestMessageTypeUnion != null) {
+      //remove existing type alias
+      findExisting(unionName, SyntaxKind.TypeAliasDeclaration).forEach(node => node.remove());
 
-// get a list of all conversion functions in the Convert class
-const convert = sourceFile.getClass("Convert");
-const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(func => func.getReturnType().getText() === "string");
+      awaitMessage.updateMessage(`Writing ${unionName} (writing union)`, true);
 
-
-//get a list of all interfaces in the file
-let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
-
-// generate a list of Interfaces that have an associated conversion function
-const matchedInterfaces = convertFunctions.map(func => {
-    const valueParameter = func.getParameter("value");
-
-    const matchingInterface = messageInterfaces.find(interfaceNode => {
-        return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
-    });
-
-
-    if (matchingInterface != null) {
-        return { func, matchingInterface };
+        // Write a union type of all interfaces that have a type that extends RequestMessageType
+        // i.e. export type AppRequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest;
+        writeUnionType(unionName, requestMessageTypeUnion);
     }
 
-    return undefined;
-}).filter(((value => value != null) as <T>(value: T | null | undefined) => value is T));
+    awaitMessage.complete(true, `Writing ${unionName}`);
+}
 
-// write a type predicate for each matched interface
-matchedInterfaces.forEach(matched => {
-    writePredicate(matched.matchingInterface, matched.func)
-    writeTypeConstant(matched.matchingInterface)
-});
+/**
+ * Writes type predicates for all interfaces found that have a matching convert function
+ */
+function writeTypePredicates(){
+  let awaitMessage = print(`Writing Type Predicates (finding convert functions)`, {spinner: true});
+
+    // get a list of all conversion functions in the Convert class that return a string
+    const convert = sourceFile.getClass('Convert');
+    const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(
+      func => func.getReturnType().getText() === 'string'
+    );
+
+    awaitMessage.updateMessage(`Writing Type Predicates (finding message interfaces)`, true);
+
+    //get a list of all interfaces in the file
+    let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+
+    // generate a list of Interfaces that have an associated conversion function
+    const matchedInterfaces = convertFunctions
+        .map(func => {
+            const valueParameter = func.getParameter('value');
+
+            const matchingInterface = messageInterfaces.find(interfaceNode => {
+                /// Find an interface who's name matches the type passed into the value parameter of the convert function
+                return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
+            });
+
+            if (matchingInterface != null) {
+                return { func, matchingInterface };
+            }
+
+            return undefined; 
+        })
+        .filter(isDefined);
+
+    const allFunctionDeclarations = sourceFile.getChildrenOfKind(SyntaxKind.FunctionDeclaration);
+
+    // write a type predicate for each matched interface
+    matchedInterfaces.forEach((matched, index) => {
+
+      awaitMessage.updateMessage(`Writing Type Predicates (${index}/${matchedInterfaces.length})`, true);
+
+        writeFastPredicate(matched.matchingInterface, allFunctionDeclarations);
+        writeValidPredicate(matched.matchingInterface, matched.func, allFunctionDeclarations);
+        writeTypeConstant(matched.matchingInterface);
+    });
+
+    awaitMessage.complete(true, `Writing Type Predicates`);
+}
 
 
 /**
@@ -64,40 +106,53 @@ matchedInterfaces.forEach(matched => {
  * export type NAME = "stringOne" | "stringTwo" | "stringThree";
  * and returns the string values
  * if the union type is not found returns undefined
+ * @param name
+ * @returns
+ */
+function findUnionType(typeAliases: TypeAliasDeclaration[], name: string): string[] | undefined {
+  const typeAlias = typeAliases.find(alias => {
+    const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
+
+    return identifiers[0].getText() === name;
+  });
+
+  return typeAlias
+    ?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
+    .getDescendantsOfKind(SyntaxKind.StringLiteral)
+    .map(literal => literal.getLiteralText());
+}
+
+/**
+ * Finds an existing declaration with the given type and name
  * @param name 
+ * @param kind 
  * @returns 
  */
-function findUnionType(name: string): string[] | undefined {
-    const typeAlias = typeAliases.find(alias => {
-        const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
-    
-        return identifiers[0].getText() === name;
-    
-    });
+function findExisting<T extends SyntaxKind>(name: string, kind: T, allDeclarationsOfType?: KindToNodeMappings[T][]) {
+  allDeclarationsOfType = allDeclarationsOfType ?? sourceFile.getChildrenOfKind(kind);
 
-    return typeAlias?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
-        .getDescendantsOfKind(SyntaxKind.StringLiteral)
-        .map(literal => literal.getLiteralText());
+  return sourceFile.getChildrenOfKind(kind).filter(child => {
+    const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
+
+    return identifier?.getText() === name;
+  });
 }
 
+/**
+ * Writes a type predicate for the given interface using the Convert method declaration
+ * @param matchingInterface 
+ * @param func 
+ */
+function writeValidPredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration, allFunctionDeclarations: KindToNodeMappings[SyntaxKind.FunctionDeclaration][]): void {
+  const predicateName = `isValid${matchingInterface.getName()}`;
 
+  // remove existing instances
+  findExisting(predicateName, SyntaxKind.FunctionDeclaration, allFunctionDeclarations).forEach(node => node.remove());
 
-
-function findExisting<T extends SyntaxKind>(name: string, kind: T) {
-    return sourceFile.getChildrenOfKind(kind).filter(child => {
-        const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
-
-        return identifier?.getText() === name;
-    })
-}
-
-function writePredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration): void {
-    const predicateName = `is${matchingInterface.getName()}`;
-
-    // remove existing instances
-    findExisting(predicateName, SyntaxKind.FunctionDeclaration).forEach(node => node.remove());
-
-    sourceFile.addStatements(`
+  sourceFile.addStatements(`
+/**
+ * Returns true if value is a valid ${matchingInterface.getName()}. This checks the type against the json schema for the message and will be slower
+ */ 
 export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
     try{
         Convert.${func.getName()}(value);
@@ -108,54 +163,100 @@ export function ${predicateName}(value: any): value is ${matchingInterface.getNa
 }`);
 }
 
+/**
+ * Writes a type predicate for the given interface checking just the value of the type property
+ * @param matchingInterface 
+ * @param func 
+ */
+function writeFastPredicate(matchingInterface: InterfaceDeclaration, allFunctionDeclarations: KindToNodeMappings[SyntaxKind.FunctionDeclaration][]): void {
+    const predicateName = `is${matchingInterface.getName()}`;
+  
+    // remove existing instances
+    findExisting(predicateName, SyntaxKind.FunctionDeclaration, allFunctionDeclarations).forEach(node => node.remove());
+  
+    const typePropertyValue = extractTypePropertyValue(matchingInterface);
 
-function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
-
-    const constantName = `${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE`;
-
-    //remove existing
-    findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+    if(typePropertyValue == null){
+        return;
+    }
 
     sourceFile.addStatements(`
-        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";`);
+/**
+ * Returns true if the value has a type property with value '${typePropertyValue}'. This is a fast check that does not check the format of the message
+ */ 
+export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
+    return value != null && value.type === '${typePropertyValue}';
+}`);
+  }
 
+function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
+  const constantName = `${matchingInterface
+    .getName()
+    .replaceAll(/([A-Z])/g, '_$1')
+    .toUpperCase()
+    .substring(1)}_TYPE`;
+
+  //remove existing
+  findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+
+  sourceFile.addStatements(`
+        export const ${matchingInterface
+          .getName()
+          .replaceAll(/([A-Z])/g, '_$1')
+          .toUpperCase()
+          .substring(1)}_TYPE = "${matchingInterface.getName()}";`);
 }
 
 /**
  * Writes a union type of all the interfaces that have a type property that extends the type values passed in.
  * For example:
  * export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest ...
- * @param unionName 
- * @param interfaces 
- * @param typeValues 
+ * @param unionName
+ * @param interfaces
+ * @param typeValues
  */
 function writeUnionType(unionName: string, typeValues: string[]): void {
-    // generate interfaces list again as we may have just removed some
-    const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+  // generate interfaces list again as we may have just removed some
+  const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
 
-    // look for interfaces that have a type property that extends one of the values in typeValues
-    const matchingInterfaces = unionInterfaces.filter(currentInterface => {
-        const typeProperty = currentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
-            return propertySignature.getChildrenOfKind(SyntaxKind.Identifier).find(identifier => identifier.getText() === "type") != null;
-        })[0];
+  // look for interfaces that have a type property that extends one of the values in typeValues
+  const matchingInterfaces = unionInterfaces.filter(currentInterface => {
+    const typePropertyValue = extractTypePropertyValue(currentInterface);
 
-        if(typeProperty == null){
-            return false;
-        }
+    return typeValues.some(typeValue => typeValue === typePropertyValue);
+  });
 
-        const stringLiterals = typeProperty.getDescendantsOfKind(SyntaxKind.StringLiteral)
-            .map(literal => literal.getLiteralText());
+  //remove existing Type
+  findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
 
-        return stringLiterals.some(literal => typeValues.some(typeValue => typeValue === literal));
-    })
-    
-    //remove existing Type
-    findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
-
-    sourceFile.addStatements(`
-    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(" | ")}; `);
+  sourceFile.addStatements(`
+    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(' | ')}; `);
 }
 
-sourceFile.formatText();
+/**
+ * Extract the type string constant from an interface such as
+ * interface ExampleMessage{
+ *     type: "stringConstant";
+ * }
+ * @param parentInterface 
+ * @returns 
+ */
+function extractTypePropertyValue(parentInterface: InterfaceDeclaration): string | undefined{
+    const typeProperty = parentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
+        return (
+          propertySignature
+            .getChildrenOfKind(SyntaxKind.Identifier)
+            .find(identifier => identifier.getText() === 'type') != null
+        );
+      })[0];
 
-project.saveSync();
+    return typeProperty?.getDescendantsOfKind(SyntaxKind.StringLiteral)
+        .map(literal => literal.getLiteralText())[0];
+}
+
+/**
+ * Type predicate to test that value is defined
+ */
+function isDefined<T>(value: T | null | undefined): value is T{
+    return value != null;
+}

--- a/packages/fdc3-schema/code-generation/generate-type-predicates.ts
+++ b/packages/fdc3-schema/code-generation/generate-type-predicates.ts
@@ -2,20 +2,45 @@ import { InterfaceDeclaration, MethodDeclaration, Project, SyntaxKind } from "ts
 
 // open a new project with just BrowserTypes as the only source file 
 const project = new Project();
-const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts")
+const sourceFile = project.addSourceFileAtPath("./generated/api/BrowserTypes.ts");
 
-//get a list of all interfaces in the file
-const interfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+const typeAliases = sourceFile.getChildrenOfKind(SyntaxKind.TypeAliasDeclaration);
+
+/**
+ * We generate the union types and remove the existing interfaces first so that we are not left with a generated type predicate for the removed base interface
+ */
+
+// get the types listed in the types union type
+// i.e. look for: export type RequestMessageType = "addContextListenerRequest" | "whatever"
+const requestMessageUnion = findUnionType("RequestMessageType");
+if(requestMessageUnion != null){
+    // Write a union type of all interfaces that have a type that extends RequestMessageType
+    writeUnionType("AppRequestMessage", requestMessageUnion);
+}
+
+const responseMessageUnion = findUnionType("ResponseMessageType");
+if(responseMessageUnion != null){
+    writeUnionType("AgentResponseMessage", responseMessageUnion);
+}
+
+const eventMessageUnion = findUnionType("EventMessageType");
+if(eventMessageUnion != null){
+    writeUnionType("AgentEventMessage", eventMessageUnion);
+}
 
 // get a list of all conversion functions in the Convert class
 const convert = sourceFile.getClass("Convert");
 const convertFunctions = (convert?.getChildrenOfKind(SyntaxKind.MethodDeclaration) ?? []).filter(func => func.getReturnType().getText() === "string");
 
+
+//get a list of all interfaces in the file
+let messageInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
+
 // generate a list of Interfaces that have an associated conversion function
 const matchedInterfaces = convertFunctions.map(func => {
     const valueParameter = func.getParameter("value");
 
-    const matchingInterface = interfaces.find(interfaceNode => {
+    const matchingInterface = messageInterfaces.find(interfaceNode => {
         return valueParameter?.getType().getText(valueParameter) === interfaceNode.getName();
     });
 
@@ -33,12 +58,44 @@ matchedInterfaces.forEach(matched => {
     writeTypeConstant(matched.matchingInterface)
 });
 
-writeUnionType("RequestMessage", interfaces, "Request");
-writeUnionType("ResponseMessage", interfaces, "Response");
-writeUnionType("EventMessage", interfaces, "Event");
+
+/**
+ * Looks for a string union type in the form:
+ * export type NAME = "stringOne" | "stringTwo" | "stringThree";
+ * and returns the string values
+ * if the union type is not found returns undefined
+ * @param name 
+ * @returns 
+ */
+function findUnionType(name: string): string[] | undefined {
+    const typeAlias = typeAliases.find(alias => {
+        const identifiers = alias.getChildrenOfKind(SyntaxKind.Identifier);
+    
+        return identifiers[0].getText() === name;
+    
+    });
+
+    return typeAlias?.getChildrenOfKind(SyntaxKind.UnionType)?.[0]
+        .getDescendantsOfKind(SyntaxKind.StringLiteral)
+        .map(literal => literal.getLiteralText());
+}
+
+
+
+
+function findExisting<T extends SyntaxKind>(name: string, kind: T) {
+    return sourceFile.getChildrenOfKind(kind).filter(child => {
+        const identifier = child.getDescendantsOfKind(SyntaxKind.Identifier)[0];
+
+        return identifier?.getText() === name;
+    })
+}
 
 function writePredicate(matchingInterface: InterfaceDeclaration, func: MethodDeclaration): void {
     const predicateName = `is${matchingInterface.getName()}`;
+
+    // remove existing instances
+    findExisting(predicateName, SyntaxKind.FunctionDeclaration).forEach(node => node.remove());
 
     sourceFile.addStatements(`
 export function ${predicateName}(value: any): value is ${matchingInterface.getName()} {
@@ -51,22 +108,52 @@ export function ${predicateName}(value: any): value is ${matchingInterface.getNa
 }`);
 }
 
+
 function writeTypeConstant(matchingInterface: InterfaceDeclaration): void {
 
+    const constantName = `${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE`;
+
+    //remove existing
+    findExisting(constantName, SyntaxKind.VariableStatement).forEach(node => node.remove());
+
     sourceFile.addStatements(`
-        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";
-    `);
+        export const ${matchingInterface.getName().replaceAll(/([A-Z])/g, '_$1').toUpperCase().substring(1)}_TYPE = "${matchingInterface.getName()}";`);
 
 }
 
+/**
+ * Writes a union type of all the interfaces that have a type property that extends the type values passed in.
+ * For example:
+ * export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest ...
+ * @param unionName 
+ * @param interfaces 
+ * @param typeValues 
+ */
+function writeUnionType(unionName: string, typeValues: string[]): void {
+    // generate interfaces list again as we may have just removed some
+    const unionInterfaces = sourceFile.getChildrenOfKind(SyntaxKind.InterfaceDeclaration);
 
-function writeUnionType(unionName: string, interfaces: InterfaceDeclaration[], nameEndsWith: string): void {
-    const matchingInterfaces = interfaces
-        .map(currentInterface => currentInterface.getName())
-        .filter(interfaceName => interfaceName.length > nameEndsWith.length && interfaceName.indexOf(nameEndsWith) === interfaceName.length - nameEndsWith.length);
+    // look for interfaces that have a type property that extends one of the values in typeValues
+    const matchingInterfaces = unionInterfaces.filter(currentInterface => {
+        const typeProperty = currentInterface.getChildrenOfKind(SyntaxKind.PropertySignature).filter(propertySignature => {
+            return propertySignature.getChildrenOfKind(SyntaxKind.Identifier).find(identifier => identifier.getText() === "type") != null;
+        })[0];
+
+        if(typeProperty == null){
+            return false;
+        }
+
+        const stringLiterals = typeProperty.getDescendantsOfKind(SyntaxKind.StringLiteral)
+            .map(literal => literal.getLiteralText());
+
+        return stringLiterals.some(literal => typeValues.some(typeValue => typeValue === literal));
+    })
+    
+    //remove existing Type
+    findExisting(unionName, SyntaxKind.InterfaceDeclaration).forEach(node => node.remove());
 
     sourceFile.addStatements(`
-    export type ${unionName} = ${matchingInterfaces.join(" | ")}; `);
+    export type ${unionName} = ${matchingInterfaces.map(match => match.getName()).join(" | ")}; `);
 }
 
 sourceFile.formatText();

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -958,30 +958,6 @@ export interface AddIntentListenerResponsePayload {
 export type FluffyError = "MalformedContext" | "DesktopAgentNotFound" | "ResolverUnavailable" | "IntentDeliveryFailed" | "NoAppsFound" | "ResolverTimeout" | "TargetAppUnavailable" | "TargetInstanceUnavailable" | "UserCancelledResolution";
 
 /**
- * Identifies the type of the message and it is typically set to the FDC3 function name that
- * the message relates to, e.g. 'findIntent', with 'Response' appended.
- */
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app representing an event.
- */
-export interface AgentEventMessage {
-    /**
-     * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
-     */
-    meta: AgentEventMessageMeta;
-    /**
-     * The message payload contains details of the event that the app is being notified about.
-     */
-    payload: { [key: string]: any };
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Response' appended.
-     */
-    type: EventMessageType;
-}
-
-/**
  * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
  */
 export interface AgentEventMessageMeta {
@@ -994,28 +970,6 @@ export interface AgentEventMessageMeta {
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
 export type EventMessageType = "addEventListenerEvent" | "broadcastEvent" | "channelChangedEvent" | "heartbeatEvent" | "intentEvent" | "privateChannelOnAddContextListenerEvent" | "privateChannelOnDisconnectEvent" | "privateChannelOnUnsubscribeEvent";
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app responding to an API call. If the
- * payload contains an `error` property, the request was unsuccessful.
- */
-export interface AgentResponseMessage {
-    /**
-     * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
-     */
-    meta: AgentResponseMessageMeta;
-    /**
-     * A payload for a response to an API call that will contain any return values or an `error`
-     * property containing a standardized error message indicating that the request was
-     * unsuccessful.
-     */
-    payload: AgentResponseMessageResponsePayload;
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Response' appended.
-     */
-    type: ResponseMessageType;
-}
 
 /**
  * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
@@ -1046,25 +1000,6 @@ export interface AgentResponseMessageResponsePayload {
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
 export type ResponseMessageType = "addContextListenerResponse" | "addEventListenerResponse" | "addIntentListenerResponse" | "broadcastResponse" | "contextListenerUnsubscribeResponse" | "createPrivateChannelResponse" | "eventListenerUnsubscribeResponse" | "findInstancesResponse" | "findIntentResponse" | "findIntentsByContextResponse" | "getAppMetadataResponse" | "getCurrentChannelResponse" | "getCurrentContextResponse" | "getInfoResponse" | "getOrCreateChannelResponse" | "getUserChannelsResponse" | "intentListenerUnsubscribeResponse" | "intentResultResponse" | "joinUserChannelResponse" | "leaveCurrentChannelResponse" | "openResponse" | "privateChannelAddEventListenerResponse" | "privateChannelDisconnectResponse" | "privateChannelUnsubscribeEventListenerResponse" | "raiseIntentForContextResponse" | "raiseIntentResponse" | "raiseIntentResultResponse";
-
-/**
- * A request message from an FDC3-enabled app to a Desktop Agent.
- */
-export interface AppRequestMessage {
-    /**
-     * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
-     */
-    meta: AppRequestMessageMeta;
-    /**
-     * The message payload typically contains the arguments to FDC3 API functions.
-     */
-    payload: { [key: string]: any };
-    /**
-     * Identifies the type of the message and it is typically set to the FDC3 function name that
-     * the message relates to, e.g. 'findIntent', with 'Request' appended.
-     */
-    type: RequestMessageType;
-}
 
 /**
  * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
@@ -5857,8 +5792,23 @@ const typeMap: any = {
         "raiseIntentResultResponse",
     ],
 };
+export type AppRequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest | BroadcastRequest | ContextListenerUnsubscribeRequest | CreatePrivateChannelRequest | EventListenerUnsubscribeRequest | FindInstancesRequest | FindIntentRequest | FindIntentsByContextRequest | GetAppMetadataRequest | GetCurrentChannelRequest | GetCurrentContextRequest | GetInfoRequest | GetOrCreateChannelRequest | GetUserChannelsRequest | HeartbeatAcknowledgementRequest | IntentListenerUnsubscribeRequest | IntentResultRequest | JoinUserChannelRequest | LeaveCurrentChannelRequest | OpenRequest | PrivateChannelAddEventListenerRequest | PrivateChannelDisconnectRequest | PrivateChannelUnsubscribeEventListenerRequest | RaiseIntentForContextRequest | RaiseIntentRequest;
 
+export type AgentResponseMessage = AddContextListenerResponse | AddEventListenerResponse | AddIntentListenerResponse | BroadcastResponse | ContextListenerUnsubscribeResponse | CreatePrivateChannelResponse | EventListenerUnsubscribeResponse | FindInstancesResponse | FindIntentResponse | FindIntentsByContextResponse | GetAppMetadataResponse | GetCurrentChannelResponse | GetCurrentContextResponse | GetInfoResponse | GetOrCreateChannelResponse | GetUserChannelsResponse | IntentListenerUnsubscribeResponse | IntentResultResponse | JoinUserChannelResponse | LeaveCurrentChannelResponse | OpenResponse | PrivateChannelAddEventListenerResponse | PrivateChannelDisconnectResponse | PrivateChannelUnsubscribeEventListenerResponse | RaiseIntentForContextResponse | RaiseIntentResponse | RaiseIntentResultResponse;
+
+export type AgentEventMessage = BroadcastEvent | ChannelChangedEvent | HeartbeatEvent | IntentEvent | PrivateChannelOnAddContextListenerEvent | PrivateChannelOnDisconnectEvent | PrivateChannelOnUnsubscribeEvent;
+
+/**
+ * Returns true if the value has a type property with value 'WCP1Hello'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+    return value != null && value.type === 'WCP1Hello';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol1Hello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
     try {
         Convert.webConnectionProtocol1HelloToJson(value);
         return true;
@@ -5869,7 +5819,17 @@ export function isWebConnectionProtocol1Hello(value: any): value is WebConnectio
 
 export const WEB_CONNECTION_PROTOCOL1_HELLO_TYPE = "WebConnectionProtocol1Hello";
 
+/**
+ * Returns true if the value has a type property with value 'WCP2LoadUrl'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+    return value != null && value.type === 'WCP2LoadUrl';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol2LoadURL. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
     try {
         Convert.webConnectionProtocol2LoadURLToJson(value);
         return true;
@@ -5880,7 +5840,17 @@ export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnect
 
 export const WEB_CONNECTION_PROTOCOL2_LOAD_U_R_L_TYPE = "WebConnectionProtocol2LoadURL";
 
+/**
+ * Returns true if the value has a type property with value 'WCP3Handshake'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+    return value != null && value.type === 'WCP3Handshake';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol3Handshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
     try {
         Convert.webConnectionProtocol3HandshakeToJson(value);
         return true;
@@ -5891,7 +5861,17 @@ export function isWebConnectionProtocol3Handshake(value: any): value is WebConne
 
 export const WEB_CONNECTION_PROTOCOL3_HANDSHAKE_TYPE = "WebConnectionProtocol3Handshake";
 
+/**
+ * Returns true if the value has a type property with value 'WCP4ValidateAppIdentity'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
+    return value != null && value.type === 'WCP4ValidateAppIdentity';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol4ValidateAppIdentity. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
     try {
         Convert.webConnectionProtocol4ValidateAppIdentityToJson(value);
         return true;
@@ -5902,7 +5882,17 @@ export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value i
 
 export const WEB_CONNECTION_PROTOCOL4_VALIDATE_APP_IDENTITY_TYPE = "WebConnectionProtocol4ValidateAppIdentity";
 
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityFailedResponse'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityFailedResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentityFailedResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
     try {
         Convert.webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value);
         return true;
@@ -5913,7 +5903,17 @@ export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value:
 
 export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_FAILED_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentityFailedResponse";
 
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityResponse'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentitySuccessResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
     try {
         Convert.webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value);
         return true;
@@ -5924,7 +5924,17 @@ export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value
 
 export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_SUCCESS_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentitySuccessResponse";
 
+/**
+ * Returns true if the value has a type property with value 'WCP6Goodbye'. This is a fast check that does not check the format of the message
+ */
 export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+    return value != null && value.type === 'WCP6Goodbye';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol6Goodbye. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
     try {
         Convert.webConnectionProtocol6GoodbyeToJson(value);
         return true;
@@ -5935,7 +5945,10 @@ export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnect
 
 export const WEB_CONNECTION_PROTOCOL6_GOODBYE_TYPE = "WebConnectionProtocol6Goodbye";
 
-export function isWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
+/**
+ * Returns true if value is a valid WebConnectionProtocolMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
     try {
         Convert.webConnectionProtocolMessageToJson(value);
         return true;
@@ -5946,7 +5959,17 @@ export function isWebConnectionProtocolMessage(value: any): value is WebConnecti
 
 export const WEB_CONNECTION_PROTOCOL_MESSAGE_TYPE = "WebConnectionProtocolMessage";
 
+/**
+ * Returns true if the value has a type property with value 'addContextListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddContextListenerRequest(value: any): value is AddContextListenerRequest {
+    return value != null && value.type === 'addContextListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerRequest(value: any): value is AddContextListenerRequest {
     try {
         Convert.addContextListenerRequestToJson(value);
         return true;
@@ -5957,7 +5980,17 @@ export function isAddContextListenerRequest(value: any): value is AddContextList
 
 export const ADD_CONTEXT_LISTENER_REQUEST_TYPE = "AddContextListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addContextListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddContextListenerResponse(value: any): value is AddContextListenerResponse {
+    return value != null && value.type === 'addContextListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerResponse(value: any): value is AddContextListenerResponse {
     try {
         Convert.addContextListenerResponseToJson(value);
         return true;
@@ -5968,7 +6001,17 @@ export function isAddContextListenerResponse(value: any): value is AddContextLis
 
 export const ADD_CONTEXT_LISTENER_RESPONSE_TYPE = "AddContextListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'addEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddEventListenerRequest(value: any): value is AddEventListenerRequest {
+    return value != null && value.type === 'addEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerRequest(value: any): value is AddEventListenerRequest {
     try {
         Convert.addEventListenerRequestToJson(value);
         return true;
@@ -5979,7 +6022,17 @@ export function isAddEventListenerRequest(value: any): value is AddEventListener
 
 export const ADD_EVENT_LISTENER_REQUEST_TYPE = "AddEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddEventListenerResponse(value: any): value is AddEventListenerResponse {
+    return value != null && value.type === 'addEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerResponse(value: any): value is AddEventListenerResponse {
     try {
         Convert.addEventListenerResponseToJson(value);
         return true;
@@ -5990,7 +6043,17 @@ export function isAddEventListenerResponse(value: any): value is AddEventListene
 
 export const ADD_EVENT_LISTENER_RESPONSE_TYPE = "AddEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
+    return value != null && value.type === 'addIntentListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
     try {
         Convert.addIntentListenerRequestToJson(value);
         return true;
@@ -6001,7 +6064,17 @@ export function isAddIntentListenerRequest(value: any): value is AddIntentListen
 
 export const ADD_INTENT_LISTENER_REQUEST_TYPE = "AddIntentListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
+    return value != null && value.type === 'addIntentListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
     try {
         Convert.addIntentListenerResponseToJson(value);
         return true;
@@ -6012,40 +6085,17 @@ export function isAddIntentListenerResponse(value: any): value is AddIntentListe
 
 export const ADD_INTENT_LISTENER_RESPONSE_TYPE = "AddIntentListenerResponse";
 
-export function isAgentEventMessage(value: any): value is AgentEventMessage {
-    try {
-        Convert.agentEventMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const AGENT_EVENT_MESSAGE_TYPE = "AgentEventMessage";
-
-export function isAgentResponseMessage(value: any): value is AgentResponseMessage {
-    try {
-        Convert.agentResponseMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const AGENT_RESPONSE_MESSAGE_TYPE = "AgentResponseMessage";
-
-export function isAppRequestMessage(value: any): value is AppRequestMessage {
-    try {
-        Convert.appRequestMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const APP_REQUEST_MESSAGE_TYPE = "AppRequestMessage";
-
+/**
+ * Returns true if the value has a type property with value 'broadcastEvent'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastEvent(value: any): value is BroadcastEvent {
+    return value != null && value.type === 'broadcastEvent';
+}
+
+/**
+ * Returns true if value is a valid BroadcastEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastEvent(value: any): value is BroadcastEvent {
     try {
         Convert.broadcastEventToJson(value);
         return true;
@@ -6056,7 +6106,17 @@ export function isBroadcastEvent(value: any): value is BroadcastEvent {
 
 export const BROADCAST_EVENT_TYPE = "BroadcastEvent";
 
+/**
+ * Returns true if the value has a type property with value 'broadcastRequest'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastRequest(value: any): value is BroadcastRequest {
+    return value != null && value.type === 'broadcastRequest';
+}
+
+/**
+ * Returns true if value is a valid BroadcastRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastRequest(value: any): value is BroadcastRequest {
     try {
         Convert.broadcastRequestToJson(value);
         return true;
@@ -6067,7 +6127,17 @@ export function isBroadcastRequest(value: any): value is BroadcastRequest {
 
 export const BROADCAST_REQUEST_TYPE = "BroadcastRequest";
 
+/**
+ * Returns true if the value has a type property with value 'broadcastResponse'. This is a fast check that does not check the format of the message
+ */
 export function isBroadcastResponse(value: any): value is BroadcastResponse {
+    return value != null && value.type === 'broadcastResponse';
+}
+
+/**
+ * Returns true if value is a valid BroadcastResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastResponse(value: any): value is BroadcastResponse {
     try {
         Convert.broadcastResponseToJson(value);
         return true;
@@ -6078,7 +6148,17 @@ export function isBroadcastResponse(value: any): value is BroadcastResponse {
 
 export const BROADCAST_RESPONSE_TYPE = "BroadcastResponse";
 
+/**
+ * Returns true if the value has a type property with value 'channelChangedEvent'. This is a fast check that does not check the format of the message
+ */
 export function isChannelChangedEvent(value: any): value is ChannelChangedEvent {
+    return value != null && value.type === 'channelChangedEvent';
+}
+
+/**
+ * Returns true if value is a valid ChannelChangedEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidChannelChangedEvent(value: any): value is ChannelChangedEvent {
     try {
         Convert.channelChangedEventToJson(value);
         return true;
@@ -6089,7 +6169,17 @@ export function isChannelChangedEvent(value: any): value is ChannelChangedEvent 
 
 export const CHANNEL_CHANGED_EVENT_TYPE = "ChannelChangedEvent";
 
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
+    return value != null && value.type === 'contextListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
     try {
         Convert.contextListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6100,7 +6190,17 @@ export function isContextListenerUnsubscribeRequest(value: any): value is Contex
 
 export const CONTEXT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "ContextListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
+    return value != null && value.type === 'contextListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
     try {
         Convert.contextListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6111,7 +6211,17 @@ export function isContextListenerUnsubscribeResponse(value: any): value is Conte
 
 export const CONTEXT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "ContextListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
+    return value != null && value.type === 'createPrivateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
     try {
         Convert.createPrivateChannelRequestToJson(value);
         return true;
@@ -6122,7 +6232,17 @@ export function isCreatePrivateChannelRequest(value: any): value is CreatePrivat
 
 export const CREATE_PRIVATE_CHANNEL_REQUEST_TYPE = "CreatePrivateChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
+    return value != null && value.type === 'createPrivateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
     try {
         Convert.createPrivateChannelResponseToJson(value);
         return true;
@@ -6133,7 +6253,17 @@ export function isCreatePrivateChannelResponse(value: any): value is CreatePriva
 
 export const CREATE_PRIVATE_CHANNEL_RESPONSE_TYPE = "CreatePrivateChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
+    return value != null && value.type === 'eventListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
     try {
         Convert.eventListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6144,7 +6274,17 @@ export function isEventListenerUnsubscribeRequest(value: any): value is EventLis
 
 export const EVENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "EventListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
+    return value != null && value.type === 'eventListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
     try {
         Convert.eventListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6155,7 +6295,17 @@ export function isEventListenerUnsubscribeResponse(value: any): value is EventLi
 
 export const EVENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "EventListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannelSelected'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+    return value != null && value.type === 'Fdc3UserInterfaceChannelSelected';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannelSelected. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
     try {
         Convert.fdc3UserInterfaceChannelSelectedToJson(value);
         return true;
@@ -6166,7 +6316,17 @@ export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3Use
 
 export const FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE = "Fdc3UserInterfaceChannelSelected";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannels'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
+    return value != null && value.type === 'Fdc3UserInterfaceChannels';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannels. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
     try {
         Convert.fdc3UserInterfaceChannelsToJson(value);
         return true;
@@ -6177,7 +6337,17 @@ export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterf
 
 export const FDC3_USER_INTERFACE_CHANNELS_TYPE = "Fdc3UserInterfaceChannels";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceDrag'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
+    return value != null && value.type === 'Fdc3UserInterfaceDrag';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceDrag. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
     try {
         Convert.fdc3UserInterfaceDragToJson(value);
         return true;
@@ -6188,7 +6358,17 @@ export function isFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceD
 
 export const FDC3_USER_INTERFACE_DRAG_TYPE = "Fdc3UserInterfaceDrag";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHandshake'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
+    return value != null && value.type === 'Fdc3UserInterfaceHandshake';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHandshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
     try {
         Convert.fdc3UserInterfaceHandshakeToJson(value);
         return true;
@@ -6199,7 +6379,17 @@ export function isFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInter
 
 export const FDC3_USER_INTERFACE_HANDSHAKE_TYPE = "Fdc3UserInterfaceHandshake";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHello'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
+    return value != null && value.type === 'Fdc3UserInterfaceHello';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
     try {
         Convert.fdc3UserInterfaceHelloToJson(value);
         return true;
@@ -6210,7 +6400,10 @@ export function isFdc3UserInterfaceHello(value: any): value is Fdc3UserInterface
 
 export const FDC3_USER_INTERFACE_HELLO_TYPE = "Fdc3UserInterfaceHello";
 
-export function isFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfaceMessage {
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfaceMessage {
     try {
         Convert.fdc3UserInterfaceMessageToJson(value);
         return true;
@@ -6221,7 +6414,17 @@ export function isFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_MESSAGE_TYPE = "Fdc3UserInterfaceMessage";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolve'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
+    return value != null && value.type === 'Fdc3UserInterfaceResolve';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolve. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
     try {
         Convert.fdc3UserInterfaceResolveToJson(value);
         return true;
@@ -6232,7 +6435,17 @@ export function isFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_RESOLVE_TYPE = "Fdc3UserInterfaceResolve";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolveAction'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
+    return value != null && value.type === 'Fdc3UserInterfaceResolveAction';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolveAction. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
     try {
         Convert.fdc3UserInterfaceResolveActionToJson(value);
         return true;
@@ -6243,7 +6456,17 @@ export function isFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserI
 
 export const FDC3_USER_INTERFACE_RESOLVE_ACTION_TYPE = "Fdc3UserInterfaceResolveAction";
 
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceRestyle'. This is a fast check that does not check the format of the message
+ */
 export function isFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
+    return value != null && value.type === 'Fdc3UserInterfaceRestyle';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceRestyle. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
     try {
         Convert.fdc3UserInterfaceRestyleToJson(value);
         return true;
@@ -6254,7 +6477,17 @@ export function isFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfa
 
 export const FDC3_USER_INTERFACE_RESTYLE_TYPE = "Fdc3UserInterfaceRestyle";
 
+/**
+ * Returns true if the value has a type property with value 'findInstancesRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindInstancesRequest(value: any): value is FindInstancesRequest {
+    return value != null && value.type === 'findInstancesRequest';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesRequest(value: any): value is FindInstancesRequest {
     try {
         Convert.findInstancesRequestToJson(value);
         return true;
@@ -6265,7 +6498,17 @@ export function isFindInstancesRequest(value: any): value is FindInstancesReques
 
 export const FIND_INSTANCES_REQUEST_TYPE = "FindInstancesRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findInstancesResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindInstancesResponse(value: any): value is FindInstancesResponse {
+    return value != null && value.type === 'findInstancesResponse';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesResponse(value: any): value is FindInstancesResponse {
     try {
         Convert.findInstancesResponseToJson(value);
         return true;
@@ -6276,7 +6519,17 @@ export function isFindInstancesResponse(value: any): value is FindInstancesRespo
 
 export const FIND_INSTANCES_RESPONSE_TYPE = "FindInstancesResponse";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentRequest(value: any): value is FindIntentRequest {
+    return value != null && value.type === 'findIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentRequest(value: any): value is FindIntentRequest {
     try {
         Convert.findIntentRequestToJson(value);
         return true;
@@ -6287,7 +6540,17 @@ export function isFindIntentRequest(value: any): value is FindIntentRequest {
 
 export const FIND_INTENT_REQUEST_TYPE = "FindIntentRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentResponse(value: any): value is FindIntentResponse {
+    return value != null && value.type === 'findIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentResponse(value: any): value is FindIntentResponse {
     try {
         Convert.findIntentResponseToJson(value);
         return true;
@@ -6298,7 +6561,17 @@ export function isFindIntentResponse(value: any): value is FindIntentResponse {
 
 export const FIND_INTENT_RESPONSE_TYPE = "FindIntentResponse";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
+    return value != null && value.type === 'findIntentsByContextRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
     try {
         Convert.findIntentsByContextRequestToJson(value);
         return true;
@@ -6309,7 +6582,17 @@ export function isFindIntentsByContextRequest(value: any): value is FindIntentsB
 
 export const FIND_INTENTS_BY_CONTEXT_REQUEST_TYPE = "FindIntentsByContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
+    return value != null && value.type === 'findIntentsByContextResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
     try {
         Convert.findIntentsByContextResponseToJson(value);
         return true;
@@ -6320,7 +6603,17 @@ export function isFindIntentsByContextResponse(value: any): value is FindIntents
 
 export const FIND_INTENTS_BY_CONTEXT_RESPONSE_TYPE = "FindIntentsByContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
+    return value != null && value.type === 'getAppMetadataRequest';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
     try {
         Convert.getAppMetadataRequestToJson(value);
         return true;
@@ -6331,7 +6624,17 @@ export function isGetAppMetadataRequest(value: any): value is GetAppMetadataRequ
 
 export const GET_APP_METADATA_REQUEST_TYPE = "GetAppMetadataRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
+    return value != null && value.type === 'getAppMetadataResponse';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
     try {
         Convert.getAppMetadataResponseToJson(value);
         return true;
@@ -6342,7 +6645,17 @@ export function isGetAppMetadataResponse(value: any): value is GetAppMetadataRes
 
 export const GET_APP_METADATA_RESPONSE_TYPE = "GetAppMetadataResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
+    return value != null && value.type === 'getCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
     try {
         Convert.getCurrentChannelRequestToJson(value);
         return true;
@@ -6353,7 +6666,17 @@ export function isGetCurrentChannelRequest(value: any): value is GetCurrentChann
 
 export const GET_CURRENT_CHANNEL_REQUEST_TYPE = "GetCurrentChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
+    return value != null && value.type === 'getCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
     try {
         Convert.getCurrentChannelResponseToJson(value);
         return true;
@@ -6364,7 +6687,17 @@ export function isGetCurrentChannelResponse(value: any): value is GetCurrentChan
 
 export const GET_CURRENT_CHANNEL_RESPONSE_TYPE = "GetCurrentChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
+    return value != null && value.type === 'getCurrentContextRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
     try {
         Convert.getCurrentContextRequestToJson(value);
         return true;
@@ -6375,7 +6708,17 @@ export function isGetCurrentContextRequest(value: any): value is GetCurrentConte
 
 export const GET_CURRENT_CONTEXT_REQUEST_TYPE = "GetCurrentContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
+    return value != null && value.type === 'getCurrentContextResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
     try {
         Convert.getCurrentContextResponseToJson(value);
         return true;
@@ -6386,7 +6729,17 @@ export function isGetCurrentContextResponse(value: any): value is GetCurrentCont
 
 export const GET_CURRENT_CONTEXT_RESPONSE_TYPE = "GetCurrentContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getInfoRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetInfoRequest(value: any): value is GetInfoRequest {
+    return value != null && value.type === 'getInfoRequest';
+}
+
+/**
+ * Returns true if value is a valid GetInfoRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoRequest(value: any): value is GetInfoRequest {
     try {
         Convert.getInfoRequestToJson(value);
         return true;
@@ -6397,7 +6750,17 @@ export function isGetInfoRequest(value: any): value is GetInfoRequest {
 
 export const GET_INFO_REQUEST_TYPE = "GetInfoRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getInfoResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetInfoResponse(value: any): value is GetInfoResponse {
+    return value != null && value.type === 'getInfoResponse';
+}
+
+/**
+ * Returns true if value is a valid GetInfoResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoResponse(value: any): value is GetInfoResponse {
     try {
         Convert.getInfoResponseToJson(value);
         return true;
@@ -6408,7 +6771,17 @@ export function isGetInfoResponse(value: any): value is GetInfoResponse {
 
 export const GET_INFO_RESPONSE_TYPE = "GetInfoResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
+    return value != null && value.type === 'getOrCreateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
     try {
         Convert.getOrCreateChannelRequestToJson(value);
         return true;
@@ -6419,7 +6792,17 @@ export function isGetOrCreateChannelRequest(value: any): value is GetOrCreateCha
 
 export const GET_OR_CREATE_CHANNEL_REQUEST_TYPE = "GetOrCreateChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
+    return value != null && value.type === 'getOrCreateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
     try {
         Convert.getOrCreateChannelResponseToJson(value);
         return true;
@@ -6430,7 +6813,17 @@ export function isGetOrCreateChannelResponse(value: any): value is GetOrCreateCh
 
 export const GET_OR_CREATE_CHANNEL_RESPONSE_TYPE = "GetOrCreateChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsRequest'. This is a fast check that does not check the format of the message
+ */
 export function isGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
+    return value != null && value.type === 'getUserChannelsRequest';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
     try {
         Convert.getUserChannelsRequestToJson(value);
         return true;
@@ -6441,7 +6834,17 @@ export function isGetUserChannelsRequest(value: any): value is GetUserChannelsRe
 
 export const GET_USER_CHANNELS_REQUEST_TYPE = "GetUserChannelsRequest";
 
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsResponse'. This is a fast check that does not check the format of the message
+ */
 export function isGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
+    return value != null && value.type === 'getUserChannelsResponse';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
     try {
         Convert.getUserChannelsResponseToJson(value);
         return true;
@@ -6452,7 +6855,17 @@ export function isGetUserChannelsResponse(value: any): value is GetUserChannelsR
 
 export const GET_USER_CHANNELS_RESPONSE_TYPE = "GetUserChannelsResponse";
 
+/**
+ * Returns true if the value has a type property with value 'heartbeatAcknowledgementRequest'. This is a fast check that does not check the format of the message
+ */
 export function isHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
+    return value != null && value.type === 'heartbeatAcknowledgementRequest';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatAcknowledgementRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
     try {
         Convert.heartbeatAcknowledgementRequestToJson(value);
         return true;
@@ -6463,7 +6876,17 @@ export function isHeartbeatAcknowledgementRequest(value: any): value is Heartbea
 
 export const HEARTBEAT_ACKNOWLEDGEMENT_REQUEST_TYPE = "HeartbeatAcknowledgementRequest";
 
+/**
+ * Returns true if the value has a type property with value 'heartbeatEvent'. This is a fast check that does not check the format of the message
+ */
 export function isHeartbeatEvent(value: any): value is HeartbeatEvent {
+    return value != null && value.type === 'heartbeatEvent';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatEvent(value: any): value is HeartbeatEvent {
     try {
         Convert.heartbeatEventToJson(value);
         return true;
@@ -6474,7 +6897,17 @@ export function isHeartbeatEvent(value: any): value is HeartbeatEvent {
 
 export const HEARTBEAT_EVENT_TYPE = "HeartbeatEvent";
 
+/**
+ * Returns true if the value has a type property with value 'intentEvent'. This is a fast check that does not check the format of the message
+ */
 export function isIntentEvent(value: any): value is IntentEvent {
+    return value != null && value.type === 'intentEvent';
+}
+
+/**
+ * Returns true if value is a valid IntentEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentEvent(value: any): value is IntentEvent {
     try {
         Convert.intentEventToJson(value);
         return true;
@@ -6485,7 +6918,17 @@ export function isIntentEvent(value: any): value is IntentEvent {
 
 export const INTENT_EVENT_TYPE = "IntentEvent";
 
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
 export function isIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
+    return value != null && value.type === 'intentListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
     try {
         Convert.intentListenerUnsubscribeRequestToJson(value);
         return true;
@@ -6496,7 +6939,17 @@ export function isIntentListenerUnsubscribeRequest(value: any): value is IntentL
 
 export const INTENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = "IntentListenerUnsubscribeRequest";
 
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
 export function isIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
+    return value != null && value.type === 'intentListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
     try {
         Convert.intentListenerUnsubscribeResponseToJson(value);
         return true;
@@ -6507,7 +6960,17 @@ export function isIntentListenerUnsubscribeResponse(value: any): value is Intent
 
 export const INTENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "IntentListenerUnsubscribeResponse";
 
+/**
+ * Returns true if the value has a type property with value 'intentResultRequest'. This is a fast check that does not check the format of the message
+ */
 export function isIntentResultRequest(value: any): value is IntentResultRequest {
+    return value != null && value.type === 'intentResultRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentResultRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultRequest(value: any): value is IntentResultRequest {
     try {
         Convert.intentResultRequestToJson(value);
         return true;
@@ -6518,7 +6981,17 @@ export function isIntentResultRequest(value: any): value is IntentResultRequest 
 
 export const INTENT_RESULT_REQUEST_TYPE = "IntentResultRequest";
 
+/**
+ * Returns true if the value has a type property with value 'intentResultResponse'. This is a fast check that does not check the format of the message
+ */
 export function isIntentResultResponse(value: any): value is IntentResultResponse {
+    return value != null && value.type === 'intentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultResponse(value: any): value is IntentResultResponse {
     try {
         Convert.intentResultResponseToJson(value);
         return true;
@@ -6529,7 +7002,17 @@ export function isIntentResultResponse(value: any): value is IntentResultRespons
 
 export const INTENT_RESULT_RESPONSE_TYPE = "IntentResultResponse";
 
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
+    return value != null && value.type === 'joinUserChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
     try {
         Convert.joinUserChannelRequestToJson(value);
         return true;
@@ -6540,7 +7023,17 @@ export function isJoinUserChannelRequest(value: any): value is JoinUserChannelRe
 
 export const JOIN_USER_CHANNEL_REQUEST_TYPE = "JoinUserChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
+    return value != null && value.type === 'joinUserChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
     try {
         Convert.joinUserChannelResponseToJson(value);
         return true;
@@ -6551,7 +7044,17 @@ export function isJoinUserChannelResponse(value: any): value is JoinUserChannelR
 
 export const JOIN_USER_CHANNEL_RESPONSE_TYPE = "JoinUserChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
 export function isLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
+    return value != null && value.type === 'leaveCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
     try {
         Convert.leaveCurrentChannelRequestToJson(value);
         return true;
@@ -6562,7 +7065,17 @@ export function isLeaveCurrentChannelRequest(value: any): value is LeaveCurrentC
 
 export const LEAVE_CURRENT_CHANNEL_REQUEST_TYPE = "LeaveCurrentChannelRequest";
 
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
 export function isLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
+    return value != null && value.type === 'leaveCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
     try {
         Convert.leaveCurrentChannelResponseToJson(value);
         return true;
@@ -6573,7 +7086,17 @@ export function isLeaveCurrentChannelResponse(value: any): value is LeaveCurrent
 
 export const LEAVE_CURRENT_CHANNEL_RESPONSE_TYPE = "LeaveCurrentChannelResponse";
 
+/**
+ * Returns true if the value has a type property with value 'openRequest'. This is a fast check that does not check the format of the message
+ */
 export function isOpenRequest(value: any): value is OpenRequest {
+    return value != null && value.type === 'openRequest';
+}
+
+/**
+ * Returns true if value is a valid OpenRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenRequest(value: any): value is OpenRequest {
     try {
         Convert.openRequestToJson(value);
         return true;
@@ -6584,7 +7107,17 @@ export function isOpenRequest(value: any): value is OpenRequest {
 
 export const OPEN_REQUEST_TYPE = "OpenRequest";
 
+/**
+ * Returns true if the value has a type property with value 'openResponse'. This is a fast check that does not check the format of the message
+ */
 export function isOpenResponse(value: any): value is OpenResponse {
+    return value != null && value.type === 'openResponse';
+}
+
+/**
+ * Returns true if value is a valid OpenResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenResponse(value: any): value is OpenResponse {
     try {
         Convert.openResponseToJson(value);
         return true;
@@ -6595,7 +7128,17 @@ export function isOpenResponse(value: any): value is OpenResponse {
 
 export const OPEN_RESPONSE_TYPE = "OpenResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelAddEventListenerRequest(value: any): value is PrivateChannelAddEventListenerRequest {
+    return value != null && value.type === 'privateChannelAddEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerRequest(value: any): value is PrivateChannelAddEventListenerRequest {
     try {
         Convert.privateChannelAddEventListenerRequestToJson(value);
         return true;
@@ -6606,7 +7149,17 @@ export function isPrivateChannelAddEventListenerRequest(value: any): value is Pr
 
 export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_REQUEST_TYPE = "PrivateChannelAddEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelAddEventListenerResponse(value: any): value is PrivateChannelAddEventListenerResponse {
+    return value != null && value.type === 'privateChannelAddEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerResponse(value: any): value is PrivateChannelAddEventListenerResponse {
     try {
         Convert.privateChannelAddEventListenerResponseToJson(value);
         return true;
@@ -6617,7 +7170,17 @@ export function isPrivateChannelAddEventListenerResponse(value: any): value is P
 
 export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_RESPONSE_TYPE = "PrivateChannelAddEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
+    return value != null && value.type === 'privateChannelDisconnectRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
     try {
         Convert.privateChannelDisconnectRequestToJson(value);
         return true;
@@ -6628,7 +7191,17 @@ export function isPrivateChannelDisconnectRequest(value: any): value is PrivateC
 
 export const PRIVATE_CHANNEL_DISCONNECT_REQUEST_TYPE = "PrivateChannelDisconnectRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
+    return value != null && value.type === 'privateChannelDisconnectResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
     try {
         Convert.privateChannelDisconnectResponseToJson(value);
         return true;
@@ -6639,7 +7212,17 @@ export function isPrivateChannelDisconnectResponse(value: any): value is Private
 
 export const PRIVATE_CHANNEL_DISCONNECT_RESPONSE_TYPE = "PrivateChannelDisconnectResponse";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnAddContextListenerEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnAddContextListenerEvent(value: any): value is PrivateChannelOnAddContextListenerEvent {
+    return value != null && value.type === 'privateChannelOnAddContextListenerEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnAddContextListenerEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnAddContextListenerEvent(value: any): value is PrivateChannelOnAddContextListenerEvent {
     try {
         Convert.privateChannelOnAddContextListenerEventToJson(value);
         return true;
@@ -6650,7 +7233,17 @@ export function isPrivateChannelOnAddContextListenerEvent(value: any): value is 
 
 export const PRIVATE_CHANNEL_ON_ADD_CONTEXT_LISTENER_EVENT_TYPE = "PrivateChannelOnAddContextListenerEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnDisconnectEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
+    return value != null && value.type === 'privateChannelOnDisconnectEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnDisconnectEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
     try {
         Convert.privateChannelOnDisconnectEventToJson(value);
         return true;
@@ -6661,7 +7254,17 @@ export function isPrivateChannelOnDisconnectEvent(value: any): value is PrivateC
 
 export const PRIVATE_CHANNEL_ON_DISCONNECT_EVENT_TYPE = "PrivateChannelOnDisconnectEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnUnsubscribeEvent'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
+    return value != null && value.type === 'privateChannelOnUnsubscribeEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnUnsubscribeEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
     try {
         Convert.privateChannelOnUnsubscribeEventToJson(value);
         return true;
@@ -6672,7 +7275,17 @@ export function isPrivateChannelOnUnsubscribeEvent(value: any): value is Private
 
 export const PRIVATE_CHANNEL_ON_UNSUBSCRIBE_EVENT_TYPE = "PrivateChannelOnUnsubscribeEvent";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelUnsubscribeEventListenerRequest(value: any): value is PrivateChannelUnsubscribeEventListenerRequest {
+    return value != null && value.type === 'privateChannelUnsubscribeEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerRequest(value: any): value is PrivateChannelUnsubscribeEventListenerRequest {
     try {
         Convert.privateChannelUnsubscribeEventListenerRequestToJson(value);
         return true;
@@ -6683,7 +7296,17 @@ export function isPrivateChannelUnsubscribeEventListenerRequest(value: any): val
 
 export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_REQUEST_TYPE = "PrivateChannelUnsubscribeEventListenerRequest";
 
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
 export function isPrivateChannelUnsubscribeEventListenerResponse(value: any): value is PrivateChannelUnsubscribeEventListenerResponse {
+    return value != null && value.type === 'privateChannelUnsubscribeEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerResponse(value: any): value is PrivateChannelUnsubscribeEventListenerResponse {
     try {
         Convert.privateChannelUnsubscribeEventListenerResponseToJson(value);
         return true;
@@ -6694,7 +7317,17 @@ export function isPrivateChannelUnsubscribeEventListenerResponse(value: any): va
 
 export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_RESPONSE_TYPE = "PrivateChannelUnsubscribeEventListenerResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextRequest'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
+    return value != null && value.type === 'raiseIntentForContextRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
     try {
         Convert.raiseIntentForContextRequestToJson(value);
         return true;
@@ -6705,7 +7338,17 @@ export function isRaiseIntentForContextRequest(value: any): value is RaiseIntent
 
 export const RAISE_INTENT_FOR_CONTEXT_REQUEST_TYPE = "RaiseIntentForContextRequest";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
+    return value != null && value.type === 'raiseIntentForContextResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
     try {
         Convert.raiseIntentForContextResponseToJson(value);
         return true;
@@ -6716,7 +7359,17 @@ export function isRaiseIntentForContextResponse(value: any): value is RaiseInten
 
 export const RAISE_INTENT_FOR_CONTEXT_RESPONSE_TYPE = "RaiseIntentForContextResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentRequest'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentRequest(value: any): value is RaiseIntentRequest {
+    return value != null && value.type === 'raiseIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentRequest(value: any): value is RaiseIntentRequest {
     try {
         Convert.raiseIntentRequestToJson(value);
         return true;
@@ -6727,7 +7380,17 @@ export function isRaiseIntentRequest(value: any): value is RaiseIntentRequest {
 
 export const RAISE_INTENT_REQUEST_TYPE = "RaiseIntentRequest";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentResponse(value: any): value is RaiseIntentResponse {
+    return value != null && value.type === 'raiseIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResponse(value: any): value is RaiseIntentResponse {
     try {
         Convert.raiseIntentResponseToJson(value);
         return true;
@@ -6738,7 +7401,17 @@ export function isRaiseIntentResponse(value: any): value is RaiseIntentResponse 
 
 export const RAISE_INTENT_RESPONSE_TYPE = "RaiseIntentResponse";
 
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResultResponse'. This is a fast check that does not check the format of the message
+ */
 export function isRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
+    return value != null && value.type === 'raiseIntentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
     try {
         Convert.raiseIntentResultResponseToJson(value);
         return true;
@@ -6747,91 +7420,4 @@ export function isRaiseIntentResultResponse(value: any): value is RaiseIntentRes
     }
 }
 
-export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";
-
-export type RequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest | BroadcastRequest | ContextListenerUnsubscribeRequest | CreatePrivateChannelRequest | EventListenerUnsubscribeRequest | FindInstancesRequest | FindIntentRequest | FindIntentsByContextRequest | GetAppMetadataRequest | GetCurrentChannelRequest | GetCurrentContextRequest | GetInfoRequest | GetOrCreateChannelRequest | GetUserChannelsRequest | HeartbeatAcknowledgementRequest | IntentListenerUnsubscribeRequest | IntentResultRequest | JoinUserChannelRequest | LeaveCurrentChannelRequest | OpenRequest | PrivateChannelAddEventListenerRequest | PrivateChannelDisconnectRequest | PrivateChannelUnsubscribeEventListenerRequest | RaiseIntentForContextRequest | RaiseIntentRequest;
-
-export type ResponseMessage = WebConnectionProtocol5ValidateAppIdentityFailedResponse | WebConnectionProtocol5ValidateAppIdentitySuccessResponse | AddContextListenerResponse | AddEventListenerResponse | AddIntentListenerResponse | BroadcastResponse | ContextListenerUnsubscribeResponse | CreatePrivateChannelResponse | EventListenerUnsubscribeResponse | FindInstancesResponse | FindIntentResponse | FindIntentsByContextResponse | GetAppMetadataResponse | GetCurrentChannelResponse | GetCurrentContextResponse | GetInfoResponse | GetOrCreateChannelResponse | GetUserChannelsResponse | IntentListenerUnsubscribeResponse | IntentResultResponse | JoinUserChannelResponse | LeaveCurrentChannelResponse | OpenResponse | PrivateChannelAddEventListenerResponse | PrivateChannelDisconnectResponse | PrivateChannelUnsubscribeEventListenerResponse | RaiseIntentForContextResponse | RaiseIntentResponse | RaiseIntentResultResponse;
-
-export type EventMessage = BroadcastEvent | ChannelChangedEvent | HeartbeatEvent | IntentEvent | PrivateChannelOnAddContextListenerEvent | PrivateChannelOnDisconnectEvent | PrivateChannelOnUnsubscribeEvent;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";                  

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -1,15 +1,7 @@
 // To parse this data:
 //
-//   import { Convert, WebConnectionProtocol1Hello, WebConnectionProtocol2LoadURL, WebConnectionProtocol3Handshake, WebConnectionProtocol4ValidateAppIdentity, WebConnectionProtocol5ValidateAppIdentityFailedResponse, WebConnectionProtocol5ValidateAppIdentitySuccessResponse, WebConnectionProtocol6Goodbye, WebConnectionProtocolMessage, AddContextListenerRequest, AddContextListenerResponse, AddEventListenerRequest, AddEventListenerResponse, AddIntentListenerRequest, AddIntentListenerResponse, AgentEventMessage, AgentResponseMessage, AppRequestMessage, BroadcastEvent, BroadcastRequest, BroadcastResponse, ChannelChangedEvent, ContextListenerUnsubscribeRequest, ContextListenerUnsubscribeResponse, CreatePrivateChannelRequest, CreatePrivateChannelResponse, EventListenerUnsubscribeRequest, EventListenerUnsubscribeResponse, Fdc3UserInterfaceChannelSelected, Fdc3UserInterfaceChannels, Fdc3UserInterfaceDrag, Fdc3UserInterfaceHandshake, Fdc3UserInterfaceHello, Fdc3UserInterfaceMessage, Fdc3UserInterfaceResolve, Fdc3UserInterfaceResolveAction, Fdc3UserInterfaceRestyle, FindInstancesRequest, FindInstancesResponse, FindIntentRequest, FindIntentResponse, FindIntentsByContextRequest, FindIntentsByContextResponse, GetAppMetadataRequest, GetAppMetadataResponse, GetCurrentChannelRequest, GetCurrentChannelResponse, GetCurrentContextRequest, GetCurrentContextResponse, GetInfoRequest, GetInfoResponse, GetOrCreateChannelRequest, GetOrCreateChannelResponse, GetUserChannelsRequest, GetUserChannelsResponse, HeartbeatAcknowledgementRequest, HeartbeatEvent, IntentEvent, IntentListenerUnsubscribeRequest, IntentListenerUnsubscribeResponse, IntentResultRequest, IntentResultResponse, JoinUserChannelRequest, JoinUserChannelResponse, LeaveCurrentChannelRequest, LeaveCurrentChannelResponse, OpenRequest, OpenResponse, PrivateChannelAddEventListenerRequest, PrivateChannelAddEventListenerResponse, PrivateChannelDisconnectRequest, PrivateChannelDisconnectResponse, PrivateChannelOnAddContextListenerEvent, PrivateChannelOnDisconnectEvent, PrivateChannelOnUnsubscribeEvent, PrivateChannelUnsubscribeEventListenerRequest, PrivateChannelUnsubscribeEventListenerResponse, RaiseIntentForContextRequest, RaiseIntentForContextResponse, RaiseIntentRequest, RaiseIntentResponse, RaiseIntentResultResponse } from "./file";
+//   import { Convert, AddContextListenerRequest, AddContextListenerResponse, AddEventListenerRequest, AddEventListenerResponse, AddIntentListenerRequest, AddIntentListenerResponse, AgentEventMessage, AgentResponseMessage, AppRequestMessage, BroadcastEvent, BroadcastRequest, BroadcastResponse, ChannelChangedEvent, ContextListenerUnsubscribeRequest, ContextListenerUnsubscribeResponse, CreatePrivateChannelRequest, CreatePrivateChannelResponse, EventListenerUnsubscribeRequest, EventListenerUnsubscribeResponse, Fdc3UserInterfaceChannels, Fdc3UserInterfaceChannelSelected, Fdc3UserInterfaceDrag, Fdc3UserInterfaceHandshake, Fdc3UserInterfaceHello, Fdc3UserInterfaceMessage, Fdc3UserInterfaceResolve, Fdc3UserInterfaceResolveAction, Fdc3UserInterfaceRestyle, FindInstancesRequest, FindInstancesResponse, FindIntentRequest, FindIntentResponse, FindIntentsByContextRequest, FindIntentsByContextResponse, GetAppMetadataRequest, GetAppMetadataResponse, GetCurrentChannelRequest, GetCurrentChannelResponse, GetCurrentContextRequest, GetCurrentContextResponse, GetInfoRequest, GetInfoResponse, GetOrCreateChannelRequest, GetOrCreateChannelResponse, GetUserChannelsRequest, GetUserChannelsResponse, HeartbeatAcknowledgementRequest, HeartbeatEvent, IntentEvent, IntentListenerUnsubscribeRequest, IntentListenerUnsubscribeResponse, IntentResultRequest, IntentResultResponse, JoinUserChannelRequest, JoinUserChannelResponse, LeaveCurrentChannelRequest, LeaveCurrentChannelResponse, OpenRequest, OpenResponse, PrivateChannelAddEventListenerRequest, PrivateChannelAddEventListenerResponse, PrivateChannelDisconnectRequest, PrivateChannelDisconnectResponse, PrivateChannelOnAddContextListenerEvent, PrivateChannelOnDisconnectEvent, PrivateChannelOnUnsubscribeEvent, PrivateChannelUnsubscribeEventListenerRequest, PrivateChannelUnsubscribeEventListenerResponse, RaiseIntentForContextRequest, RaiseIntentForContextResponse, RaiseIntentRequest, RaiseIntentResponse, RaiseIntentResultResponse, WebConnectionProtocol1Hello, WebConnectionProtocol2LoadURL, WebConnectionProtocol3Handshake, WebConnectionProtocol4ValidateAppIdentity, WebConnectionProtocol5ValidateAppIdentityFailedResponse, WebConnectionProtocol5ValidateAppIdentitySuccessResponse, WebConnectionProtocol6Goodbye, WebConnectionProtocolMessage } from "./file";
 //
-//   const webConnectionProtocol1Hello = Convert.toWebConnectionProtocol1Hello(json);
-//   const webConnectionProtocol2LoadURL = Convert.toWebConnectionProtocol2LoadURL(json);
-//   const webConnectionProtocol3Handshake = Convert.toWebConnectionProtocol3Handshake(json);
-//   const webConnectionProtocol4ValidateAppIdentity = Convert.toWebConnectionProtocol4ValidateAppIdentity(json);
-//   const webConnectionProtocol5ValidateAppIdentityFailedResponse = Convert.toWebConnectionProtocol5ValidateAppIdentityFailedResponse(json);
-//   const webConnectionProtocol5ValidateAppIdentitySuccessResponse = Convert.toWebConnectionProtocol5ValidateAppIdentitySuccessResponse(json);
-//   const webConnectionProtocol6Goodbye = Convert.toWebConnectionProtocol6Goodbye(json);
-//   const webConnectionProtocolMessage = Convert.toWebConnectionProtocolMessage(json);
 //   const addContextListenerRequest = Convert.toAddContextListenerRequest(json);
 //   const addContextListenerResponse = Convert.toAddContextListenerResponse(json);
 //   const addEventListenerRequest = Convert.toAddEventListenerRequest(json);
@@ -29,8 +21,8 @@
 //   const createPrivateChannelResponse = Convert.toCreatePrivateChannelResponse(json);
 //   const eventListenerUnsubscribeRequest = Convert.toEventListenerUnsubscribeRequest(json);
 //   const eventListenerUnsubscribeResponse = Convert.toEventListenerUnsubscribeResponse(json);
-//   const fdc3UserInterfaceChannelSelected = Convert.toFdc3UserInterfaceChannelSelected(json);
 //   const fdc3UserInterfaceChannels = Convert.toFdc3UserInterfaceChannels(json);
+//   const fdc3UserInterfaceChannelSelected = Convert.toFdc3UserInterfaceChannelSelected(json);
 //   const fdc3UserInterfaceDrag = Convert.toFdc3UserInterfaceDrag(json);
 //   const fdc3UserInterfaceHandshake = Convert.toFdc3UserInterfaceHandshake(json);
 //   const fdc3UserInterfaceHello = Convert.toFdc3UserInterfaceHello(json);
@@ -83,534 +75,17 @@
 //   const raiseIntentRequest = Convert.toRaiseIntentRequest(json);
 //   const raiseIntentResponse = Convert.toRaiseIntentResponse(json);
 //   const raiseIntentResultResponse = Convert.toRaiseIntentResultResponse(json);
+//   const webConnectionProtocol1Hello = Convert.toWebConnectionProtocol1Hello(json);
+//   const webConnectionProtocol2LoadURL = Convert.toWebConnectionProtocol2LoadURL(json);
+//   const webConnectionProtocol3Handshake = Convert.toWebConnectionProtocol3Handshake(json);
+//   const webConnectionProtocol4ValidateAppIdentity = Convert.toWebConnectionProtocol4ValidateAppIdentity(json);
+//   const webConnectionProtocol5ValidateAppIdentityFailedResponse = Convert.toWebConnectionProtocol5ValidateAppIdentityFailedResponse(json);
+//   const webConnectionProtocol5ValidateAppIdentitySuccessResponse = Convert.toWebConnectionProtocol5ValidateAppIdentitySuccessResponse(json);
+//   const webConnectionProtocol6Goodbye = Convert.toWebConnectionProtocol6Goodbye(json);
+//   const webConnectionProtocolMessage = Convert.toWebConnectionProtocolMessage(json);
 //
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
-
-/**
- * Hello message sent by an application to a parent window or frame when attempting to
- * establish connectivity to a Desktop Agent.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol1Hello {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol1HelloPayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP1Hello";
-}
-
-/**
- * Metadata for a Web Connection Protocol message.
- */
-export interface WebConnectionProtocol1HelloMeta {
-    connectionAttemptUuid: string;
-    timestamp: Date;
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol1HelloPayload {
-    /**
-     * The current URL of the page attempting to connect. This may differ from the identityUrl,
-     * but the origins MUST match.
-     */
-    actualUrl: string;
-    /**
-     * A flag that may be used to indicate that a channel selector user interface is or is not
-     * required. Set to `false` if the app includes its own interface for selecting channels or
-     * does not work with user channels.
-     */
-    channelSelector?: boolean;
-    /**
-     * The version of FDC3 API that the app supports.
-     */
-    fdc3Version: string;
-    /**
-     * URL to use for the identity of the application. Desktop Agents MUST validate that the
-     * origin of the message matches the URL, but MAY implement custom comparison logic.
-     */
-    identityUrl: string;
-    /**
-     * A flag that may be used to indicate that an intent resolver is or is not required. Set to
-     * `false` if no intents, or only targeted intents, are raised.
-     */
-    intentResolver?: boolean;
-    [property: string]: any;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Response from a Desktop Agent to an application requesting access to it indicating that
- * it should load a specified URL into a hidden iframe in order to establish connectivity to
- * a Desktop Agent.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol2LoadURL {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol2LoadURLPayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP2LoadUrl";
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol2LoadURLPayload {
-    /**
-     * A URL which can be used to establish communication with the Desktop Agent, via loading
-     * the URL into an iframe and restarting the Web Connection protocol with the iframe as the
-     * target.
-     */
-    iframeUrl: string;
-    [property: string]: any;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Handshake message sent by the Desktop Agent to the app (with a MessagePort appended) that
- * should be used for subsequent communication steps.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol3Handshake {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol3HandshakePayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP3Handshake";
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol3HandshakePayload {
-    /**
-     * Indicates whether a channel selector user interface is required and the URL to use to do
-     * so. Set to `true` to use the default or `false` to disable the channel selector (as the
-     * Desktop Agent will handle it another way).
-     */
-    channelSelectorUrl: boolean | string;
-    /**
-     * The version of FDC3 API that the Desktop Agent will provide support for.
-     */
-    fdc3Version: string;
-    /**
-     * Indicates whether an intent resolver user interface is required and the URL to use to do
-     * so. Set to `true` to use the default or `false` to disable the intent resolver (as the
-     * Desktop Agent will handle it another way).
-     */
-    intentResolverUrl: boolean | string;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Identity Validation request from an app attempting to connect to a Desktop Agent.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol4ValidateAppIdentity {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol4ValidateAppIdentityPayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP4ValidateAppIdentity";
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol4ValidateAppIdentityPayload {
-    /**
-     * The current URL of the page attempting to connect. This may differ from the identityUrl,
-     * but the origins MUST match.
-     */
-    actualUrl: string;
-    /**
-     * URL to use for the identity of the application. Desktop Agents MUST validate that the
-     * origin of the message matches the URL, but MAY implement custom comparison logic.
-     */
-    identityUrl: string;
-    /**
-     * If an application has previously connected to the Desktop Agent, it may specify its prior
-     * instance id and associated instance UUID to request the same same instance Id be assigned.
-     */
-    instanceId?: string;
-    /**
-     * Instance UUID associated with the requested instanceId.
-     */
-    instanceUuid?: string;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Message sent by the Desktop Agent to an app if their identity validation fails.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol5ValidateAppIdentityFailedResponse {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP5ValidateAppIdentityFailedResponse";
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload {
-    message?: string;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Message sent by the Desktop Agent to an app after successful identity validation.
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol1HelloMeta;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload: WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP5ValidateAppIdentityResponse";
-}
-
-/**
- * The message payload, containing data pertaining to this connection step.
- */
-export interface WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload {
-    /**
-     * The appId that the app's identity was validated against.
-     */
-    appId: string;
-    /**
-     * Implementation metadata for the Desktop Agent, which includes an appMetadata element
-     * containing a copy of the app's own metadata.
-     */
-    implementationMetadata: ImplementationMetadata;
-    /**
-     * The instance Id granted to the application by the Desktop Agent.
-     */
-    instanceId: string;
-    /**
-     * Instance UUID associated with the instanceId granted, which may be used to retrieve the
-     * same instanceId if the app is reloaded or navigates.
-     */
-    instanceUuid: string;
-}
-
-/**
- * Implementation metadata for the Desktop Agent, which includes an appMetadata element
- * containing a copy of the app's own metadata.
- *
- * Includes Metadata for the current application.
- *
- * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
- */
-export interface ImplementationMetadata {
-    /**
-     * The calling application instance's own metadata, according to the Desktop Agent (MUST
-     * include at least the `appId` and `instanceId`).
-     */
-    appMetadata: AppMetadata;
-    /**
-     * The version number of the FDC3 specification that the implementation provides.
-     * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
-     */
-    fdc3Version: string;
-    /**
-     * Metadata indicating whether the Desktop Agent implements optional features of
-     * the Desktop Agent API.
-     */
-    optionalFeatures: OptionalFeatures;
-    /**
-     * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
-     * OpenFin etc.).
-     */
-    provider: string;
-    /**
-     * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
-     */
-    providerVersion?: string;
-}
-
-/**
- * The calling application instance's own metadata, according to the Desktop Agent (MUST
- * include at least the `appId` and `instanceId`).
- *
- * Extends an `AppIdentifier`, describing an application or instance of an application, with
- * additional descriptive metadata that is usually provided by an FDC3 App Directory that
- * the Desktop Agent connects to.
- *
- * The additional information from an app directory can aid in rendering UI elements, such
- * as a launcher menu or resolver UI. This includes a title, description, tooltip and icon
- * and screenshot URLs.
- *
- * Note that as `AppMetadata` instances are also `AppIdentifiers` they may be passed to the
- * `app` argument of `fdc3.open`, `fdc3.raiseIntent` etc.
- */
-export interface AppMetadata {
-    /**
-     * The unique application identifier located within a specific application directory
-     * instance. An example of an appId might be 'app@sub.root'.
-     */
-    appId: string;
-    /**
-     * A longer, multi-paragraph description for the application that could include markup.
-     */
-    description?: string;
-    /**
-     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
-     * identify the Desktop Agent to target.
-     */
-    desktopAgent?: string;
-    /**
-     * A list of icon URLs for the application that can be used to render UI elements.
-     */
-    icons?: Icon[];
-    /**
-     * An optional instance identifier, indicating that this object represents a specific
-     * instance of the application described.
-     */
-    instanceId?: string;
-    /**
-     * An optional set of, implementation specific, metadata fields that can be used to
-     * disambiguate instances, such as a window title or screen position. Must only be set if
-     * `instanceId` is set.
-     */
-    instanceMetadata?: { [key: string]: any };
-    /**
-     * The 'friendly' app name.
-     * This field was used with the `open` and `raiseIntent` calls in FDC3 <2.0, which now
-     * require an `AppIdentifier` wth `appId` set.
-     * Note that for display purposes the `title` field should be used, if set, in preference to
-     * this field.
-     */
-    name?: string;
-    /**
-     * The type of output returned for any intent specified during resolution. May express a
-     * particular context type (e.g. "fdc3.instrument"), channel (e.g. "channel") or a channel
-     * that will receive a specified type (e.g. "channel<fdc3.instrument>").
-     */
-    resultType?: null | string;
-    /**
-     * Images representing the app in common usage scenarios that can be used to render UI
-     * elements.
-     */
-    screenshots?: Image[];
-    /**
-     * A more user-friendly application title that can be used to render UI elements.
-     */
-    title?: string;
-    /**
-     * A tooltip for the application that can be used to render UI elements.
-     */
-    tooltip?: string;
-    /**
-     * The Version of the application.
-     */
-    version?: string;
-}
-
-/**
- * Describes an Icon images that may be used to represent the application.
- */
-export interface Icon {
-    /**
-     * The icon dimension, formatted as `<height>x<width>`.
-     */
-    size?: string;
-    /**
-     * The icon url.
-     */
-    src: string;
-    /**
-     * Icon media type. If not present the Desktop Agent may use the src file extension.
-     */
-    type?: string;
-}
-
-/**
- * Describes an image file, typically a screenshot, that often represents the application in
- * a common usage scenario.
- */
-export interface Image {
-    /**
-     * Caption for the image.
-     */
-    label?: string;
-    /**
-     * The image dimension, formatted as `<height>x<width>`.
-     */
-    size?: string;
-    /**
-     * The image url.
-     */
-    src: string;
-    /**
-     * Image media type. If not present the Desktop Agent may use the src file extension.
-     */
-    type?: string;
-}
-
-/**
- * Metadata indicating whether the Desktop Agent implements optional features of
- * the Desktop Agent API.
- */
-export interface OptionalFeatures {
-    /**
-     * Used to indicate whether the experimental Desktop Agent Bridging
-     * feature is implemented by the Desktop Agent.
-     */
-    DesktopAgentBridging: boolean;
-    /**
-     * Used to indicate whether the exposure of 'originating app metadata' for
-     * context and intent messages is supported by the Desktop Agent.
-     */
-    OriginatingAppMetadata: boolean;
-    /**
-     * Used to indicate whether the optional `fdc3.joinUserChannel`,
-     * `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
-     * the Desktop Agent.
-     */
-    UserChannelMembershipAPIs: boolean;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * Goodbye message to be sent to the Desktop Agent when disconnecting (e.g. when closing the
- * window or navigating). Desktop Agents should close the MessagePort after receiving this
- * message, but retain instance details in case the application reconnects (e.g. after a
- * navigation event).
- *
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocol6Goodbye {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: WebConnectionProtocol6GoodbyeMeta;
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: "WCP6Goodbye";
-}
-
-/**
- * Metadata for a Web Connection Protocol message.
- */
-export interface WebConnectionProtocol6GoodbyeMeta {
-    timestamp: Date;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-
-/**
- * A message used during the connection flow for an application to a Desktop Agent in a
- * browser window. Used for messages sent in either direction.
- */
-export interface WebConnectionProtocolMessage {
-    /**
-     * Metadata for a Web Connection Protocol message.
-     */
-    meta: ConnectionStepMetadata;
-    /**
-     * The message payload, containing data pertaining to this connection step.
-     */
-    payload?: { [key: string]: any };
-    /**
-     * Identifies the type of the connection step message.
-     */
-    type: ConnectionStepMessageType;
-}
-
-/**
- * Metadata for a Web Connection Protocol message.
- */
-export interface ConnectionStepMetadata {
-    timestamp: Date;
-    connectionAttemptUuid?: string;
-}
-
-/**
- * Identifies the type of the connection step message.
- */
-export type ConnectionStepMessageType = "WCP1Hello" | "WCP2LoadUrl" | "WCP3Handshake" | "WCP4ValidateAppIdentity" | "WCP5ValidateAppIdentityFailedResponse" | "WCP5ValidateAppIdentityResponse" | "WCP6Goodbye";
 
 /**
  * A request to add a context listener to a specified Channel OR to the current user
@@ -1520,40 +995,6 @@ export interface EventListenerUnsubscribeResponse {
  */
 
 /**
- * Message from a channel selector UI to the DA proxy sent when the channel selection
- * changes.
- *
- * A message used to communicate with user interface frames injected by `getAgent()` for
- * displaying UI elements such as the intent resolver or channel selector. Used for messages
- * sent in either direction.
- */
-export interface Fdc3UserInterfaceChannelSelected {
-    /**
-     * The message payload.
-     */
-    payload: Fdc3UserInterfaceChannelSelectedPayload;
-    /**
-     * Identifies the type of the message to or from the user interface frame.
-     */
-    type: "Fdc3UserInterfaceChannelSelected";
-}
-
-/**
- * The message payload.
- */
-export interface Fdc3UserInterfaceChannelSelectedPayload {
-    /**
-     * The id of the channel that should be currently selected, or `null` if none should be
-     * selected.
-     */
-    selected: null | string;
-}
-
-/**
- * Identifies the type of the message to or from the user interface frame.
- */
-
-/**
  * Setup message sent by the DA proxy code in getAgent() to a channel selector UI in an
  * iframe with the channel definitions and current channel selection.
  *
@@ -1585,6 +1026,40 @@ export interface Fdc3UserInterfaceChannelsPayload {
      * User Channel definitions.```````s
      */
     userChannels: Channel[];
+}
+
+/**
+ * Identifies the type of the message to or from the user interface frame.
+ */
+
+/**
+ * Message from a channel selector UI to the DA proxy sent when the channel selection
+ * changes.
+ *
+ * A message used to communicate with user interface frames injected by `getAgent()` for
+ * displaying UI elements such as the intent resolver or channel selector. Used for messages
+ * sent in either direction.
+ */
+export interface Fdc3UserInterfaceChannelSelected {
+    /**
+     * The message payload.
+     */
+    payload: Fdc3UserInterfaceChannelSelectedPayload;
+    /**
+     * Identifies the type of the message to or from the user interface frame.
+     */
+    type: "Fdc3UserInterfaceChannelSelected";
+}
+
+/**
+ * The message payload.
+ */
+export interface Fdc3UserInterfaceChannelSelectedPayload {
+    /**
+     * The id of the channel that should be currently selected, or `null` if none should be
+     * selected.
+     */
+    selected: null | string;
 }
 
 /**
@@ -1824,6 +1299,125 @@ export interface AppIntent {
 }
 
 /**
+ * Extends an `AppIdentifier`, describing an application or instance of an application, with
+ * additional descriptive metadata that is usually provided by an FDC3 App Directory that
+ * the Desktop Agent connects to.
+ *
+ * The additional information from an app directory can aid in rendering UI elements, such
+ * as a launcher menu or resolver UI. This includes a title, description, tooltip and icon
+ * and screenshot URLs.
+ *
+ * Note that as `AppMetadata` instances are also `AppIdentifiers` they may be passed to the
+ * `app` argument of `fdc3.open`, `fdc3.raiseIntent` etc.
+ *
+ * The calling application instance's own metadata, according to the Desktop Agent (MUST
+ * include at least the `appId` and `instanceId`).
+ */
+export interface AppMetadata {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * A longer, multi-paragraph description for the application that could include markup.
+     */
+    description?: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent?: string;
+    /**
+     * A list of icon URLs for the application that can be used to render UI elements.
+     */
+    icons?: Icon[];
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    /**
+     * An optional set of, implementation specific, metadata fields that can be used to
+     * disambiguate instances, such as a window title or screen position. Must only be set if
+     * `instanceId` is set.
+     */
+    instanceMetadata?: { [key: string]: any };
+    /**
+     * The 'friendly' app name.
+     * This field was used with the `open` and `raiseIntent` calls in FDC3 <2.0, which now
+     * require an `AppIdentifier` wth `appId` set.
+     * Note that for display purposes the `title` field should be used, if set, in preference to
+     * this field.
+     */
+    name?: string;
+    /**
+     * The type of output returned for any intent specified during resolution. May express a
+     * particular context type (e.g. "fdc3.instrument"), channel (e.g. "channel") or a channel
+     * that will receive a specified type (e.g. "channel<fdc3.instrument>").
+     */
+    resultType?: null | string;
+    /**
+     * Images representing the app in common usage scenarios that can be used to render UI
+     * elements.
+     */
+    screenshots?: Image[];
+    /**
+     * A more user-friendly application title that can be used to render UI elements.
+     */
+    title?: string;
+    /**
+     * A tooltip for the application that can be used to render UI elements.
+     */
+    tooltip?: string;
+    /**
+     * The Version of the application.
+     */
+    version?: string;
+}
+
+/**
+ * Describes an Icon image that may be used to represent the application.
+ */
+export interface Icon {
+    /**
+     * The icon dimension, formatted as `<height>x<width>`.
+     */
+    size?: string;
+    /**
+     * The icon url.
+     */
+    src: string;
+    /**
+     * Icon media type. If not present the Desktop Agent may use the src file extension.
+     */
+    type?: string;
+}
+
+/**
+ * Describes an image file, typically a screenshot, that often represents the application in
+ * a common usage scenario.
+ */
+export interface Image {
+    /**
+     * Caption for the image.
+     */
+    label?: string;
+    /**
+     * The image dimension, formatted as `<height>x<width>`.
+     */
+    size?: string;
+    /**
+     * The image url.
+     */
+    src: string;
+    /**
+     * Image media type. If not present the Desktop Agent may use the src file extension.
+     */
+    type?: string;
+}
+
+/**
  * Details of the intent whose relationship to resolving applications is being described.
  *
  * Metadata describing an Intent.
@@ -2045,10 +1639,6 @@ export interface FindInstancesResponsePayload {
  * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
  * DesktopAgent (`fdc3`).
  *
- * Unique identifier for a for an attempt to connect to a Desktop Agent. A Unique UUID
- * should be used in the first (WCP1Hello) message and should be quoted in all subsequent
- * messages to link them to the same connection attempt.
- *
  * Unique identifier for a request or event message. Required in all message types.
  *
  * Unique identifier for a response to a specific message and must always be accompanied by
@@ -2059,6 +1649,10 @@ export interface FindInstancesResponsePayload {
  * listeners and used to identify it in messages (e.g. when unsubscribing).
  *
  * Unique identifier for an event message sent from a Desktop Agent to an app.
+ *
+ * Unique identifier for a for an attempt to connect to a Desktop Agent. A Unique UUID
+ * should be used in the first (WCP1Hello) message and should be quoted in all subsequent
+ * messages to link them to the same connection attempt.
  *
  * Should be set if the raiseIntent request returned an error.
  */
@@ -2448,7 +2042,7 @@ export interface GetCurrentContextResponsePayload {
  */
 
 /**
- * Request to retrieve information about the FDC3 Desktop Agent implementation  and the
+ * Request to retrieve information about the FDC3 Desktop Agent implementation and the
  * metadata of the calling application according to the Desktop Agent.
  *
  * A request message from an FDC3-enabled app to a Desktop Agent.
@@ -2512,6 +2106,64 @@ export interface GetInfoResponse {
 export interface GetInfoResponsePayload {
     error?: ResponsePayloadError;
     implementationMetadata?: ImplementationMetadata;
+}
+
+/**
+ * Implementation metadata for the Desktop Agent, which includes an appMetadata element
+ * containing a copy of the app's own metadata.
+ *
+ * Includes Metadata for the current application.
+ *
+ * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
+ */
+export interface ImplementationMetadata {
+    /**
+     * The calling application instance's own metadata, according to the Desktop Agent (MUST
+     * include at least the `appId` and `instanceId`).
+     */
+    appMetadata: AppMetadata;
+    /**
+     * The version number of the FDC3 specification that the implementation provides.
+     * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
+     */
+    fdc3Version: string;
+    /**
+     * Metadata indicating whether the Desktop Agent implements optional features of
+     * the Desktop Agent API.
+     */
+    optionalFeatures: OptionalFeatures;
+    /**
+     * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
+     * OpenFin etc.).
+     */
+    provider: string;
+    /**
+     * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
+     */
+    providerVersion?: string;
+}
+
+/**
+ * Metadata indicating whether the Desktop Agent implements optional features of
+ * the Desktop Agent API.
+ */
+export interface OptionalFeatures {
+    /**
+     * Used to indicate whether the experimental Desktop Agent Bridging
+     * feature is implemented by the Desktop Agent.
+     */
+    DesktopAgentBridging: boolean;
+    /**
+     * Used to indicate whether the exposure of 'originating app metadata' for
+     * context and intent messages is supported by the Desktop Agent.
+     */
+    OriginatingAppMetadata: boolean;
+    /**
+     * Used to indicate whether the optional `fdc3.joinUserChannel`,
+     * `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
+     * the Desktop Agent.
+     */
+    UserChannelMembershipAPIs: boolean;
 }
 
 /**
@@ -3785,73 +3437,357 @@ export interface RaiseIntentResultResponsePayload {
  * the message relates to, e.g. 'findIntent', with 'Response' appended.
  */
 
+/**
+ * Hello message sent by an application to a parent window or frame when attempting to
+ * establish connectivity to a Desktop Agent.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol1Hello {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol1HelloPayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP1Hello";
+}
+
+/**
+ * Metadata for a Web Connection Protocol message.
+ */
+export interface WebConnectionProtocol1HelloMeta {
+    connectionAttemptUuid: string;
+    timestamp: Date;
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol1HelloPayload {
+    /**
+     * The current URL of the page attempting to connect. This may differ from the identityUrl,
+     * but the origins MUST match.
+     */
+    actualUrl: string;
+    /**
+     * A flag that may be used to indicate that a channel selector user interface is or is not
+     * required. Set to `false` if the app includes its own interface for selecting channels or
+     * does not work with user channels.
+     */
+    channelSelector?: boolean;
+    /**
+     * The version of FDC3 API that the app supports.
+     */
+    fdc3Version: string;
+    /**
+     * URL to use for the identity of the application. Desktop Agents MUST validate that the
+     * origin of the message matches the URL, but MAY implement custom comparison logic.
+     */
+    identityUrl: string;
+    /**
+     * A flag that may be used to indicate that an intent resolver is or is not required. Set to
+     * `false` if no intents, or only targeted intents, are raised.
+     */
+    intentResolver?: boolean;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Response from a Desktop Agent to an application requesting access to it indicating that
+ * it should load a specified URL into a hidden iframe in order to establish connectivity to
+ * a Desktop Agent.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol2LoadURL {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol2LoadURLPayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP2LoadUrl";
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol2LoadURLPayload {
+    /**
+     * A URL which can be used to establish communication with the Desktop Agent, via loading
+     * the URL into an iframe and restarting the Web Connection protocol with the iframe as the
+     * target.
+     */
+    iframeUrl: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Handshake message sent by the Desktop Agent to the app (with a MessagePort appended) that
+ * should be used for subsequent communication steps.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol3Handshake {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol3HandshakePayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP3Handshake";
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol3HandshakePayload {
+    /**
+     * Indicates whether a channel selector user interface is required and the URL to use to do
+     * so. Set to `true` to use the default or `false` to disable the channel selector (as the
+     * Desktop Agent will handle it another way).
+     */
+    channelSelectorUrl: boolean | string;
+    /**
+     * The version of FDC3 API that the Desktop Agent will provide support for.
+     */
+    fdc3Version: string;
+    /**
+     * Indicates whether an intent resolver user interface is required and the URL to use to do
+     * so. Set to `true` to use the default or `false` to disable the intent resolver (as the
+     * Desktop Agent will handle it another way).
+     */
+    intentResolverUrl: boolean | string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Identity Validation request from an app attempting to connect to a Desktop Agent.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol4ValidateAppIdentity {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol4ValidateAppIdentityPayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP4ValidateAppIdentity";
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol4ValidateAppIdentityPayload {
+    /**
+     * The current URL of the page attempting to connect. This may differ from the identityUrl,
+     * but the origins MUST match.
+     */
+    actualUrl: string;
+    /**
+     * URL to use for the identity of the application. Desktop Agents MUST validate that the
+     * origin of the message matches the URL, but MAY implement custom comparison logic.
+     */
+    identityUrl: string;
+    /**
+     * If an application has previously connected to the Desktop Agent, it may specify its prior
+     * instance id and associated instance UUID to request the same same instance Id be assigned.
+     */
+    instanceId?: string;
+    /**
+     * Instance UUID associated with the requested instanceId.
+     */
+    instanceUuid?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Message sent by the Desktop Agent to an app if their identity validation fails.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP5ValidateAppIdentityFailedResponse";
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload {
+    message?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Message sent by the Desktop Agent to an app after successful identity validation.
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol1HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP5ValidateAppIdentityResponse";
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload {
+    /**
+     * The appId that the app's identity was validated against.
+     */
+    appId: string;
+    /**
+     * Implementation metadata for the Desktop Agent, which includes an appMetadata element
+     * containing a copy of the app's own metadata.
+     */
+    implementationMetadata: ImplementationMetadata;
+    /**
+     * The instance Id granted to the application by the Desktop Agent.
+     */
+    instanceId: string;
+    /**
+     * Instance UUID associated with the instanceId granted, which may be used to retrieve the
+     * same instanceId if the app is reloaded or navigates.
+     */
+    instanceUuid: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Goodbye message to be sent to the Desktop Agent when disconnecting (e.g. when closing the
+ * window or navigating). Desktop Agents should close the MessagePort after receiving this
+ * message, but retain instance details in case the application reconnects (e.g. after a
+ * navigation event).
+ *
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocol6Goodbye {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: WebConnectionProtocol6GoodbyeMeta;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "WCP6Goodbye";
+}
+
+/**
+ * Metadata for a Web Connection Protocol message.
+ */
+export interface WebConnectionProtocol6GoodbyeMeta {
+    timestamp: Date;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * A message used during the connection flow for an application to a Desktop Agent in a
+ * browser window. Used for messages sent in either direction.
+ */
+export interface WebConnectionProtocolMessage {
+    /**
+     * Metadata for a Web Connection Protocol message.
+     */
+    meta: ConnectionStepMetadata;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload?: { [key: string]: any };
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: ConnectionStepMessageType;
+}
+
+/**
+ * Metadata for a Web Connection Protocol message.
+ */
+export interface ConnectionStepMetadata {
+    timestamp: Date;
+    connectionAttemptUuid?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+export type ConnectionStepMessageType = "WCP1Hello" | "WCP2LoadUrl" | "WCP3Handshake" | "WCP4ValidateAppIdentity" | "WCP5ValidateAppIdentityFailedResponse" | "WCP5ValidateAppIdentityResponse" | "WCP6Goodbye";
+
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-    public static toWebConnectionProtocol1Hello(json: string): WebConnectionProtocol1Hello {
-        return cast(JSON.parse(json), r("WebConnectionProtocol1Hello"));
-    }
-
-    public static webConnectionProtocol1HelloToJson(value: WebConnectionProtocol1Hello): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol1Hello")), null, 2);
-    }
-
-    public static toWebConnectionProtocol2LoadURL(json: string): WebConnectionProtocol2LoadURL {
-        return cast(JSON.parse(json), r("WebConnectionProtocol2LoadURL"));
-    }
-
-    public static webConnectionProtocol2LoadURLToJson(value: WebConnectionProtocol2LoadURL): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol2LoadURL")), null, 2);
-    }
-
-    public static toWebConnectionProtocol3Handshake(json: string): WebConnectionProtocol3Handshake {
-        return cast(JSON.parse(json), r("WebConnectionProtocol3Handshake"));
-    }
-
-    public static webConnectionProtocol3HandshakeToJson(value: WebConnectionProtocol3Handshake): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol3Handshake")), null, 2);
-    }
-
-    public static toWebConnectionProtocol4ValidateAppIdentity(json: string): WebConnectionProtocol4ValidateAppIdentity {
-        return cast(JSON.parse(json), r("WebConnectionProtocol4ValidateAppIdentity"));
-    }
-
-    public static webConnectionProtocol4ValidateAppIdentityToJson(value: WebConnectionProtocol4ValidateAppIdentity): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol4ValidateAppIdentity")), null, 2);
-    }
-
-    public static toWebConnectionProtocol5ValidateAppIdentityFailedResponse(json: string): WebConnectionProtocol5ValidateAppIdentityFailedResponse {
-        return cast(JSON.parse(json), r("WebConnectionProtocol5ValidateAppIdentityFailedResponse"));
-    }
-
-    public static webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value: WebConnectionProtocol5ValidateAppIdentityFailedResponse): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol5ValidateAppIdentityFailedResponse")), null, 2);
-    }
-
-    public static toWebConnectionProtocol5ValidateAppIdentitySuccessResponse(json: string): WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
-        return cast(JSON.parse(json), r("WebConnectionProtocol5ValidateAppIdentitySuccessResponse"));
-    }
-
-    public static webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value: WebConnectionProtocol5ValidateAppIdentitySuccessResponse): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol5ValidateAppIdentitySuccessResponse")), null, 2);
-    }
-
-    public static toWebConnectionProtocol6Goodbye(json: string): WebConnectionProtocol6Goodbye {
-        return cast(JSON.parse(json), r("WebConnectionProtocol6Goodbye"));
-    }
-
-    public static webConnectionProtocol6GoodbyeToJson(value: WebConnectionProtocol6Goodbye): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocol6Goodbye")), null, 2);
-    }
-
-    public static toWebConnectionProtocolMessage(json: string): WebConnectionProtocolMessage {
-        return cast(JSON.parse(json), r("WebConnectionProtocolMessage"));
-    }
-
-    public static webConnectionProtocolMessageToJson(value: WebConnectionProtocolMessage): string {
-        return JSON.stringify(uncast(value, r("WebConnectionProtocolMessage")), null, 2);
-    }
-
     public static toAddContextListenerRequest(json: string): AddContextListenerRequest {
         return cast(JSON.parse(json), r("AddContextListenerRequest"));
     }
@@ -4004,20 +3940,20 @@ export class Convert {
         return JSON.stringify(uncast(value, r("EventListenerUnsubscribeResponse")), null, 2);
     }
 
-    public static toFdc3UserInterfaceChannelSelected(json: string): Fdc3UserInterfaceChannelSelected {
-        return cast(JSON.parse(json), r("Fdc3UserInterfaceChannelSelected"));
-    }
-
-    public static fdc3UserInterfaceChannelSelectedToJson(value: Fdc3UserInterfaceChannelSelected): string {
-        return JSON.stringify(uncast(value, r("Fdc3UserInterfaceChannelSelected")), null, 2);
-    }
-
     public static toFdc3UserInterfaceChannels(json: string): Fdc3UserInterfaceChannels {
         return cast(JSON.parse(json), r("Fdc3UserInterfaceChannels"));
     }
 
     public static fdc3UserInterfaceChannelsToJson(value: Fdc3UserInterfaceChannels): string {
         return JSON.stringify(uncast(value, r("Fdc3UserInterfaceChannels")), null, 2);
+    }
+
+    public static toFdc3UserInterfaceChannelSelected(json: string): Fdc3UserInterfaceChannelSelected {
+        return cast(JSON.parse(json), r("Fdc3UserInterfaceChannelSelected"));
+    }
+
+    public static fdc3UserInterfaceChannelSelectedToJson(value: Fdc3UserInterfaceChannelSelected): string {
+        return JSON.stringify(uncast(value, r("Fdc3UserInterfaceChannelSelected")), null, 2);
     }
 
     public static toFdc3UserInterfaceDrag(json: string): Fdc3UserInterfaceDrag {
@@ -4435,6 +4371,70 @@ export class Convert {
     public static raiseIntentResultResponseToJson(value: RaiseIntentResultResponse): string {
         return JSON.stringify(uncast(value, r("RaiseIntentResultResponse")), null, 2);
     }
+
+    public static toWebConnectionProtocol1Hello(json: string): WebConnectionProtocol1Hello {
+        return cast(JSON.parse(json), r("WebConnectionProtocol1Hello"));
+    }
+
+    public static webConnectionProtocol1HelloToJson(value: WebConnectionProtocol1Hello): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol1Hello")), null, 2);
+    }
+
+    public static toWebConnectionProtocol2LoadURL(json: string): WebConnectionProtocol2LoadURL {
+        return cast(JSON.parse(json), r("WebConnectionProtocol2LoadURL"));
+    }
+
+    public static webConnectionProtocol2LoadURLToJson(value: WebConnectionProtocol2LoadURL): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol2LoadURL")), null, 2);
+    }
+
+    public static toWebConnectionProtocol3Handshake(json: string): WebConnectionProtocol3Handshake {
+        return cast(JSON.parse(json), r("WebConnectionProtocol3Handshake"));
+    }
+
+    public static webConnectionProtocol3HandshakeToJson(value: WebConnectionProtocol3Handshake): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol3Handshake")), null, 2);
+    }
+
+    public static toWebConnectionProtocol4ValidateAppIdentity(json: string): WebConnectionProtocol4ValidateAppIdentity {
+        return cast(JSON.parse(json), r("WebConnectionProtocol4ValidateAppIdentity"));
+    }
+
+    public static webConnectionProtocol4ValidateAppIdentityToJson(value: WebConnectionProtocol4ValidateAppIdentity): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol4ValidateAppIdentity")), null, 2);
+    }
+
+    public static toWebConnectionProtocol5ValidateAppIdentityFailedResponse(json: string): WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+        return cast(JSON.parse(json), r("WebConnectionProtocol5ValidateAppIdentityFailedResponse"));
+    }
+
+    public static webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value: WebConnectionProtocol5ValidateAppIdentityFailedResponse): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol5ValidateAppIdentityFailedResponse")), null, 2);
+    }
+
+    public static toWebConnectionProtocol5ValidateAppIdentitySuccessResponse(json: string): WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+        return cast(JSON.parse(json), r("WebConnectionProtocol5ValidateAppIdentitySuccessResponse"));
+    }
+
+    public static webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value: WebConnectionProtocol5ValidateAppIdentitySuccessResponse): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol5ValidateAppIdentitySuccessResponse")), null, 2);
+    }
+
+    public static toWebConnectionProtocol6Goodbye(json: string): WebConnectionProtocol6Goodbye {
+        return cast(JSON.parse(json), r("WebConnectionProtocol6Goodbye"));
+    }
+
+    public static webConnectionProtocol6GoodbyeToJson(value: WebConnectionProtocol6Goodbye): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocol6Goodbye")), null, 2);
+    }
+
+    public static toWebConnectionProtocolMessage(json: string): WebConnectionProtocolMessage {
+        return cast(JSON.parse(json), r("WebConnectionProtocolMessage"));
+    }
+
+    public static webConnectionProtocolMessageToJson(value: WebConnectionProtocolMessage): string {
+        return JSON.stringify(uncast(value, r("WebConnectionProtocolMessage")), null, 2);
+    }
 }
 
 function invalidValue(typ: any, val: any, key: any, parent: any = ''): never {
@@ -4590,123 +4590,6 @@ function r(name: string) {
 }
 
 const typeMap: any = {
-    "WebConnectionProtocol1Hello": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol1HelloPayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol1HelloType") },
-    ], false),
-    "WebConnectionProtocol1HelloMeta": o([
-        { json: "connectionAttemptUuid", js: "connectionAttemptUuid", typ: "" },
-        { json: "timestamp", js: "timestamp", typ: Date },
-    ], false),
-    "WebConnectionProtocol1HelloPayload": o([
-        { json: "actualUrl", js: "actualUrl", typ: "" },
-        { json: "channelSelector", js: "channelSelector", typ: u(undefined, true) },
-        { json: "fdc3Version", js: "fdc3Version", typ: "" },
-        { json: "identityUrl", js: "identityUrl", typ: "" },
-        { json: "intentResolver", js: "intentResolver", typ: u(undefined, true) },
-    ], "any"),
-    "WebConnectionProtocol2LoadURL": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol2LoadURLPayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol2LoadURLType") },
-    ], false),
-    "WebConnectionProtocol2LoadURLPayload": o([
-        { json: "iframeUrl", js: "iframeUrl", typ: "" },
-    ], "any"),
-    "WebConnectionProtocol3Handshake": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol3HandshakePayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol3HandshakeType") },
-    ], false),
-    "WebConnectionProtocol3HandshakePayload": o([
-        { json: "channelSelectorUrl", js: "channelSelectorUrl", typ: u(true, "") },
-        { json: "fdc3Version", js: "fdc3Version", typ: "" },
-        { json: "intentResolverUrl", js: "intentResolverUrl", typ: u(true, "") },
-    ], false),
-    "WebConnectionProtocol4ValidateAppIdentity": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol4ValidateAppIdentityPayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol4ValidateAppIdentityType") },
-    ], false),
-    "WebConnectionProtocol4ValidateAppIdentityPayload": o([
-        { json: "actualUrl", js: "actualUrl", typ: "" },
-        { json: "identityUrl", js: "identityUrl", typ: "" },
-        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
-        { json: "instanceUuid", js: "instanceUuid", typ: u(undefined, "") },
-    ], false),
-    "WebConnectionProtocol5ValidateAppIdentityFailedResponse": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol5ValidateAppIdentityFailedResponseType") },
-    ], false),
-    "WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload": o([
-        { json: "message", js: "message", typ: u(undefined, "") },
-    ], false),
-    "WebConnectionProtocol5ValidateAppIdentitySuccessResponse": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
-        { json: "payload", js: "payload", typ: r("WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol5ValidateAppIdentitySuccessResponseType") },
-    ], false),
-    "WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload": o([
-        { json: "appId", js: "appId", typ: "" },
-        { json: "implementationMetadata", js: "implementationMetadata", typ: r("ImplementationMetadata") },
-        { json: "instanceId", js: "instanceId", typ: "" },
-        { json: "instanceUuid", js: "instanceUuid", typ: "" },
-    ], false),
-    "ImplementationMetadata": o([
-        { json: "appMetadata", js: "appMetadata", typ: r("AppMetadata") },
-        { json: "fdc3Version", js: "fdc3Version", typ: "" },
-        { json: "optionalFeatures", js: "optionalFeatures", typ: r("OptionalFeatures") },
-        { json: "provider", js: "provider", typ: "" },
-        { json: "providerVersion", js: "providerVersion", typ: u(undefined, "") },
-    ], false),
-    "AppMetadata": o([
-        { json: "appId", js: "appId", typ: "" },
-        { json: "description", js: "description", typ: u(undefined, "") },
-        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
-        { json: "icons", js: "icons", typ: u(undefined, a(r("Icon"))) },
-        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
-        { json: "instanceMetadata", js: "instanceMetadata", typ: u(undefined, m("any")) },
-        { json: "name", js: "name", typ: u(undefined, "") },
-        { json: "resultType", js: "resultType", typ: u(undefined, u(null, "")) },
-        { json: "screenshots", js: "screenshots", typ: u(undefined, a(r("Image"))) },
-        { json: "title", js: "title", typ: u(undefined, "") },
-        { json: "tooltip", js: "tooltip", typ: u(undefined, "") },
-        { json: "version", js: "version", typ: u(undefined, "") },
-    ], false),
-    "Icon": o([
-        { json: "size", js: "size", typ: u(undefined, "") },
-        { json: "src", js: "src", typ: "" },
-        { json: "type", js: "type", typ: u(undefined, "") },
-    ], false),
-    "Image": o([
-        { json: "label", js: "label", typ: u(undefined, "") },
-        { json: "size", js: "size", typ: u(undefined, "") },
-        { json: "src", js: "src", typ: "" },
-        { json: "type", js: "type", typ: u(undefined, "") },
-    ], false),
-    "OptionalFeatures": o([
-        { json: "DesktopAgentBridging", js: "DesktopAgentBridging", typ: true },
-        { json: "OriginatingAppMetadata", js: "OriginatingAppMetadata", typ: true },
-        { json: "UserChannelMembershipAPIs", js: "UserChannelMembershipAPIs", typ: true },
-    ], false),
-    "WebConnectionProtocol6Goodbye": o([
-        { json: "meta", js: "meta", typ: r("WebConnectionProtocol6GoodbyeMeta") },
-        { json: "type", js: "type", typ: r("WebConnectionProtocol6GoodbyeType") },
-    ], false),
-    "WebConnectionProtocol6GoodbyeMeta": o([
-        { json: "timestamp", js: "timestamp", typ: Date },
-    ], false),
-    "WebConnectionProtocolMessage": o([
-        { json: "meta", js: "meta", typ: r("ConnectionStepMetadata") },
-        { json: "payload", js: "payload", typ: u(undefined, m("any")) },
-        { json: "type", js: "type", typ: r("ConnectionStepMessageType") },
-    ], false),
-    "ConnectionStepMetadata": o([
-        { json: "timestamp", js: "timestamp", typ: Date },
-        { json: "connectionAttemptUuid", js: "connectionAttemptUuid", typ: u(undefined, "") },
-    ], false),
     "AddContextListenerRequest": o([
         { json: "meta", js: "meta", typ: r("AddContextListenerRequestMeta") },
         { json: "payload", js: "payload", typ: r("AddContextListenerRequestPayload") },
@@ -4904,13 +4787,6 @@ const typeMap: any = {
         { json: "payload", js: "payload", typ: r("BroadcastResponseResponsePayload") },
         { json: "type", js: "type", typ: r("EventListenerUnsubscribeResponseType") },
     ], false),
-    "Fdc3UserInterfaceChannelSelected": o([
-        { json: "payload", js: "payload", typ: r("Fdc3UserInterfaceChannelSelectedPayload") },
-        { json: "type", js: "type", typ: r("Fdc3UserInterfaceChannelSelectedType") },
-    ], false),
-    "Fdc3UserInterfaceChannelSelectedPayload": o([
-        { json: "selected", js: "selected", typ: u(null, "") },
-    ], false),
     "Fdc3UserInterfaceChannels": o([
         { json: "payload", js: "payload", typ: r("Fdc3UserInterfaceChannelsPayload") },
         { json: "type", js: "type", typ: r("Fdc3UserInterfaceChannelsType") },
@@ -4918,6 +4794,13 @@ const typeMap: any = {
     "Fdc3UserInterfaceChannelsPayload": o([
         { json: "selected", js: "selected", typ: u(null, "") },
         { json: "userChannels", js: "userChannels", typ: a(r("Channel")) },
+    ], false),
+    "Fdc3UserInterfaceChannelSelected": o([
+        { json: "payload", js: "payload", typ: r("Fdc3UserInterfaceChannelSelectedPayload") },
+        { json: "type", js: "type", typ: r("Fdc3UserInterfaceChannelSelectedType") },
+    ], false),
+    "Fdc3UserInterfaceChannelSelectedPayload": o([
+        { json: "selected", js: "selected", typ: u(null, "") },
     ], false),
     "Fdc3UserInterfaceDrag": o([
         { json: "payload", js: "payload", typ: r("Fdc3UserInterfaceDragPayload") },
@@ -4972,6 +4855,31 @@ const typeMap: any = {
     "AppIntent": o([
         { json: "apps", js: "apps", typ: a(r("AppMetadata")) },
         { json: "intent", js: "intent", typ: r("IntentMetadata") },
+    ], false),
+    "AppMetadata": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
+        { json: "icons", js: "icons", typ: u(undefined, a(r("Icon"))) },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+        { json: "instanceMetadata", js: "instanceMetadata", typ: u(undefined, m("any")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "resultType", js: "resultType", typ: u(undefined, u(null, "")) },
+        { json: "screenshots", js: "screenshots", typ: u(undefined, a(r("Image"))) },
+        { json: "title", js: "title", typ: u(undefined, "") },
+        { json: "tooltip", js: "tooltip", typ: u(undefined, "") },
+        { json: "version", js: "version", typ: u(undefined, "") },
+    ], false),
+    "Icon": o([
+        { json: "size", js: "size", typ: u(undefined, "") },
+        { json: "src", js: "src", typ: "" },
+        { json: "type", js: "type", typ: u(undefined, "") },
+    ], false),
+    "Image": o([
+        { json: "label", js: "label", typ: u(undefined, "") },
+        { json: "size", js: "size", typ: u(undefined, "") },
+        { json: "src", js: "src", typ: "" },
+        { json: "type", js: "type", typ: u(undefined, "") },
     ], false),
     "IntentMetadata": o([
         { json: "displayName", js: "displayName", typ: u(undefined, "") },
@@ -5125,6 +5033,18 @@ const typeMap: any = {
     "GetInfoResponsePayload": o([
         { json: "error", js: "error", typ: u(undefined, r("ResponsePayloadError")) },
         { json: "implementationMetadata", js: "implementationMetadata", typ: u(undefined, r("ImplementationMetadata")) },
+    ], false),
+    "ImplementationMetadata": o([
+        { json: "appMetadata", js: "appMetadata", typ: r("AppMetadata") },
+        { json: "fdc3Version", js: "fdc3Version", typ: "" },
+        { json: "optionalFeatures", js: "optionalFeatures", typ: r("OptionalFeatures") },
+        { json: "provider", js: "provider", typ: "" },
+        { json: "providerVersion", js: "providerVersion", typ: u(undefined, "") },
+    ], false),
+    "OptionalFeatures": o([
+        { json: "DesktopAgentBridging", js: "DesktopAgentBridging", typ: true },
+        { json: "OriginatingAppMetadata", js: "OriginatingAppMetadata", typ: true },
+        { json: "UserChannelMembershipAPIs", js: "UserChannelMembershipAPIs", typ: true },
     ], false),
     "GetOrCreateChannelRequest": o([
         { json: "meta", js: "meta", typ: r("AddContextListenerRequestMeta") },
@@ -5391,36 +5311,86 @@ const typeMap: any = {
         { json: "error", js: "error", typ: u(undefined, r("ResponsePayloadError")) },
         { json: "intentResult", js: "intentResult", typ: u(undefined, r("IntentResult")) },
     ], false),
-    "WebConnectionProtocol1HelloType": [
-        "WCP1Hello",
-    ],
-    "WebConnectionProtocol2LoadURLType": [
-        "WCP2LoadUrl",
-    ],
-    "WebConnectionProtocol3HandshakeType": [
-        "WCP3Handshake",
-    ],
-    "WebConnectionProtocol4ValidateAppIdentityType": [
-        "WCP4ValidateAppIdentity",
-    ],
-    "WebConnectionProtocol5ValidateAppIdentityFailedResponseType": [
-        "WCP5ValidateAppIdentityFailedResponse",
-    ],
-    "WebConnectionProtocol5ValidateAppIdentitySuccessResponseType": [
-        "WCP5ValidateAppIdentityResponse",
-    ],
-    "WebConnectionProtocol6GoodbyeType": [
-        "WCP6Goodbye",
-    ],
-    "ConnectionStepMessageType": [
-        "WCP1Hello",
-        "WCP2LoadUrl",
-        "WCP3Handshake",
-        "WCP4ValidateAppIdentity",
-        "WCP5ValidateAppIdentityFailedResponse",
-        "WCP5ValidateAppIdentityResponse",
-        "WCP6Goodbye",
-    ],
+    "WebConnectionProtocol1Hello": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol1HelloPayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol1HelloType") },
+    ], false),
+    "WebConnectionProtocol1HelloMeta": o([
+        { json: "connectionAttemptUuid", js: "connectionAttemptUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "WebConnectionProtocol1HelloPayload": o([
+        { json: "actualUrl", js: "actualUrl", typ: "" },
+        { json: "channelSelector", js: "channelSelector", typ: u(undefined, true) },
+        { json: "fdc3Version", js: "fdc3Version", typ: "" },
+        { json: "identityUrl", js: "identityUrl", typ: "" },
+        { json: "intentResolver", js: "intentResolver", typ: u(undefined, true) },
+    ], "any"),
+    "WebConnectionProtocol2LoadURL": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol2LoadURLPayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol2LoadURLType") },
+    ], false),
+    "WebConnectionProtocol2LoadURLPayload": o([
+        { json: "iframeUrl", js: "iframeUrl", typ: "" },
+    ], "any"),
+    "WebConnectionProtocol3Handshake": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol3HandshakePayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol3HandshakeType") },
+    ], false),
+    "WebConnectionProtocol3HandshakePayload": o([
+        { json: "channelSelectorUrl", js: "channelSelectorUrl", typ: u(true, "") },
+        { json: "fdc3Version", js: "fdc3Version", typ: "" },
+        { json: "intentResolverUrl", js: "intentResolverUrl", typ: u(true, "") },
+    ], false),
+    "WebConnectionProtocol4ValidateAppIdentity": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol4ValidateAppIdentityPayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol4ValidateAppIdentityType") },
+    ], false),
+    "WebConnectionProtocol4ValidateAppIdentityPayload": o([
+        { json: "actualUrl", js: "actualUrl", typ: "" },
+        { json: "identityUrl", js: "identityUrl", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+        { json: "instanceUuid", js: "instanceUuid", typ: u(undefined, "") },
+    ], false),
+    "WebConnectionProtocol5ValidateAppIdentityFailedResponse": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol5ValidateAppIdentityFailedResponseType") },
+    ], false),
+    "WebConnectionProtocol5ValidateAppIdentityFailedResponsePayload": o([
+        { json: "message", js: "message", typ: u(undefined, "") },
+    ], false),
+    "WebConnectionProtocol5ValidateAppIdentitySuccessResponse": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol1HelloMeta") },
+        { json: "payload", js: "payload", typ: r("WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol5ValidateAppIdentitySuccessResponseType") },
+    ], false),
+    "WebConnectionProtocol5ValidateAppIdentitySuccessResponsePayload": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "implementationMetadata", js: "implementationMetadata", typ: r("ImplementationMetadata") },
+        { json: "instanceId", js: "instanceId", typ: "" },
+        { json: "instanceUuid", js: "instanceUuid", typ: "" },
+    ], false),
+    "WebConnectionProtocol6Goodbye": o([
+        { json: "meta", js: "meta", typ: r("WebConnectionProtocol6GoodbyeMeta") },
+        { json: "type", js: "type", typ: r("WebConnectionProtocol6GoodbyeType") },
+    ], false),
+    "WebConnectionProtocol6GoodbyeMeta": o([
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "WebConnectionProtocolMessage": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStepMetadata") },
+        { json: "payload", js: "payload", typ: u(undefined, m("any")) },
+        { json: "type", js: "type", typ: r("ConnectionStepMessageType") },
+    ], false),
+    "ConnectionStepMetadata": o([
+        { json: "timestamp", js: "timestamp", typ: Date },
+        { json: "connectionAttemptUuid", js: "connectionAttemptUuid", typ: u(undefined, "") },
+    ], false),
     "AddContextListenerRequestType": [
         "addContextListenerRequest",
     ],
@@ -5585,11 +5555,11 @@ const typeMap: any = {
     "EventListenerUnsubscribeResponseType": [
         "eventListenerUnsubscribeResponse",
     ],
-    "Fdc3UserInterfaceChannelSelectedType": [
-        "Fdc3UserInterfaceChannelSelected",
-    ],
     "Fdc3UserInterfaceChannelsType": [
         "Fdc3UserInterfaceChannels",
+    ],
+    "Fdc3UserInterfaceChannelSelectedType": [
+        "Fdc3UserInterfaceChannelSelected",
     ],
     "Fdc3UserInterfaceDragType": [
         "Fdc3UserInterfaceDrag",
@@ -5791,173 +5761,43 @@ const typeMap: any = {
     "RaiseIntentResultResponseType": [
         "raiseIntentResultResponse",
     ],
+    "WebConnectionProtocol1HelloType": [
+        "WCP1Hello",
+    ],
+    "WebConnectionProtocol2LoadURLType": [
+        "WCP2LoadUrl",
+    ],
+    "WebConnectionProtocol3HandshakeType": [
+        "WCP3Handshake",
+    ],
+    "WebConnectionProtocol4ValidateAppIdentityType": [
+        "WCP4ValidateAppIdentity",
+    ],
+    "WebConnectionProtocol5ValidateAppIdentityFailedResponseType": [
+        "WCP5ValidateAppIdentityFailedResponse",
+    ],
+    "WebConnectionProtocol5ValidateAppIdentitySuccessResponseType": [
+        "WCP5ValidateAppIdentityResponse",
+    ],
+    "WebConnectionProtocol6GoodbyeType": [
+        "WCP6Goodbye",
+    ],
+    "ConnectionStepMessageType": [
+        "WCP1Hello",
+        "WCP2LoadUrl",
+        "WCP3Handshake",
+        "WCP4ValidateAppIdentity",
+        "WCP5ValidateAppIdentityFailedResponse",
+        "WCP5ValidateAppIdentityResponse",
+        "WCP6Goodbye",
+    ],
 };
+
 export type AppRequestMessage = AddContextListenerRequest | AddEventListenerRequest | AddIntentListenerRequest | BroadcastRequest | ContextListenerUnsubscribeRequest | CreatePrivateChannelRequest | EventListenerUnsubscribeRequest | FindInstancesRequest | FindIntentRequest | FindIntentsByContextRequest | GetAppMetadataRequest | GetCurrentChannelRequest | GetCurrentContextRequest | GetInfoRequest | GetOrCreateChannelRequest | GetUserChannelsRequest | HeartbeatAcknowledgementRequest | IntentListenerUnsubscribeRequest | IntentResultRequest | JoinUserChannelRequest | LeaveCurrentChannelRequest | OpenRequest | PrivateChannelAddEventListenerRequest | PrivateChannelDisconnectRequest | PrivateChannelUnsubscribeEventListenerRequest | RaiseIntentForContextRequest | RaiseIntentRequest;
 
 export type AgentResponseMessage = AddContextListenerResponse | AddEventListenerResponse | AddIntentListenerResponse | BroadcastResponse | ContextListenerUnsubscribeResponse | CreatePrivateChannelResponse | EventListenerUnsubscribeResponse | FindInstancesResponse | FindIntentResponse | FindIntentsByContextResponse | GetAppMetadataResponse | GetCurrentChannelResponse | GetCurrentContextResponse | GetInfoResponse | GetOrCreateChannelResponse | GetUserChannelsResponse | IntentListenerUnsubscribeResponse | IntentResultResponse | JoinUserChannelResponse | LeaveCurrentChannelResponse | OpenResponse | PrivateChannelAddEventListenerResponse | PrivateChannelDisconnectResponse | PrivateChannelUnsubscribeEventListenerResponse | RaiseIntentForContextResponse | RaiseIntentResponse | RaiseIntentResultResponse;
 
 export type AgentEventMessage = BroadcastEvent | ChannelChangedEvent | HeartbeatEvent | IntentEvent | PrivateChannelOnAddContextListenerEvent | PrivateChannelOnDisconnectEvent | PrivateChannelOnUnsubscribeEvent;
-
-/**
- * Returns true if the value has a type property with value 'WCP1Hello'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
-    return value != null && value.type === 'WCP1Hello';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol1Hello. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
-    try {
-        Convert.webConnectionProtocol1HelloToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL1_HELLO_TYPE = "WebConnectionProtocol1Hello";
-
-/**
- * Returns true if the value has a type property with value 'WCP2LoadUrl'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
-    return value != null && value.type === 'WCP2LoadUrl';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol2LoadURL. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
-    try {
-        Convert.webConnectionProtocol2LoadURLToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL2_LOAD_U_R_L_TYPE = "WebConnectionProtocol2LoadURL";
-
-/**
- * Returns true if the value has a type property with value 'WCP3Handshake'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
-    return value != null && value.type === 'WCP3Handshake';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol3Handshake. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
-    try {
-        Convert.webConnectionProtocol3HandshakeToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL3_HANDSHAKE_TYPE = "WebConnectionProtocol3Handshake";
-
-/**
- * Returns true if the value has a type property with value 'WCP4ValidateAppIdentity'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
-    return value != null && value.type === 'WCP4ValidateAppIdentity';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol4ValidateAppIdentity. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
-    try {
-        Convert.webConnectionProtocol4ValidateAppIdentityToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL4_VALIDATE_APP_IDENTITY_TYPE = "WebConnectionProtocol4ValidateAppIdentity";
-
-/**
- * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityFailedResponse'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
-    return value != null && value.type === 'WCP5ValidateAppIdentityFailedResponse';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentityFailedResponse. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
-    try {
-        Convert.webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_FAILED_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentityFailedResponse";
-
-/**
- * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityResponse'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
-    return value != null && value.type === 'WCP5ValidateAppIdentityResponse';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentitySuccessResponse. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
-    try {
-        Convert.webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_SUCCESS_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentitySuccessResponse";
-
-/**
- * Returns true if the value has a type property with value 'WCP6Goodbye'. This is a fast check that does not check the format of the message
- */
-export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
-    return value != null && value.type === 'WCP6Goodbye';
-}
-
-/**
- * Returns true if value is a valid WebConnectionProtocol6Goodbye. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
-    try {
-        Convert.webConnectionProtocol6GoodbyeToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL6_GOODBYE_TYPE = "WebConnectionProtocol6Goodbye";
-
-/**
- * Returns true if value is a valid WebConnectionProtocolMessage. This checks the type against the json schema for the message and will be slower
- */
-export function isValidWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
-    try {
-        Convert.webConnectionProtocolMessageToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const WEB_CONNECTION_PROTOCOL_MESSAGE_TYPE = "WebConnectionProtocolMessage";
 
 /**
  * Returns true if the value has a type property with value 'addContextListenerRequest'. This is a fast check that does not check the format of the message
@@ -6296,27 +6136,6 @@ export function isValidEventListenerUnsubscribeResponse(value: any): value is Ev
 export const EVENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = "EventListenerUnsubscribeResponse";
 
 /**
- * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannelSelected'. This is a fast check that does not check the format of the message
- */
-export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
-    return value != null && value.type === 'Fdc3UserInterfaceChannelSelected';
-}
-
-/**
- * Returns true if value is a valid Fdc3UserInterfaceChannelSelected. This checks the type against the json schema for the message and will be slower
- */
-export function isValidFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
-    try {
-        Convert.fdc3UserInterfaceChannelSelectedToJson(value);
-        return true;
-    } catch (_e: any) {
-        return false;
-    }
-}
-
-export const FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE = "Fdc3UserInterfaceChannelSelected";
-
-/**
  * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannels'. This is a fast check that does not check the format of the message
  */
 export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
@@ -6336,6 +6155,27 @@ export function isValidFdc3UserInterfaceChannels(value: any): value is Fdc3UserI
 }
 
 export const FDC3_USER_INTERFACE_CHANNELS_TYPE = "Fdc3UserInterfaceChannels";
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannelSelected'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+    return value != null && value.type === 'Fdc3UserInterfaceChannelSelected';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannelSelected. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+    try {
+        Convert.fdc3UserInterfaceChannelSelectedToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE = "Fdc3UserInterfaceChannelSelected";
 
 /**
  * Returns true if the value has a type property with value 'Fdc3UserInterfaceDrag'. This is a fast check that does not check the format of the message
@@ -7420,4 +7260,165 @@ export function isValidRaiseIntentResultResponse(value: any): value is RaiseInte
     }
 }
 
-export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";                  
+export const RAISE_INTENT_RESULT_RESPONSE_TYPE = "RaiseIntentResultResponse";
+
+/**
+ * Returns true if the value has a type property with value 'WCP1Hello'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+    return value != null && value.type === 'WCP1Hello';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol1Hello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+    try {
+        Convert.webConnectionProtocol1HelloToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL1_HELLO_TYPE = "WebConnectionProtocol1Hello";
+
+/**
+ * Returns true if the value has a type property with value 'WCP2LoadUrl'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+    return value != null && value.type === 'WCP2LoadUrl';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol2LoadURL. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+    try {
+        Convert.webConnectionProtocol2LoadURLToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL2_LOAD_U_R_L_TYPE = "WebConnectionProtocol2LoadURL";
+
+/**
+ * Returns true if the value has a type property with value 'WCP3Handshake'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+    return value != null && value.type === 'WCP3Handshake';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol3Handshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+    try {
+        Convert.webConnectionProtocol3HandshakeToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL3_HANDSHAKE_TYPE = "WebConnectionProtocol3Handshake";
+
+/**
+ * Returns true if the value has a type property with value 'WCP4ValidateAppIdentity'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
+    return value != null && value.type === 'WCP4ValidateAppIdentity';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol4ValidateAppIdentity. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol4ValidateAppIdentity(value: any): value is WebConnectionProtocol4ValidateAppIdentity {
+    try {
+        Convert.webConnectionProtocol4ValidateAppIdentityToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL4_VALIDATE_APP_IDENTITY_TYPE = "WebConnectionProtocol4ValidateAppIdentity";
+
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityFailedResponse'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityFailedResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentityFailedResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentityFailedResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+    try {
+        Convert.webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_FAILED_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentityFailedResponse";
+
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityResponse'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+    return value != null && value.type === 'WCP5ValidateAppIdentityResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentitySuccessResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentitySuccessResponse(value: any): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+    try {
+        Convert.webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_SUCCESS_RESPONSE_TYPE = "WebConnectionProtocol5ValidateAppIdentitySuccessResponse";
+
+/**
+ * Returns true if the value has a type property with value 'WCP6Goodbye'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+    return value != null && value.type === 'WCP6Goodbye';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol6Goodbye. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+    try {
+        Convert.webConnectionProtocol6GoodbyeToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL6_GOODBYE_TYPE = "WebConnectionProtocol6Goodbye";
+
+/**
+ * Returns true if value is a valid WebConnectionProtocolMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
+    try {
+        Convert.webConnectionProtocolMessageToJson(value);
+        return true;
+    } catch (_e: any) {
+        return false;
+    }
+}
+
+export const WEB_CONNECTION_PROTOCOL_MESSAGE_TYPE = "WebConnectionProtocolMessage";   

--- a/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
+++ b/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
@@ -1,1 +1,6057 @@
-export const something = ""
+// To parse this data:
+//
+//   import { Convert, AgentErrorResponseMessage, AgentRequestMessage, AgentResponseMessage, BridgeErrorResponseMessage, BridgeRequestMessage, BridgeResponseMessage, BroadcastAgentRequest, BroadcastBridgeRequest, ConnectionStepMessage, ConnectionStep2Hello, ConnectionStep3Handshake, ConnectionStep4AuthenticationFailed, ConnectionStep6ConnectedAgentsUpdate, FindInstancesAgentErrorResponse, FindInstancesAgentRequest, FindInstancesAgentResponse, FindInstancesBridgeErrorResponse, FindInstancesBridgeRequest, FindInstancesBridgeResponse, FindIntentAgentErrorResponse, FindIntentAgentRequest, FindIntentAgentResponse, FindIntentBridgeErrorResponse, FindIntentBridgeRequest, FindIntentBridgeResponse, FindIntentsByContextAgentErrorResponse, FindIntentsByContextAgentRequest, FindIntentsByContextAgentResponse, FindIntentsByContextBridgeErrorResponse, FindIntentsByContextBridgeRequest, FindIntentsByContextBridgeResponse, GetAppMetadataAgentErrorResponse, GetAppMetadataAgentRequest, GetAppMetadataAgentResponse, GetAppMetadataBridgeErrorResponse, GetAppMetadataBridgeRequest, GetAppMetadataBridgeResponse, OpenAgentErrorResponse, OpenAgentRequest, OpenAgentResponse, OpenBridgeErrorResponse, OpenBridgeRequest, OpenBridgeResponse, PrivateChannelBroadcastAgentRequest, PrivateChannelBroadcastBridgeRequest, PrivateChannelEventListenerAddedAgentRequest, PrivateChannelEventListenerAddedBridgeRequest, PrivateChannelEventListenerRemovedAgentRequest, PrivateChannelEventListenerRemovedBridgeRequest, PrivateChannelOnAddContextListenerAgentRequest, PrivateChannelOnAddContextListenerBridgeRequest, PrivateChannelOnDisconnectAgentRequest, PrivateChannelOnDisconnectBridgeRequest, PrivateChannelOnUnsubscribeAgentRequest, PrivateChannelOnUnsubscribeBridgeRequest, RaiseIntentAgentErrorResponse, RaiseIntentAgentRequest, RaiseIntentAgentResponse, RaiseIntentBridgeErrorResponse, RaiseIntentBridgeRequest, RaiseIntentBridgeResponse, RaiseIntentResultAgentErrorResponse, RaiseIntentResultAgentResponse, RaiseIntentResultBridgeErrorResponse, RaiseIntentResultBridgeResponse } from "./file";
+//
+//   const agentErrorResponseMessage = Convert.toAgentErrorResponseMessage(json);
+//   const agentRequestMessage = Convert.toAgentRequestMessage(json);
+//   const agentResponseMessage = Convert.toAgentResponseMessage(json);
+//   const bridgeErrorResponseMessage = Convert.toBridgeErrorResponseMessage(json);
+//   const bridgeRequestMessage = Convert.toBridgeRequestMessage(json);
+//   const bridgeResponseMessage = Convert.toBridgeResponseMessage(json);
+//   const broadcastAgentRequest = Convert.toBroadcastAgentRequest(json);
+//   const broadcastBridgeRequest = Convert.toBroadcastBridgeRequest(json);
+//   const bridgeCommonDefinitions = Convert.toBridgeCommonDefinitions(json);
+//   const connectionStepMessage = Convert.toConnectionStepMessage(json);
+//   const connectionStep2Hello = Convert.toConnectionStep2Hello(json);
+//   const connectionStep3Handshake = Convert.toConnectionStep3Handshake(json);
+//   const connectionStep4AuthenticationFailed = Convert.toConnectionStep4AuthenticationFailed(json);
+//   const connectionStep6ConnectedAgentsUpdate = Convert.toConnectionStep6ConnectedAgentsUpdate(json);
+//   const findInstancesAgentErrorResponse = Convert.toFindInstancesAgentErrorResponse(json);
+//   const findInstancesAgentRequest = Convert.toFindInstancesAgentRequest(json);
+//   const findInstancesAgentResponse = Convert.toFindInstancesAgentResponse(json);
+//   const findInstancesBridgeErrorResponse = Convert.toFindInstancesBridgeErrorResponse(json);
+//   const findInstancesBridgeRequest = Convert.toFindInstancesBridgeRequest(json);
+//   const findInstancesBridgeResponse = Convert.toFindInstancesBridgeResponse(json);
+//   const findIntentAgentErrorResponse = Convert.toFindIntentAgentErrorResponse(json);
+//   const findIntentAgentRequest = Convert.toFindIntentAgentRequest(json);
+//   const findIntentAgentResponse = Convert.toFindIntentAgentResponse(json);
+//   const findIntentBridgeErrorResponse = Convert.toFindIntentBridgeErrorResponse(json);
+//   const findIntentBridgeRequest = Convert.toFindIntentBridgeRequest(json);
+//   const findIntentBridgeResponse = Convert.toFindIntentBridgeResponse(json);
+//   const findIntentsByContextAgentErrorResponse = Convert.toFindIntentsByContextAgentErrorResponse(json);
+//   const findIntentsByContextAgentRequest = Convert.toFindIntentsByContextAgentRequest(json);
+//   const findIntentsByContextAgentResponse = Convert.toFindIntentsByContextAgentResponse(json);
+//   const findIntentsByContextBridgeErrorResponse = Convert.toFindIntentsByContextBridgeErrorResponse(json);
+//   const findIntentsByContextBridgeRequest = Convert.toFindIntentsByContextBridgeRequest(json);
+//   const findIntentsByContextBridgeResponse = Convert.toFindIntentsByContextBridgeResponse(json);
+//   const getAppMetadataAgentErrorResponse = Convert.toGetAppMetadataAgentErrorResponse(json);
+//   const getAppMetadataAgentRequest = Convert.toGetAppMetadataAgentRequest(json);
+//   const getAppMetadataAgentResponse = Convert.toGetAppMetadataAgentResponse(json);
+//   const getAppMetadataBridgeErrorResponse = Convert.toGetAppMetadataBridgeErrorResponse(json);
+//   const getAppMetadataBridgeRequest = Convert.toGetAppMetadataBridgeRequest(json);
+//   const getAppMetadataBridgeResponse = Convert.toGetAppMetadataBridgeResponse(json);
+//   const openAgentErrorResponse = Convert.toOpenAgentErrorResponse(json);
+//   const openAgentRequest = Convert.toOpenAgentRequest(json);
+//   const openAgentResponse = Convert.toOpenAgentResponse(json);
+//   const openBridgeErrorResponse = Convert.toOpenBridgeErrorResponse(json);
+//   const openBridgeRequest = Convert.toOpenBridgeRequest(json);
+//   const openBridgeResponse = Convert.toOpenBridgeResponse(json);
+//   const privateChannelBroadcastAgentRequest = Convert.toPrivateChannelBroadcastAgentRequest(json);
+//   const privateChannelBroadcastBridgeRequest = Convert.toPrivateChannelBroadcastBridgeRequest(json);
+//   const privateChannelEventListenerAddedAgentRequest = Convert.toPrivateChannelEventListenerAddedAgentRequest(json);
+//   const privateChannelEventListenerAddedBridgeRequest = Convert.toPrivateChannelEventListenerAddedBridgeRequest(json);
+//   const privateChannelEventListenerRemovedAgentRequest = Convert.toPrivateChannelEventListenerRemovedAgentRequest(json);
+//   const privateChannelEventListenerRemovedBridgeRequest = Convert.toPrivateChannelEventListenerRemovedBridgeRequest(json);
+//   const privateChannelOnAddContextListenerAgentRequest = Convert.toPrivateChannelOnAddContextListenerAgentRequest(json);
+//   const privateChannelOnAddContextListenerBridgeRequest = Convert.toPrivateChannelOnAddContextListenerBridgeRequest(json);
+//   const privateChannelOnDisconnectAgentRequest = Convert.toPrivateChannelOnDisconnectAgentRequest(json);
+//   const privateChannelOnDisconnectBridgeRequest = Convert.toPrivateChannelOnDisconnectBridgeRequest(json);
+//   const privateChannelOnUnsubscribeAgentRequest = Convert.toPrivateChannelOnUnsubscribeAgentRequest(json);
+//   const privateChannelOnUnsubscribeBridgeRequest = Convert.toPrivateChannelOnUnsubscribeBridgeRequest(json);
+//   const raiseIntentAgentErrorResponse = Convert.toRaiseIntentAgentErrorResponse(json);
+//   const raiseIntentAgentRequest = Convert.toRaiseIntentAgentRequest(json);
+//   const raiseIntentAgentResponse = Convert.toRaiseIntentAgentResponse(json);
+//   const raiseIntentBridgeErrorResponse = Convert.toRaiseIntentBridgeErrorResponse(json);
+//   const raiseIntentBridgeRequest = Convert.toRaiseIntentBridgeRequest(json);
+//   const raiseIntentBridgeResponse = Convert.toRaiseIntentBridgeResponse(json);
+//   const raiseIntentResultAgentErrorResponse = Convert.toRaiseIntentResultAgentErrorResponse(json);
+//   const raiseIntentResultAgentResponse = Convert.toRaiseIntentResultAgentResponse(json);
+//   const raiseIntentResultBridgeErrorResponse = Convert.toRaiseIntentResultBridgeErrorResponse(json);
+//   const raiseIntentResultBridgeResponse = Convert.toRaiseIntentResultBridgeResponse(json);
+//
+// These functions will throw an error if the JSON doesn't
+// match the expected interface, even if the JSON is valid.
+
+/**
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface AgentErrorResponseMessage {
+    meta: AgentResponseMetadata;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: ErrorResponseMessagePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: ResponseMessageType;
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface AgentResponseMetadata {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface ErrorResponseMessagePayload {
+    error: ResponseErrorDetail;
+    [property: string]: any;
+}
+
+/**
+ * Array of error message strings for responses that were not returned to the bridge before
+ * the timeout or because an error occurred. Should be the same length as the `errorSources`
+ * array and ordered the same. May be omitted if all sources responded without errors.
+ *
+ * Constants representing the errors that can be encountered when calling the `open` method
+ * on the DesktopAgent object (`fdc3`).
+ *
+ * Constants representing the errors that can be encountered when calling the `findIntent`,
+ * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
+ * DesktopAgent (`fdc3`).
+ */
+export type ResponseErrorDetail = "AccessDenied" | "CreationFailed" | "MalformedContext" | "NoChannelFound" | "AppNotFound" | "AppTimeout" | "DesktopAgentNotFound" | "ErrorOnLaunch" | "ResolverUnavailable" | "IntentDeliveryFailed" | "NoAppsFound" | "ResolverTimeout" | "TargetAppUnavailable" | "TargetInstanceUnavailable" | "UserCancelledResolution" | "IntentHandlerRejected" | "NoResultReturned" | "AgentDisconnected" | "NotConnectedToBridge" | "ResponseToBridgeTimedOut" | "MalformedMessage";
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ */
+export type ResponseMessageType = "findInstancesResponse" | "findIntentResponse" | "findIntentsByContextResponse" | "getAppMetadataResponse" | "openResponse" | "raiseIntentResponse" | "raiseIntentResultResponse";
+
+/**
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface AgentRequestMessage {
+    meta: AgentRequestMetadata;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: { [key: string]: any };
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: RequestMessageType;
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface AgentRequestMetadata {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceIdentifier;
+    timestamp: Date;
+}
+
+/**
+ * Optional field that represents the destination that the request should be routed to. Must
+ * be set by the Desktop Agent for API calls that include a target app parameter and must
+ * include the name of the Desktop Agent hosting the target application.
+ *
+ * Represents identifiers that MUST include the Desktop Agent name and MAY identify a
+ * specific app or instance.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+ * be set by the bridge.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface BridgeParticipantIdentifier {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId?: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself.
+ *
+ * Field that represents the source application that a request or response was received
+ * from, or the source Desktop Agent if it issued the request or response itself.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ */
+export interface SourceIdentifier {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId?: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     *
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     */
+    desktopAgent?: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ */
+export type RequestMessageType = "broadcastRequest" | "findInstancesRequest" | "findIntentRequest" | "findIntentsByContextRequest" | "getAppMetadataRequest" | "openRequest" | "PrivateChannel.broadcast" | "PrivateChannel.eventListenerAdded" | "PrivateChannel.eventListenerRemoved" | "PrivateChannel.onAddContextListener" | "PrivateChannel.onDisconnect" | "PrivateChannel.onUnsubscribe" | "raiseIntentRequest";
+
+/**
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface AgentResponseMessage {
+    meta: AgentResponseMetadata;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: { [key: string]: any };
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: ResponseMessageType;
+}
+
+/**
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface BridgeErrorResponseMessage {
+    meta: BridgeErrorResponseMessageMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: ResponseErrorMessagePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: string;
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface BridgeErrorResponseMessageMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ */
+export interface DesktopAgentIdentifier {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     */
+    desktopAgent: string;
+    [property: string]: any;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface ResponseErrorMessagePayload {
+    error?: ResponseErrorDetail;
+    [property: string]: any;
+}
+
+/**
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface BridgeRequestMessage {
+    meta: BridgeRequestMetadata;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: { [key: string]: any };
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: string;
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface BridgeRequestMetadata {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    BridgeParticipantIdentifier;
+    timestamp: Date;
+}
+
+/**
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface BridgeResponseMessage {
+    meta: BridgeResponseMessageMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: { [key: string]: any };
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: string;
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface BridgeResponseMessageMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * A request to broadcast context on a channel.
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface BroadcastAgentRequest {
+    meta: BroadcastAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: BroadcastAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "broadcastRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface BroadcastAgentRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source:    SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself.
+ *
+ * Field that represents the source application that a request or response was received
+ * from, or the source Desktop Agent if it issued the request or response itself.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ */
+export interface SourceObject {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     *
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     */
+    desktopAgent?: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface BroadcastAgentRequestPayload {
+    /**
+     * The Id of the Channel that the broadcast was sent on.
+     */
+    channelId: string;
+    /**
+     * The context object that is to be broadcast.
+     */
+    context: Context;
+}
+
+/**
+ * The context object that is to be broadcast.
+ *
+ * The context object that was the payload of a broadcast message.
+ *
+ * The `fdc3.context` type defines the basic contract or "shape" for all data exchanged by
+ * FDC3 operations. As such, it is not really meant to be used on its own, but is imported
+ * by more specific type definitions (standardized or custom) to provide the structure and
+ * properties shared by all FDC3 context data types.
+ *
+ * The key element of FDC3 context types is their mandatory `type` property, which is used
+ * to identify what type of data the object represents, and what shape it has.
+ *
+ * The FDC3 context type, and all derived types, define the minimum set of fields a context
+ * data object of a particular type can be expected to have, but this can always be extended
+ * with custom fields as appropriate.
+ */
+export interface Context {
+    /**
+     * Context data objects may include a set of equivalent key-value pairs that can be used to
+     * help applications identify and look up the context type they receive in their own domain.
+     * The idea behind this design is that applications can provide as many equivalent
+     * identifiers to a target application as possible, e.g. an instrument may be represented by
+     * an ISIN, CUSIP or Bloomberg identifier.
+     *
+     * Identifiers do not make sense for all types of data, so the `id` property is therefore
+     * optional, but some derived types may choose to require at least one identifier.
+     * Identifier values SHOULD always be of type string.
+     */
+    id?: { [key: string]: any };
+    /**
+     * Context data objects may include a name property that can be used for more information,
+     * or display purposes. Some derived types may require the name object as mandatory,
+     * depending on use case.
+     */
+    name?: string;
+    /**
+     * The type property is the only _required_ part of the FDC3 context data schema. The FDC3
+     * [API](https://fdc3.finos.org/docs/api/spec) relies on the `type` property being present
+     * to route shared context data appropriately.
+     *
+     * FDC3 [Intents](https://fdc3.finos.org/docs/intents/spec) also register the context data
+     * types they support in an FDC3 [App
+     * Directory](https://fdc3.finos.org/docs/app-directory/overview), used for intent discovery
+     * and routing.
+     *
+     * Standardized FDC3 context types have well-known `type` properties prefixed with the
+     * `fdc3` namespace, e.g. `fdc3.instrument`. For non-standard types, e.g. those defined and
+     * used by a particular organization, the convention is to prefix them with an
+     * organization-specific namespace, e.g. `blackrock.fund`.
+     *
+     * See the [Context Data Specification](https://fdc3.finos.org/docs/context/spec) for more
+     * information about context data types.
+     */
+    type: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to broadcast context on a channel.
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface BroadcastBridgeRequest {
+    meta: BroadcastBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: BroadcastBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "broadcastRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface BroadcastBridgeRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ *
+ * Optional field that represents the destination that the request should be routed to. Must
+ * be set by the Desktop Agent for API calls that include a target app parameter and must
+ * include the name of the Desktop Agent hosting the target application.
+ *
+ * Represents identifiers that MUST include the Desktop Agent name and MAY identify a
+ * specific app or instance.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+ * be set by the bridge.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ */
+export interface MetaSource {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     *
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     */
+    desktopAgent: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface BroadcastBridgeRequestPayload {
+    /**
+     * The Id of the Channel that the broadcast was sent on.
+     */
+    channelId: string;
+    /**
+     * The context object that is to be broadcast.
+     */
+    context: Context;
+}
+
+/**
+ * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
+ * messages sent in either direction.
+ */
+export interface ConnectionStepMessage {
+    meta: ConnectionStepMetadata;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: { [key: string]: any };
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: ConnectionStepMessageType;
+}
+
+/**
+ * Metadata for this connection step message.
+ */
+export interface ConnectionStepMetadata {
+    requestUuid?:  string;
+    responseUuid?: string;
+    timestamp:     Date;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+export type ConnectionStepMessageType = "hello" | "handshake" | "authenticationFailed" | "connectedAgentsUpdate";
+
+/**
+ * Hello message sent by the Bridge to anyone connecting to the Bridge (enables
+ * identification as a bridge and confirmation of whether authentication is required)
+ *
+ * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
+ * messages sent in either direction.
+ */
+export interface ConnectionStep2Hello {
+    meta: ConnectionStep2HelloMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: ConnectionStep2HelloPayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "hello";
+}
+
+/**
+ * Metadata for this connection step message.
+ */
+export interface ConnectionStep2HelloMeta {
+    timestamp: Date;
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface ConnectionStep2HelloPayload {
+    /**
+     * A flag indicating whether the Desktop Agent Bridge requires authentication or not.
+     */
+    authRequired: boolean;
+    /**
+     * An optional Desktop Agent Bridge JWT authentication token if the Desktop Agent want to
+     * authenticate a bridge.
+     */
+    authToken?: string;
+    /**
+     * The version of the Bridge
+     */
+    desktopAgentBridgeVersion: string;
+    /**
+     * The FDC3 versions supported by the Bridge
+     */
+    supportedFDC3Versions: string[];
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Handshake message sent by the Desktop Agent to the Bridge (including requested name,
+ * channel state and authentication data)
+ *
+ * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
+ * messages sent in either direction.
+ */
+export interface ConnectionStep3Handshake {
+    meta: ConnectionStep3HandshakeMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: ConnectionStep3HandshakePayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "handshake";
+}
+
+/**
+ * Metadata for this connection step message.
+ */
+export interface ConnectionStep3HandshakeMeta {
+    requestUuid: string;
+    timestamp:   Date;
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface ConnectionStep3HandshakePayload {
+    authToken?: string;
+    /**
+     * The current state of the Desktop Agent's App and User channels (exclude any Private
+     * channels), as a mapping of channel id to an array of Context objects, one per type found
+     * in the channel, most recent first.
+     */
+    channelsState: { [key: string]: Context[] };
+    /**
+     * Desktop Agent ImplementationMetadata trying to connect to the bridge.
+     */
+    implementationMetadata: ConnectingAgentImplementationMetadata;
+    /**
+     * The requested Desktop Agent name
+     */
+    requestedName: string;
+}
+
+/**
+ * Desktop Agent ImplementationMetadata trying to connect to the bridge.
+ *
+ * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
+ */
+export interface ConnectingAgentImplementationMetadata {
+    /**
+     * The version number of the FDC3 specification that the implementation provides.
+     * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
+     */
+    fdc3Version: string;
+    /**
+     * Metadata indicating whether the Desktop Agent implements optional features of
+     * the Desktop Agent API.
+     */
+    optionalFeatures: OptionalFeatures;
+    /**
+     * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
+     * OpenFin etc.).
+     */
+    provider: string;
+    /**
+     * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
+     */
+    providerVersion?: string;
+}
+
+/**
+ * Metadata indicating whether the Desktop Agent implements optional features of
+ * the Desktop Agent API.
+ */
+export interface OptionalFeatures {
+    /**
+     * Used to indicate whether the experimental Desktop Agent Bridging
+     * feature is implemented by the Desktop Agent.
+     */
+    DesktopAgentBridging: boolean;
+    /**
+     * Used to indicate whether the exposure of 'originating app metadata' for
+     * context and intent messages is supported by the Desktop Agent.
+     */
+    OriginatingAppMetadata: boolean;
+    /**
+     * Used to indicate whether the optional `fdc3.joinUserChannel`,
+     * `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
+     * the Desktop Agent.
+     */
+    UserChannelMembershipAPIs: boolean;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Message sent by Bridge to Desktop Agent if their authentication fails.
+ *
+ * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
+ * messages sent in either direction.
+ */
+export interface ConnectionStep4AuthenticationFailed {
+    meta: ConnectionStep4AuthenticationFailedMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: ConnectionStep4AuthenticationFailedPayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "authenticationFailed";
+}
+
+/**
+ * Metadata for this connection step message.
+ */
+export interface ConnectionStep4AuthenticationFailedMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface ConnectionStep4AuthenticationFailedPayload {
+    message?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * Message sent by Bridge to all Desktop Agent when an agent joins or leaves the bridge,
+ * includes the details of all agents, the change made and the expected channel state for
+ * all agents.
+ *
+ * A message used during the connection flow for a Desktop Agent to the Bridge. Used for
+ * messages sent in either direction.
+ */
+export interface ConnectionStep6ConnectedAgentsUpdate {
+    meta: ConnectionStep6ConnectedAgentsUpdateMeta;
+    /**
+     * The message payload, containing data pertaining to this connection step.
+     */
+    payload: ConnectionStep6ConnectedAgentsUpdatePayload;
+    /**
+     * Identifies the type of the connection step message.
+     */
+    type: "connectedAgentsUpdate";
+}
+
+/**
+ * Metadata for this connection step message.
+ */
+export interface ConnectionStep6ConnectedAgentsUpdateMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload, containing data pertaining to this connection step.
+ */
+export interface ConnectionStep6ConnectedAgentsUpdatePayload {
+    /**
+     * Should be set when an agent first connects to the bridge and provide its assigned name.
+     */
+    addAgent?: string;
+    /**
+     * Desktop Agent Bridge implementation metadata of all connected agents.
+     */
+    allAgents: DesktopAgentImplementationMetadata[];
+    /**
+     * The updated state of channels that should be adopted by the agents. Should only be set
+     * when an agent is connecting to the bridge.
+     */
+    channelsState?: { [key: string]: Context[] };
+    /**
+     * Should be set when an agent disconnects from the bridge and provide the name that no
+     * longer is assigned.
+     */
+    removeAgent?: string;
+}
+
+/**
+ * Includes the name assigned to the Desktop Agent by the Bridge.
+ *
+ * Metadata relating to the FDC3 Desktop Agent implementation and its provider.
+ */
+export interface DesktopAgentImplementationMetadata {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a particular Desktop
+     * Agent.
+     */
+    desktopAgent: string;
+    /**
+     * The version number of the FDC3 specification that the implementation provides.
+     * The string must be a numeric semver version, e.g. 1.2 or 1.2.1.
+     */
+    fdc3Version: string;
+    /**
+     * Metadata indicating whether the Desktop Agent implements optional features of
+     * the Desktop Agent API.
+     */
+    optionalFeatures: OptionalFeatures;
+    /**
+     * The name of the provider of the Desktop Agent implementation (e.g. Finsemble, Glue42,
+     * OpenFin etc.).
+     */
+    provider: string;
+    /**
+     * The version of the provider of the Desktop Agent implementation (e.g. 5.3.0).
+     */
+    providerVersion?: string;
+}
+
+/**
+ * Identifies the type of the connection step message.
+ */
+
+/**
+ * A response to a findInstances request that contains an error.
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface FindInstancesAgentErrorResponse {
+    meta: FindInstancesAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: PayloadClass;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findInstancesResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface FindInstancesAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface PayloadClass {
+    error: FindInstancesErrors;
+}
+
+/**
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ *
+ * Should be set if the raiseIntent request returned an error.
+ *
+ * Constants representing the errors that can be encountered when calling the `findIntent`,
+ * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
+ * DesktopAgent (`fdc3`).
+ *
+ * Array of error message strings for responses that were not returned to the bridge before
+ * the timeout or because an error occurred. Should be the same length as the `errorSources`
+ * array and ordered the same. May be omitted if all sources responded without errors.
+ *
+ * Constants representing the errors that can be encountered when calling the `open` method
+ * on the DesktopAgent object (`fdc3`).
+ */
+export type FindInstancesErrors = "DesktopAgentNotFound" | "IntentDeliveryFailed" | "MalformedContext" | "NoAppsFound" | "ResolverTimeout" | "ResolverUnavailable" | "TargetAppUnavailable" | "TargetInstanceUnavailable" | "UserCancelledResolution" | "AgentDisconnected" | "NotConnectedToBridge" | "ResponseToBridgeTimedOut" | "MalformedMessage";
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request for details of instances of a particular app
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface FindInstancesAgentRequest {
+    meta: FindInstancesAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindInstancesAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findInstancesRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface FindInstancesAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceIdentifier;
+    timestamp: Date;
+}
+
+/**
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Optional field that represents the destination that the request should be routed to. Must
+ * be set by the Desktop Agent for API calls that include a target app parameter and must
+ * include the name of the Desktop Agent hosting the target application.
+ *
+ * Represents identifiers that MUST include the Desktop Agent name and MAY identify a
+ * specific app or instance.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+ * be set by the bridge.
+ *
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface DestinationObject {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId?: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindInstancesAgentRequestPayload {
+    app: AppIdentifier;
+}
+
+/**
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface AppIdentifier {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent?: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to a findInstances request.
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface FindInstancesAgentResponse {
+    meta: AgentResponseMetadata;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindInstancesAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findInstancesResponse";
+}
+
+/**
+ * The message payload contains a flag indicating whether the API call was successful, plus
+ * any return values for the FDC3 API function called, or indicating that the request
+ * resulted in an error and including a standardized error message.
+ *
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindInstancesAgentResponsePayload {
+    appIdentifiers: AppMetadata[];
+}
+
+/**
+ * Extends an `AppIdentifier`, describing an application or instance of an application, with
+ * additional descriptive metadata that is usually provided by an FDC3 App Directory that
+ * the Desktop Agent connects to.
+ *
+ * The additional information from an app directory can aid in rendering UI elements, such
+ * as a launcher menu or resolver UI. This includes a title, description, tooltip and icon
+ * and screenshot URLs.
+ *
+ * Note that as `AppMetadata` instances are also `AppIdentifiers` they may be passed to the
+ * `app` argument of `fdc3.open`, `fdc3.raiseIntent` etc.
+ */
+export interface AppMetadata {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * A longer, multi-paragraph description for the application that could include markup.
+     */
+    description?: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent?: string;
+    /**
+     * A list of icon URLs for the application that can be used to render UI elements.
+     */
+    icons?: Icon[];
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    /**
+     * An optional set of, implementation specific, metadata fields that can be used to
+     * disambiguate instances, such as a window title or screen position. Must only be set if
+     * `instanceId` is set.
+     */
+    instanceMetadata?: { [key: string]: any };
+    /**
+     * The 'friendly' app name.
+     * This field was used with the `open` and `raiseIntent` calls in FDC3 <2.0, which now
+     * require an `AppIdentifier` wth `appId` set.
+     * Note that for display purposes the `title` field should be used, if set, in preference to
+     * this field.
+     */
+    name?: string;
+    /**
+     * The type of output returned for any intent specified during resolution. May express a
+     * particular context type (e.g. "fdc3.instrument"), channel (e.g. "channel") or a channel
+     * that will receive a specified type (e.g. "channel<fdc3.instrument>").
+     */
+    resultType?: null | string;
+    /**
+     * Images representing the app in common usage scenarios that can be used to render UI
+     * elements.
+     */
+    screenshots?: Image[];
+    /**
+     * A more user-friendly application title that can be used to render UI elements.
+     */
+    title?: string;
+    /**
+     * A tooltip for the application that can be used to render UI elements.
+     */
+    tooltip?: string;
+    /**
+     * The Version of the application.
+     */
+    version?: string;
+}
+
+/**
+ * Describes an Icon image that may be used to represent the application.
+ */
+export interface Icon {
+    /**
+     * The icon dimension, formatted as `<height>x<width>`.
+     */
+    size?: string;
+    /**
+     * The icon url.
+     */
+    src: string;
+    /**
+     * Icon media type. If not present the Desktop Agent may use the src file extension.
+     */
+    type?: string;
+}
+
+/**
+ * Describes an image file, typically a screenshot, that often represents the application in
+ * a common usage scenario.
+ */
+export interface Image {
+    /**
+     * Caption for the image.
+     */
+    label?: string;
+    /**
+     * The image dimension, formatted as `<height>x<width>`.
+     */
+    size?: string;
+    /**
+     * The image url.
+     */
+    src: string;
+    /**
+     * Image media type. If not present the Desktop Agent may use the src file extension.
+     */
+    type?: string;
+}
+
+/**
+ * A response to a findInstances request that contains an error.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface FindInstancesBridgeErrorResponse {
+    meta: FindInstancesBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: MessagePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findInstancesResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface FindInstancesBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface MessagePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * A request for details of instances of a particular app
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface FindInstancesBridgeRequest {
+    meta: FindInstancesBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindInstancesBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findInstancesRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface FindInstancesBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSourceObject;
+    timestamp: Date;
+}
+
+/**
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself.
+ *
+ * Field that represents the source application that a request or response was received
+ * from, or the source Desktop Agent if it issued the request or response itself.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Optional field that represents the destination that the request should be routed to. Must
+ * be set by the Desktop Agent for API calls that include a target app parameter and must
+ * include the name of the Desktop Agent hosting the target application.
+ *
+ * Represents identifiers that MUST include the Desktop Agent name and MAY identify a
+ * specific app or instance.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+ * be set by the bridge.
+ *
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ */
+export interface MetaSourceObject {
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId?: string;
+    /**
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     *
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     */
+    desktopAgent: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindInstancesBridgeRequestPayload {
+    app: AppIdentifier;
+}
+
+/**
+ * A response to a findInstances request.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface FindInstancesBridgeResponse {
+    meta: BridgeResponseMessageMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindInstancesBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findInstancesResponse";
+}
+
+/**
+ * The message payload contains a flag indicating whether the API call was successful, plus
+ * any return values for the FDC3 API function called, or indicating that the request
+ * resulted in an error and including a standardized error message.
+ *
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindInstancesBridgeResponsePayload {
+    appIdentifiers: AppMetadata[];
+}
+
+/**
+ * A response to a findIntent request that contains an error.
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface FindIntentAgentErrorResponse {
+    meta: FindIntentAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: FindIntentAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface FindIntentAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface FindIntentAgentErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request for details of apps available to resolve a particular intent and context pair.
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface FindIntentAgentRequest {
+    meta: FindIntentAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindIntentAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findIntentRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface FindIntentAgentRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceIdentifier;
+    timestamp: Date;
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindIntentAgentRequestPayload {
+    context?:    Context;
+    intent:      string;
+    resultType?: string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to a findIntent request.
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface FindIntentAgentResponse {
+    meta: FindIntentAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindIntentAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface FindIntentAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindIntentAgentResponsePayload {
+    appIntent: AppIntent;
+}
+
+/**
+ * An interface that relates an intent to apps.
+ */
+export interface AppIntent {
+    /**
+     * Details of applications that can resolve the intent.
+     */
+    apps: AppMetadata[];
+    /**
+     * Details of the intent whose relationship to resolving applications is being described.
+     */
+    intent: IntentMetadata;
+}
+
+/**
+ * Details of the intent whose relationship to resolving applications is being described.
+ *
+ * Metadata describing an Intent.
+ */
+export interface IntentMetadata {
+    /**
+     * Display name for the intent.
+     */
+    displayName?: string;
+    /**
+     * The unique name of the intent that can be invoked by the raiseIntent call.
+     */
+    name: string;
+}
+
+/**
+ * A response to a findIntent request that contains an error.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface FindIntentBridgeErrorResponse {
+    meta: FindIntentBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: FindIntentBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface FindIntentBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface FindIntentBridgeErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * A request for details of apps available to resolve a particular intent and context pair.
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface FindIntentBridgeRequest {
+    meta: FindIntentBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindIntentBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findIntentRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface FindIntentBridgeRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    BridgeParticipantIdentifier;
+    timestamp: Date;
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindIntentBridgeRequestPayload {
+    context?:    Context;
+    intent:      string;
+    resultType?: string;
+}
+
+/**
+ * A response to a findIntent request.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface FindIntentBridgeResponse {
+    meta: FindIntentBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindIntentBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface FindIntentBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindIntentBridgeResponsePayload {
+    appIntent: AppIntent;
+}
+
+/**
+ * A response to a findIntentsByContext request that contains an error.
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface FindIntentsByContextAgentErrorResponse {
+    meta: FindIntentsByContextAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: FindIntentsByContextAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentsByContextResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface FindIntentsByContextAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface FindIntentsByContextAgentErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request for details of intents and apps available to resolve them for a particular
+ * context.
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface FindIntentsByContextAgentRequest {
+    meta: FindIntentsByContextAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindIntentsByContextAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findIntentsByContextRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface FindIntentsByContextAgentRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindIntentsByContextAgentRequestPayload {
+    context:     Context;
+    resultType?: string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to a findIntentsByContext request.
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface FindIntentsByContextAgentResponse {
+    meta: FindIntentsByContextAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindIntentsByContextAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentsByContextResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface FindIntentsByContextAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindIntentsByContextAgentResponsePayload {
+    appIntents: AppIntent[];
+}
+
+/**
+ * A response to a findIntentsByContext request that contains an error.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface FindIntentsByContextBridgeErrorResponse {
+    meta: FindIntentsByContextBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: FindIntentsByContextBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentsByContextResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface FindIntentsByContextBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface FindIntentsByContextBridgeErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * A request for details of intents and apps available to resolve them for a particular
+ * context.
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface FindIntentsByContextBridgeRequest {
+    meta: FindIntentsByContextBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: FindIntentsByContextBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "findIntentsByContextRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface FindIntentsByContextBridgeRequestMeta {
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: BridgeParticipantIdentifier;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface FindIntentsByContextBridgeRequestPayload {
+    context:     Context;
+    resultType?: string;
+}
+
+/**
+ * A response to a findIntentsByContext request.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface FindIntentsByContextBridgeResponse {
+    meta: FindIntentsByContextBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: FindIntentsByContextBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "findIntentsByContextResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface FindIntentsByContextBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface FindIntentsByContextBridgeResponsePayload {
+    appIntents: AppIntent[];
+}
+
+/**
+ * A response to a getAppMetadata request that contains an error.
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface GetAppMetadataAgentErrorResponse {
+    meta: GetAppMetadataAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: GetAppMetadataAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "getAppMetadataResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface GetAppMetadataAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface GetAppMetadataAgentErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request for metadata about an app
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface GetAppMetadataAgentRequest {
+    meta: GetAppMetadataAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: GetAppMetadataAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "getAppMetadataRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface GetAppMetadataAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceIdentifier;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface GetAppMetadataAgentRequestPayload {
+    app: AppObject;
+}
+
+/**
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface AppObject {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to a getAppMetadata request.
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface GetAppMetadataAgentResponse {
+    meta: GetAppMetadataAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: GetAppMetadataAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "getAppMetadataResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface GetAppMetadataAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface GetAppMetadataAgentResponsePayload {
+    appMetadata: AppMetadata;
+}
+
+/**
+ * A response to a getAppMetadata request that contains an error.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface GetAppMetadataBridgeErrorResponse {
+    meta: GetAppMetadataBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: GetAppMetadataBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "getAppMetadataResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface GetAppMetadataBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface GetAppMetadataBridgeErrorResponsePayload {
+    error: FindInstancesErrors;
+}
+
+/**
+ * A request for metadata about an app
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface GetAppMetadataBridgeRequest {
+    meta: GetAppMetadataBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: GetAppMetadataBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "getAppMetadataRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface GetAppMetadataBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface GetAppMetadataBridgeRequestPayload {
+    app: AppObject;
+}
+
+/**
+ * A response to a getAppMetadata request.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface GetAppMetadataBridgeResponse {
+    meta: GetAppMetadataBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: GetAppMetadataBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "getAppMetadataResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface GetAppMetadataBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface GetAppMetadataBridgeResponsePayload {
+    appMetadata: AppMetadata;
+}
+
+/**
+ * A response to an open request that contains an error
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface OpenAgentErrorResponse {
+    meta: OpenAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: OpenAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "openResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface OpenAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface OpenAgentErrorResponsePayload {
+    error: OpenErrorResponsePayload;
+}
+
+/**
+ * Constants representing the errors that can be encountered when calling the `open` method
+ * on the DesktopAgent object (`fdc3`).
+ *
+ * Array of error message strings for responses that were not returned to the bridge before
+ * the timeout or because an error occurred. Should be the same length as the `errorSources`
+ * array and ordered the same. May be omitted if all sources responded without errors.
+ *
+ * Constants representing the errors that can be encountered when calling the `findIntent`,
+ * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
+ * DesktopAgent (`fdc3`).
+ */
+export type OpenErrorResponsePayload = "AppNotFound" | "AppTimeout" | "DesktopAgentNotFound" | "ErrorOnLaunch" | "MalformedContext" | "ResolverUnavailable" | "AgentDisconnected" | "NotConnectedToBridge" | "ResponseToBridgeTimedOut" | "MalformedMessage";
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to open an application
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface OpenAgentRequest {
+    meta: OpenAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: OpenAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "openRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface OpenAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source:    SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface OpenAgentRequestPayload {
+    /**
+     * The application to open on the specified Desktop Agent
+     */
+    app:      AppToOpen;
+    context?: Context;
+}
+
+/**
+ * The application to open on the specified Desktop Agent
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface AppToOpen {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to an open request
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface OpenAgentResponse {
+    meta: OpenAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: OpenAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "openResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface OpenAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface OpenAgentResponsePayload {
+    appIdentifier: AppIdentifier;
+}
+
+/**
+ * A response to an open request that contains an error
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface OpenBridgeErrorResponse {
+    meta: OpenBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: OpenBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "openResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface OpenBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface OpenBridgeErrorResponsePayload {
+    error: OpenErrorResponsePayload;
+}
+
+/**
+ * A request to open an application
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface OpenBridgeRequest {
+    meta: OpenBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: OpenBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "openRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface OpenBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: DestinationObject;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface OpenBridgeRequestPayload {
+    /**
+     * The application to open on the specified Desktop Agent
+     */
+    app:      AppToOpen;
+    context?: Context;
+}
+
+/**
+ * A response to an open request
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface OpenBridgeResponse {
+    meta: OpenBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: OpenBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "openResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface OpenBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface OpenBridgeResponsePayload {
+    appIdentifier: AppIdentifier;
+}
+
+/**
+ * A request to broadcast on a PrivateChannel.
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelBroadcastAgentRequest {
+    meta: PrivateChannelBroadcastAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelBroadcastAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.broadcast";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelBroadcastAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ *
+ * Optional field that represents the destination that the request should be routed to. Must
+ * be set by the Desktop Agent for API calls that include a target app parameter and must
+ * include the name of the Desktop Agent hosting the target application.
+ *
+ * Represents identifiers that MUST include the Desktop Agent name and MAY identify a
+ * specific app or instance.
+ *
+ * Field that represents the source application that the request was received from, or the
+ * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+ * be set by the bridge.
+ */
+export interface MetaDestination {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelBroadcastAgentRequestPayload {
+    /**
+     * The Id of the PrivateChannel that the broadcast was sent on
+     */
+    channelId: string;
+    /**
+     * The context object that was the payload of a broadcast message.
+     */
+    context: Context;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to broadcast on a PrivateChannel.
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelBroadcastBridgeRequest {
+    meta: PrivateChannelBroadcastBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelBroadcastBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.broadcast";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface PrivateChannelBroadcastBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelBroadcastBridgeRequestPayload {
+    /**
+     * The Id of the PrivateChannel that the broadcast was sent on
+     */
+    channelId: string;
+    /**
+     * The context object that was the payload of a broadcast message.
+     */
+    context: Context;
+}
+
+/**
+ * A request to forward on an EventListenerAdded event, relating to a PrivateChannel
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelEventListenerAddedAgentRequest {
+    meta: PrivateChannelEventListenerAddedAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelEventListenerAddedAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.eventListenerAdded";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelEventListenerAddedAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelEventListenerAddedAgentRequestPayload {
+    /**
+     * The id of the PrivateChannel that the event listener was added to.
+     */
+    channelId:    string;
+    listenerType: PrivateChannelEventListenerTypes;
+}
+
+/**
+ * Event listener type names for Private Channel events.
+ */
+export type PrivateChannelEventListenerTypes = "onAddContextListener" | "onUnsubscribe" | "onDisconnect";
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to forward on an EventListenerAdded event, relating to a PrivateChannel
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelEventListenerAddedBridgeRequest {
+    meta: PrivateChannelEventListenerAddedBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelEventListenerAddedBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.eventListenerAdded";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface PrivateChannelEventListenerAddedBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelEventListenerAddedBridgeRequestPayload {
+    /**
+     * The id of the PrivateChannel that the event listener was added to.
+     */
+    channelId:    string;
+    listenerType: PrivateChannelEventListenerTypes;
+}
+
+/**
+ * A request to forward on an EventListenerRemoved event, relating to a PrivateChannel
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelEventListenerRemovedAgentRequest {
+    meta: PrivateChannelEventListenerRemovedAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelEventListenerRemovedAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.eventListenerRemoved";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelEventListenerRemovedAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelEventListenerRemovedAgentRequestPayload {
+    /**
+     * The id of the PrivateChannel that the event listener was removed from.
+     */
+    channelId:    string;
+    listenerType: PrivateChannelEventListenerTypes;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to forward on an EventListenerRemoved event, relating to a PrivateChannel
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelEventListenerRemovedBridgeRequest {
+    meta: PrivateChannelEventListenerRemovedBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelEventListenerRemovedBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.eventListenerRemoved";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface PrivateChannelEventListenerRemovedBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelEventListenerRemovedBridgeRequestPayload {
+    /**
+     * The id of the PrivateChannel that the event listener was removed from.
+     */
+    channelId:    string;
+    listenerType: PrivateChannelEventListenerTypes;
+}
+
+/**
+ * A request to forward on an AddContextListener event, relating to a PrivateChannel
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelOnAddContextListenerAgentRequest {
+    meta: PrivateChannelOnAddContextListenerAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnAddContextListenerAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onAddContextListener";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelOnAddContextListenerAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnAddContextListenerAgentRequestPayload {
+    /**
+     * The id of the PrivateChannel that the context listener was added to.
+     */
+    channelId: string;
+    /**
+     * The type of the context listener added. Should be null for an untyped listener.
+     */
+    contextType: null | string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to forward on an AddContextListener event, relating to a PrivateChannel
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelOnAddContextListenerBridgeRequest {
+    meta: PrivateChannelOnAddContextListenerBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnAddContextListenerBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onAddContextListener";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface PrivateChannelOnAddContextListenerBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnAddContextListenerBridgeRequestPayload {
+    /**
+     * The id of the PrivateChannel that the context listener was added to.
+     */
+    channelId: string;
+    /**
+     * The type of the context listener added. Should be null for an untyped listener.
+     */
+    contextType: null | string;
+}
+
+/**
+ * A request to forward on a Disconnect event, relating to a PrivateChannel
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelOnDisconnectAgentRequest {
+    meta: PrivateChannelOnDisconnectAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnDisconnectAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onDisconnect";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelOnDisconnectAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnDisconnectAgentRequestPayload {
+    /**
+     * The id of the PrivateChannel that the agent discconnected from.
+     */
+    channelId: string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to forward on a Disconnect event, relating to a PrivateChannel
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelOnDisconnectBridgeRequest {
+    meta: PrivateChannelOnDisconnectBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnDisconnectBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onDisconnect";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface PrivateChannelOnDisconnectBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnDisconnectBridgeRequestPayload {
+    /**
+     * The id of the PrivateChannel that the agent discconnected from.
+     */
+    channelId: string;
+}
+
+/**
+ * A request to forward on an Unsubscribe event, relating to a PrivateChannel
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface PrivateChannelOnUnsubscribeAgentRequest {
+    meta: PrivateChannelOnUnsubscribeAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnUnsubscribeAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onUnsubscribe";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface PrivateChannelOnUnsubscribeAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source?:   SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnUnsubscribeAgentRequestPayload {
+    /**
+     * The id of the PrivateChannel that the context listener was unsubscribed from.
+     */
+    channelId: string;
+    /**
+     * The type of the context listener that was unsubscribed. Should be null for an untyped
+     * listener.
+     */
+    contextType: null | string;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to forward on an Unsubscribe event, relating to a PrivateChannel
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface PrivateChannelOnUnsubscribeBridgeRequest {
+    meta: ERequestMetadata;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: PrivateChannelOnUnsubscribeBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "PrivateChannel.onUnsubscribe";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface ERequestMetadata {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination?: MetaDestination;
+    requestUuid:  string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface PrivateChannelOnUnsubscribeBridgeRequestPayload {
+    /**
+     * The id of the PrivateChannel that the context listener was unsubscribed from.
+     */
+    channelId: string;
+    /**
+     * The type of the context listener that was unsubscribed. Should be null for an untyped
+     * listener.
+     */
+    contextType: null | string;
+}
+
+/**
+ * A response to a request to raise an intent that contains an error.
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface RaiseIntentAgentErrorResponse {
+    meta: RaiseIntentAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: RaiseIntentAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface RaiseIntentAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Used if a raiseIntent request resulted in an error.
+ *
+ * Error message payload containing an standardized error string.
+ */
+export interface RaiseIntentAgentErrorResponsePayload {
+    /**
+     * Should be set if the raiseIntent request returned an error.
+     */
+    error: FindInstancesErrors;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A request to raise an intent.
+ *
+ * A request message from a Desktop Agent to the Bridge.
+ */
+export interface RaiseIntentAgentRequest {
+    meta: RaiseIntentAgentRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: RaiseIntentAgentRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "raiseIntentRequest";
+}
+
+/**
+ * Metadata for a request message sent by Desktop Agents to the Bridge.
+ */
+export interface RaiseIntentAgentRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination: MetaDestination;
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself.
+     */
+    source:    SourceObject;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface RaiseIntentAgentRequestPayload {
+    app:     AppDestinationIdentifier;
+    context: Context;
+    intent:  string;
+}
+
+/**
+ * Field that represents a destination App on a remote Desktop Agent that a request is to be
+ * sent to.
+ *
+ * Identifies a particular Desktop Agent in Desktop Agent Bridging scenarios
+ * where a request needs to be directed to a Desktop Agent rather than a specific app, or a
+ * response message is returned by the Desktop Agent (or more specifically its resolver)
+ * rather than a specific app. Used as a substitute for `AppIdentifier` in cases where no
+ * app details are available or are appropriate.
+ *
+ * Array of DesktopAgentIdentifiers for responses that were not returned to the bridge
+ * before the timeout or because an error occurred. May be omitted if all sources responded
+ * without errors. MUST include the `desktopAgent` field when returned by the bridge.
+ *
+ * Array of DesktopAgentIdentifiers for the sources that generated responses to the request.
+ * Will contain a single value for individual responses and multiple values for responses
+ * that were collated by the bridge. May be omitted if all sources errored. MUST include the
+ * `desktopAgent` field when returned by the bridge.
+ *
+ * Field that represents a destination Desktop Agent that a request is to be sent to.
+ *
+ * Identifies an application, or instance of an application, and is used to target FDC3 API
+ * calls, such as `fdc3.open` or `fdc3.raiseIntent` at specific applications or application
+ * instances.
+ *
+ * Will always include at least an `appId` field, which uniquely identifies a specific app.
+ *
+ * If the `instanceId` field is set then the `AppMetadata` object represents a specific
+ * instance of the application that may be addressed using that Id.
+ *
+ * Field that represents the source application that a request or response was received
+ * from.
+ *
+ * Identifier for the app instance that was selected (or started) to resolve the intent.
+ * `source.instanceId` MUST be set, indicating the specific app instance that
+ * received the intent.
+ */
+export interface AppDestinationIdentifier {
+    /**
+     * Used in Desktop Agent Bridging to attribute or target a message to a
+     * particular Desktop Agent.
+     *
+     * The Desktop Agent that the app is available on. Used in Desktop Agent Bridging to
+     * identify the Desktop Agent to target.
+     */
+    desktopAgent: string;
+    /**
+     * The unique application identifier located within a specific application directory
+     * instance. An example of an appId might be 'app@sub.root'.
+     */
+    appId: string;
+    /**
+     * An optional instance identifier, indicating that this object represents a specific
+     * instance of the application described.
+     */
+    instanceId?: string;
+    [property: string]: any;
+}
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Request' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A response to a request to raise an intent.
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface RaiseIntentAgentResponse {
+    meta: RaiseIntentAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: RaiseIntentAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface RaiseIntentAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface RaiseIntentAgentResponsePayload {
+    /**
+     * Used if the raiseIntent request was successfully resolved.
+     */
+    intentResolution: IntentResolution;
+}
+
+/**
+ * Used if the raiseIntent request was successfully resolved.
+ *
+ * IntentResolution provides a standard format for data returned upon resolving an intent.
+ *
+ * ```javascript
+ * //resolve a "Chain" type intent
+ * let resolution = await agent.raiseIntent("intentName", context);
+ *
+ * //resolve a "Client-Service" type intent with a data response or a Channel
+ * let resolution = await agent.raiseIntent("intentName", context);
+ * try {
+ * const result = await resolution.getResult();
+ * if (result && result.broadcast) {
+ * console.log(`${resolution.source} returned a channel with id ${result.id}`);
+ * } else if (result){
+ * console.log(`${resolution.source} returned data: ${JSON.stringify(result)}`);
+ * } else {
+ * console.error(`${resolution.source} didn't return data`
+ * }
+ * } catch(error) {
+ * console.error(`${resolution.source} returned an error: ${error}`);
+ * }
+ *
+ * // Use metadata about the resolving app instance to target a further intent
+ * await agent.raiseIntent("intentName", context, resolution.source);
+ * ```
+ */
+export interface IntentResolution {
+    /**
+     * The intent that was raised. May be used to determine which intent the user
+     * chose in response to `fdc3.raiseIntentForContext()`.
+     */
+    intent: string;
+    /**
+     * Identifier for the app instance that was selected (or started) to resolve the intent.
+     * `source.instanceId` MUST be set, indicating the specific app instance that
+     * received the intent.
+     */
+    source: AppIdentifier;
+}
+
+/**
+ * A response to a request to raise an intent that contains an error.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface RaiseIntentBridgeErrorResponse {
+    meta: RaiseIntentBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: RaiseIntentBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface RaiseIntentBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Used if a raiseIntent request resulted in an error.
+ *
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface RaiseIntentBridgeErrorResponsePayload {
+    /**
+     * Should be set if the raiseIntent request returned an error.
+     */
+    error: FindInstancesErrors;
+}
+
+/**
+ * A request to raise an intent.
+ *
+ * A request message forwarded from the Bridge onto a Desktop Agent connected to it.
+ */
+export interface RaiseIntentBridgeRequest {
+    meta: RaiseIntentBridgeRequestMeta;
+    /**
+     * The message payload typically contains the arguments to FDC3 API functions.
+     */
+    payload: RaiseIntentBridgeRequestPayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Request' appended.
+     */
+    type: "raiseIntentRequest";
+}
+
+/**
+ * Metadata required in a request message forwarded on by the Bridge
+ */
+export interface RaiseIntentBridgeRequestMeta {
+    /**
+     * Optional field that represents the destination that the request should be routed to. Must
+     * be set by the Desktop Agent for API calls that include a target app parameter and must
+     * include the name of the Desktop Agent hosting the target application.
+     */
+    destination: MetaDestination;
+    requestUuid: string;
+    /**
+     * Field that represents the source application that the request was received from, or the
+     * source Desktop Agent if it issued the request itself. The Desktop Agent identifier MUST
+     * be set by the bridge.
+     */
+    source:    MetaSource;
+    timestamp: Date;
+}
+
+/**
+ * The message payload typically contains the arguments to FDC3 API functions.
+ */
+export interface RaiseIntentBridgeRequestPayload {
+    app:     AppDestinationIdentifier;
+    context: Context;
+    intent:  string;
+}
+
+/**
+ * A response to a request to raise an intent.
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface RaiseIntentBridgeResponse {
+    meta: RaiseIntentBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: RaiseIntentBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface RaiseIntentBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface RaiseIntentBridgeResponsePayload {
+    /**
+     * Used if the raiseIntent request was successfully resolved.
+     */
+    intentResolution: IntentResolution;
+}
+
+/**
+ * A secondary response to a request to raise an intent used to deliver the intent result,
+ * which contains an error
+ *
+ * A response message from a Desktop Agent to the Bridge containing an error, to be used in
+ * preference to the standard response when an error needs to be returned.
+ */
+export interface RaiseIntentResultAgentErrorResponse {
+    meta: RaiseIntentResultAgentErrorResponseMeta;
+    /**
+     * Error message payload containing an standardized error string.
+     */
+    payload: RaiseIntentResultAgentErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResultResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface RaiseIntentResultAgentErrorResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * Error message payload containing an standardized error string.
+ */
+export interface RaiseIntentResultAgentErrorResponsePayload {
+    error: RaiseIntentResultErrorMessage;
+}
+
+/**
+ * Array of error message strings for responses that were not returned to the bridge before
+ * the timeout or because an error occurred. Should be the same length as the `errorSources`
+ * array and ordered the same. May be omitted if all sources responded without errors.
+ *
+ * Constants representing the errors that can be encountered when calling the `open` method
+ * on the DesktopAgent object (`fdc3`).
+ *
+ * Constants representing the errors that can be encountered when calling the `findIntent`,
+ * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
+ * DesktopAgent (`fdc3`).
+ */
+export type RaiseIntentResultErrorMessage = "IntentHandlerRejected" | "NoResultReturned" | "AgentDisconnected" | "NotConnectedToBridge" | "ResponseToBridgeTimedOut" | "MalformedMessage";
+
+/**
+ * Identifies the type of the message and it is typically set to the FDC3 function name that
+ * the message relates to, e.g. 'findIntent', with 'Response' appended.
+ *
+ * Unique identifier for a request or event message. Required in all message types.
+ *
+ * Unique identifier for a response to a specific message and must always be accompanied by
+ * a RequestUuid.
+ */
+
+/**
+ * A secondary response to a request to raise an intent used to deliver the intent result
+ *
+ * A response message from a Desktop Agent to the Bridge.
+ */
+export interface RaiseIntentResultAgentResponse {
+    meta: RaiseIntentResultAgentResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: RaiseIntentResultAgentResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResultResponse";
+}
+
+/**
+ * Metadata for a response messages sent by a Desktop Agent to the Bridge
+ */
+export interface RaiseIntentResultAgentResponseMeta {
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface RaiseIntentResultAgentResponsePayload {
+    intentResult: IntentResult;
+}
+
+export interface IntentResult {
+    context?: Context;
+    channel?: Channel;
+}
+
+/**
+ * Represents a context channel that applications can use to send and receive
+ * context data.
+ *
+ * Please note that There are differences in behavior when you interact with a
+ * User channel via the `DesktopAgent` interface and the `Channel` interface.
+ * Specifically, when 'joining' a User channel or adding a context listener
+ * when already joined to a channel via the `DesktopAgent` interface, existing
+ * context (matching the type of the context listener) on the channel is
+ * received by the context listener immediately. Whereas, when a context
+ * listener is added via the Channel interface, context is not received
+ * automatically, but may be retrieved manually via the `getCurrentContext()`
+ * function.
+ */
+export interface Channel {
+    /**
+     * Channels may be visualized and selectable by users. DisplayMetadata may be used to
+     * provide hints on how to see them.
+     * For App channels, displayMetadata would typically not be present.
+     */
+    displayMetadata?: DisplayMetadata;
+    /**
+     * Constant that uniquely identifies this channel.
+     */
+    id: string;
+    /**
+     * Uniquely defines each channel type.
+     * Can be "user", "app" or "private".
+     */
+    type: Type;
+}
+
+/**
+ * Channels may be visualized and selectable by users. DisplayMetadata may be used to
+ * provide hints on how to see them.
+ * For App channels, displayMetadata would typically not be present.
+ *
+ * A system channel will be global enough to have a presence across many apps. This gives us
+ * some hints
+ * to render them in a standard way. It is assumed it may have other properties too, but if
+ * it has these,
+ * this is their meaning.
+ */
+export interface DisplayMetadata {
+    /**
+     * The color that should be associated within this channel when displaying this channel in a
+     * UI, e.g: `0xFF0000`.
+     */
+    color?: string;
+    /**
+     * A URL of an image that can be used to display this channel.
+     */
+    glyph?: string;
+    /**
+     * A user-readable name for this channel, e.g: `"Red"`.
+     */
+    name?: string;
+}
+
+/**
+ * Uniquely defines each channel type.
+ * Can be "user", "app" or "private".
+ */
+export type Type = "app" | "private" | "user";
+
+/**
+ * A secondary response to a request to raise an intent used to deliver the intent result,
+ * which contains an error
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request, used where all connected agents returned errors.
+ */
+export interface RaiseIntentResultBridgeErrorResponse {
+    meta: RaiseIntentResultBridgeErrorResponseMeta;
+    /**
+     * The error message payload contains details of an error return to the app or agent that
+     * raised the original request.
+     */
+    payload: RaiseIntentResultBridgeErrorResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResultResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface RaiseIntentResultBridgeErrorResponseMeta {
+    errorDetails: ResponseErrorDetail[];
+    errorSources: DesktopAgentIdentifier[];
+    requestUuid:  string;
+    responseUuid: string;
+    timestamp:    Date;
+}
+
+/**
+ * The error message payload contains details of an error return to the app or agent that
+ * raised the original request.
+ */
+export interface RaiseIntentResultBridgeErrorResponsePayload {
+    error: RaiseIntentResultErrorMessage;
+}
+
+/**
+ * A secondary response to a request to raise an intent used to deliver the intent result
+ *
+ * A response message from the Bridge back to the original Desktop Agent that raised the
+ * request.
+ */
+export interface RaiseIntentResultBridgeResponse {
+    meta: RaiseIntentResultBridgeResponseMeta;
+    /**
+     * The message payload typically contains return values for FDC3 API functions.
+     */
+    payload: RaiseIntentResultBridgeResponsePayload;
+    /**
+     * Identifies the type of the message and it is typically set to the FDC3 function name that
+     * the message relates to, e.g. 'findIntent', with 'Response' appended.
+     */
+    type: "raiseIntentResultResponse";
+}
+
+/**
+ * Metadata required in a response message collated and/or forwarded on by the Bridge
+ */
+export interface RaiseIntentResultBridgeResponseMeta {
+    errorDetails?: ResponseErrorDetail[];
+    errorSources?: DesktopAgentIdentifier[];
+    requestUuid:   string;
+    responseUuid:  string;
+    sources?:      DesktopAgentIdentifier[];
+    timestamp:     Date;
+}
+
+/**
+ * The message payload typically contains return values for FDC3 API functions.
+ */
+export interface RaiseIntentResultBridgeResponsePayload {
+    intentResult: IntentResult;
+}
+
+// Converts JSON strings to/from your types
+// and asserts the results of JSON.parse at runtime
+export class Convert {
+    public static toAgentErrorResponseMessage(json: string): AgentErrorResponseMessage {
+        return cast(JSON.parse(json), r("AgentErrorResponseMessage"));
+    }
+
+    public static agentErrorResponseMessageToJson(value: AgentErrorResponseMessage): string {
+        return JSON.stringify(uncast(value, r("AgentErrorResponseMessage")), null, 2);
+    }
+
+    public static toAgentRequestMessage(json: string): AgentRequestMessage {
+        return cast(JSON.parse(json), r("AgentRequestMessage"));
+    }
+
+    public static agentRequestMessageToJson(value: AgentRequestMessage): string {
+        return JSON.stringify(uncast(value, r("AgentRequestMessage")), null, 2);
+    }
+
+    public static toAgentResponseMessage(json: string): AgentResponseMessage {
+        return cast(JSON.parse(json), r("AgentResponseMessage"));
+    }
+
+    public static agentResponseMessageToJson(value: AgentResponseMessage): string {
+        return JSON.stringify(uncast(value, r("AgentResponseMessage")), null, 2);
+    }
+
+    public static toBridgeErrorResponseMessage(json: string): BridgeErrorResponseMessage {
+        return cast(JSON.parse(json), r("BridgeErrorResponseMessage"));
+    }
+
+    public static bridgeErrorResponseMessageToJson(value: BridgeErrorResponseMessage): string {
+        return JSON.stringify(uncast(value, r("BridgeErrorResponseMessage")), null, 2);
+    }
+
+    public static toBridgeRequestMessage(json: string): BridgeRequestMessage {
+        return cast(JSON.parse(json), r("BridgeRequestMessage"));
+    }
+
+    public static bridgeRequestMessageToJson(value: BridgeRequestMessage): string {
+        return JSON.stringify(uncast(value, r("BridgeRequestMessage")), null, 2);
+    }
+
+    public static toBridgeResponseMessage(json: string): BridgeResponseMessage {
+        return cast(JSON.parse(json), r("BridgeResponseMessage"));
+    }
+
+    public static bridgeResponseMessageToJson(value: BridgeResponseMessage): string {
+        return JSON.stringify(uncast(value, r("BridgeResponseMessage")), null, 2);
+    }
+
+    public static toBroadcastAgentRequest(json: string): BroadcastAgentRequest {
+        return cast(JSON.parse(json), r("BroadcastAgentRequest"));
+    }
+
+    public static broadcastAgentRequestToJson(value: BroadcastAgentRequest): string {
+        return JSON.stringify(uncast(value, r("BroadcastAgentRequest")), null, 2);
+    }
+
+    public static toBroadcastBridgeRequest(json: string): BroadcastBridgeRequest {
+        return cast(JSON.parse(json), r("BroadcastBridgeRequest"));
+    }
+
+    public static broadcastBridgeRequestToJson(value: BroadcastBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("BroadcastBridgeRequest")), null, 2);
+    }
+
+    public static toBridgeCommonDefinitions(json: string): { [key: string]: any } {
+        return cast(JSON.parse(json), m("any"));
+    }
+
+    public static bridgeCommonDefinitionsToJson(value: { [key: string]: any }): string {
+        return JSON.stringify(uncast(value, m("any")), null, 2);
+    }
+
+    public static toConnectionStepMessage(json: string): ConnectionStepMessage {
+        return cast(JSON.parse(json), r("ConnectionStepMessage"));
+    }
+
+    public static connectionStepMessageToJson(value: ConnectionStepMessage): string {
+        return JSON.stringify(uncast(value, r("ConnectionStepMessage")), null, 2);
+    }
+
+    public static toConnectionStep2Hello(json: string): ConnectionStep2Hello {
+        return cast(JSON.parse(json), r("ConnectionStep2Hello"));
+    }
+
+    public static connectionStep2HelloToJson(value: ConnectionStep2Hello): string {
+        return JSON.stringify(uncast(value, r("ConnectionStep2Hello")), null, 2);
+    }
+
+    public static toConnectionStep3Handshake(json: string): ConnectionStep3Handshake {
+        return cast(JSON.parse(json), r("ConnectionStep3Handshake"));
+    }
+
+    public static connectionStep3HandshakeToJson(value: ConnectionStep3Handshake): string {
+        return JSON.stringify(uncast(value, r("ConnectionStep3Handshake")), null, 2);
+    }
+
+    public static toConnectionStep4AuthenticationFailed(json: string): ConnectionStep4AuthenticationFailed {
+        return cast(JSON.parse(json), r("ConnectionStep4AuthenticationFailed"));
+    }
+
+    public static connectionStep4AuthenticationFailedToJson(value: ConnectionStep4AuthenticationFailed): string {
+        return JSON.stringify(uncast(value, r("ConnectionStep4AuthenticationFailed")), null, 2);
+    }
+
+    public static toConnectionStep6ConnectedAgentsUpdate(json: string): ConnectionStep6ConnectedAgentsUpdate {
+        return cast(JSON.parse(json), r("ConnectionStep6ConnectedAgentsUpdate"));
+    }
+
+    public static connectionStep6ConnectedAgentsUpdateToJson(value: ConnectionStep6ConnectedAgentsUpdate): string {
+        return JSON.stringify(uncast(value, r("ConnectionStep6ConnectedAgentsUpdate")), null, 2);
+    }
+
+    public static toFindInstancesAgentErrorResponse(json: string): FindInstancesAgentErrorResponse {
+        return cast(JSON.parse(json), r("FindInstancesAgentErrorResponse"));
+    }
+
+    public static findInstancesAgentErrorResponseToJson(value: FindInstancesAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindInstancesAgentErrorResponse")), null, 2);
+    }
+
+    public static toFindInstancesAgentRequest(json: string): FindInstancesAgentRequest {
+        return cast(JSON.parse(json), r("FindInstancesAgentRequest"));
+    }
+
+    public static findInstancesAgentRequestToJson(value: FindInstancesAgentRequest): string {
+        return JSON.stringify(uncast(value, r("FindInstancesAgentRequest")), null, 2);
+    }
+
+    public static toFindInstancesAgentResponse(json: string): FindInstancesAgentResponse {
+        return cast(JSON.parse(json), r("FindInstancesAgentResponse"));
+    }
+
+    public static findInstancesAgentResponseToJson(value: FindInstancesAgentResponse): string {
+        return JSON.stringify(uncast(value, r("FindInstancesAgentResponse")), null, 2);
+    }
+
+    public static toFindInstancesBridgeErrorResponse(json: string): FindInstancesBridgeErrorResponse {
+        return cast(JSON.parse(json), r("FindInstancesBridgeErrorResponse"));
+    }
+
+    public static findInstancesBridgeErrorResponseToJson(value: FindInstancesBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindInstancesBridgeErrorResponse")), null, 2);
+    }
+
+    public static toFindInstancesBridgeRequest(json: string): FindInstancesBridgeRequest {
+        return cast(JSON.parse(json), r("FindInstancesBridgeRequest"));
+    }
+
+    public static findInstancesBridgeRequestToJson(value: FindInstancesBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("FindInstancesBridgeRequest")), null, 2);
+    }
+
+    public static toFindInstancesBridgeResponse(json: string): FindInstancesBridgeResponse {
+        return cast(JSON.parse(json), r("FindInstancesBridgeResponse"));
+    }
+
+    public static findInstancesBridgeResponseToJson(value: FindInstancesBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("FindInstancesBridgeResponse")), null, 2);
+    }
+
+    public static toFindIntentAgentErrorResponse(json: string): FindIntentAgentErrorResponse {
+        return cast(JSON.parse(json), r("FindIntentAgentErrorResponse"));
+    }
+
+    public static findIntentAgentErrorResponseToJson(value: FindIntentAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentAgentErrorResponse")), null, 2);
+    }
+
+    public static toFindIntentAgentRequest(json: string): FindIntentAgentRequest {
+        return cast(JSON.parse(json), r("FindIntentAgentRequest"));
+    }
+
+    public static findIntentAgentRequestToJson(value: FindIntentAgentRequest): string {
+        return JSON.stringify(uncast(value, r("FindIntentAgentRequest")), null, 2);
+    }
+
+    public static toFindIntentAgentResponse(json: string): FindIntentAgentResponse {
+        return cast(JSON.parse(json), r("FindIntentAgentResponse"));
+    }
+
+    public static findIntentAgentResponseToJson(value: FindIntentAgentResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentAgentResponse")), null, 2);
+    }
+
+    public static toFindIntentBridgeErrorResponse(json: string): FindIntentBridgeErrorResponse {
+        return cast(JSON.parse(json), r("FindIntentBridgeErrorResponse"));
+    }
+
+    public static findIntentBridgeErrorResponseToJson(value: FindIntentBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentBridgeErrorResponse")), null, 2);
+    }
+
+    public static toFindIntentBridgeRequest(json: string): FindIntentBridgeRequest {
+        return cast(JSON.parse(json), r("FindIntentBridgeRequest"));
+    }
+
+    public static findIntentBridgeRequestToJson(value: FindIntentBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("FindIntentBridgeRequest")), null, 2);
+    }
+
+    public static toFindIntentBridgeResponse(json: string): FindIntentBridgeResponse {
+        return cast(JSON.parse(json), r("FindIntentBridgeResponse"));
+    }
+
+    public static findIntentBridgeResponseToJson(value: FindIntentBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentBridgeResponse")), null, 2);
+    }
+
+    public static toFindIntentsByContextAgentErrorResponse(json: string): FindIntentsByContextAgentErrorResponse {
+        return cast(JSON.parse(json), r("FindIntentsByContextAgentErrorResponse"));
+    }
+
+    public static findIntentsByContextAgentErrorResponseToJson(value: FindIntentsByContextAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextAgentErrorResponse")), null, 2);
+    }
+
+    public static toFindIntentsByContextAgentRequest(json: string): FindIntentsByContextAgentRequest {
+        return cast(JSON.parse(json), r("FindIntentsByContextAgentRequest"));
+    }
+
+    public static findIntentsByContextAgentRequestToJson(value: FindIntentsByContextAgentRequest): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextAgentRequest")), null, 2);
+    }
+
+    public static toFindIntentsByContextAgentResponse(json: string): FindIntentsByContextAgentResponse {
+        return cast(JSON.parse(json), r("FindIntentsByContextAgentResponse"));
+    }
+
+    public static findIntentsByContextAgentResponseToJson(value: FindIntentsByContextAgentResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextAgentResponse")), null, 2);
+    }
+
+    public static toFindIntentsByContextBridgeErrorResponse(json: string): FindIntentsByContextBridgeErrorResponse {
+        return cast(JSON.parse(json), r("FindIntentsByContextBridgeErrorResponse"));
+    }
+
+    public static findIntentsByContextBridgeErrorResponseToJson(value: FindIntentsByContextBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextBridgeErrorResponse")), null, 2);
+    }
+
+    public static toFindIntentsByContextBridgeRequest(json: string): FindIntentsByContextBridgeRequest {
+        return cast(JSON.parse(json), r("FindIntentsByContextBridgeRequest"));
+    }
+
+    public static findIntentsByContextBridgeRequestToJson(value: FindIntentsByContextBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextBridgeRequest")), null, 2);
+    }
+
+    public static toFindIntentsByContextBridgeResponse(json: string): FindIntentsByContextBridgeResponse {
+        return cast(JSON.parse(json), r("FindIntentsByContextBridgeResponse"));
+    }
+
+    public static findIntentsByContextBridgeResponseToJson(value: FindIntentsByContextBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("FindIntentsByContextBridgeResponse")), null, 2);
+    }
+
+    public static toGetAppMetadataAgentErrorResponse(json: string): GetAppMetadataAgentErrorResponse {
+        return cast(JSON.parse(json), r("GetAppMetadataAgentErrorResponse"));
+    }
+
+    public static getAppMetadataAgentErrorResponseToJson(value: GetAppMetadataAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataAgentErrorResponse")), null, 2);
+    }
+
+    public static toGetAppMetadataAgentRequest(json: string): GetAppMetadataAgentRequest {
+        return cast(JSON.parse(json), r("GetAppMetadataAgentRequest"));
+    }
+
+    public static getAppMetadataAgentRequestToJson(value: GetAppMetadataAgentRequest): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataAgentRequest")), null, 2);
+    }
+
+    public static toGetAppMetadataAgentResponse(json: string): GetAppMetadataAgentResponse {
+        return cast(JSON.parse(json), r("GetAppMetadataAgentResponse"));
+    }
+
+    public static getAppMetadataAgentResponseToJson(value: GetAppMetadataAgentResponse): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataAgentResponse")), null, 2);
+    }
+
+    public static toGetAppMetadataBridgeErrorResponse(json: string): GetAppMetadataBridgeErrorResponse {
+        return cast(JSON.parse(json), r("GetAppMetadataBridgeErrorResponse"));
+    }
+
+    public static getAppMetadataBridgeErrorResponseToJson(value: GetAppMetadataBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataBridgeErrorResponse")), null, 2);
+    }
+
+    public static toGetAppMetadataBridgeRequest(json: string): GetAppMetadataBridgeRequest {
+        return cast(JSON.parse(json), r("GetAppMetadataBridgeRequest"));
+    }
+
+    public static getAppMetadataBridgeRequestToJson(value: GetAppMetadataBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataBridgeRequest")), null, 2);
+    }
+
+    public static toGetAppMetadataBridgeResponse(json: string): GetAppMetadataBridgeResponse {
+        return cast(JSON.parse(json), r("GetAppMetadataBridgeResponse"));
+    }
+
+    public static getAppMetadataBridgeResponseToJson(value: GetAppMetadataBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("GetAppMetadataBridgeResponse")), null, 2);
+    }
+
+    public static toOpenAgentErrorResponse(json: string): OpenAgentErrorResponse {
+        return cast(JSON.parse(json), r("OpenAgentErrorResponse"));
+    }
+
+    public static openAgentErrorResponseToJson(value: OpenAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("OpenAgentErrorResponse")), null, 2);
+    }
+
+    public static toOpenAgentRequest(json: string): OpenAgentRequest {
+        return cast(JSON.parse(json), r("OpenAgentRequest"));
+    }
+
+    public static openAgentRequestToJson(value: OpenAgentRequest): string {
+        return JSON.stringify(uncast(value, r("OpenAgentRequest")), null, 2);
+    }
+
+    public static toOpenAgentResponse(json: string): OpenAgentResponse {
+        return cast(JSON.parse(json), r("OpenAgentResponse"));
+    }
+
+    public static openAgentResponseToJson(value: OpenAgentResponse): string {
+        return JSON.stringify(uncast(value, r("OpenAgentResponse")), null, 2);
+    }
+
+    public static toOpenBridgeErrorResponse(json: string): OpenBridgeErrorResponse {
+        return cast(JSON.parse(json), r("OpenBridgeErrorResponse"));
+    }
+
+    public static openBridgeErrorResponseToJson(value: OpenBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("OpenBridgeErrorResponse")), null, 2);
+    }
+
+    public static toOpenBridgeRequest(json: string): OpenBridgeRequest {
+        return cast(JSON.parse(json), r("OpenBridgeRequest"));
+    }
+
+    public static openBridgeRequestToJson(value: OpenBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("OpenBridgeRequest")), null, 2);
+    }
+
+    public static toOpenBridgeResponse(json: string): OpenBridgeResponse {
+        return cast(JSON.parse(json), r("OpenBridgeResponse"));
+    }
+
+    public static openBridgeResponseToJson(value: OpenBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("OpenBridgeResponse")), null, 2);
+    }
+
+    public static toPrivateChannelBroadcastAgentRequest(json: string): PrivateChannelBroadcastAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelBroadcastAgentRequest"));
+    }
+
+    public static privateChannelBroadcastAgentRequestToJson(value: PrivateChannelBroadcastAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelBroadcastAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelBroadcastBridgeRequest(json: string): PrivateChannelBroadcastBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelBroadcastBridgeRequest"));
+    }
+
+    public static privateChannelBroadcastBridgeRequestToJson(value: PrivateChannelBroadcastBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelBroadcastBridgeRequest")), null, 2);
+    }
+
+    public static toPrivateChannelEventListenerAddedAgentRequest(json: string): PrivateChannelEventListenerAddedAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelEventListenerAddedAgentRequest"));
+    }
+
+    public static privateChannelEventListenerAddedAgentRequestToJson(value: PrivateChannelEventListenerAddedAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelEventListenerAddedAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelEventListenerAddedBridgeRequest(json: string): PrivateChannelEventListenerAddedBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelEventListenerAddedBridgeRequest"));
+    }
+
+    public static privateChannelEventListenerAddedBridgeRequestToJson(value: PrivateChannelEventListenerAddedBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelEventListenerAddedBridgeRequest")), null, 2);
+    }
+
+    public static toPrivateChannelEventListenerRemovedAgentRequest(json: string): PrivateChannelEventListenerRemovedAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelEventListenerRemovedAgentRequest"));
+    }
+
+    public static privateChannelEventListenerRemovedAgentRequestToJson(value: PrivateChannelEventListenerRemovedAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelEventListenerRemovedAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelEventListenerRemovedBridgeRequest(json: string): PrivateChannelEventListenerRemovedBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelEventListenerRemovedBridgeRequest"));
+    }
+
+    public static privateChannelEventListenerRemovedBridgeRequestToJson(value: PrivateChannelEventListenerRemovedBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelEventListenerRemovedBridgeRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnAddContextListenerAgentRequest(json: string): PrivateChannelOnAddContextListenerAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnAddContextListenerAgentRequest"));
+    }
+
+    public static privateChannelOnAddContextListenerAgentRequestToJson(value: PrivateChannelOnAddContextListenerAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnAddContextListenerAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnAddContextListenerBridgeRequest(json: string): PrivateChannelOnAddContextListenerBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnAddContextListenerBridgeRequest"));
+    }
+
+    public static privateChannelOnAddContextListenerBridgeRequestToJson(value: PrivateChannelOnAddContextListenerBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnAddContextListenerBridgeRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnDisconnectAgentRequest(json: string): PrivateChannelOnDisconnectAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnDisconnectAgentRequest"));
+    }
+
+    public static privateChannelOnDisconnectAgentRequestToJson(value: PrivateChannelOnDisconnectAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnDisconnectAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnDisconnectBridgeRequest(json: string): PrivateChannelOnDisconnectBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnDisconnectBridgeRequest"));
+    }
+
+    public static privateChannelOnDisconnectBridgeRequestToJson(value: PrivateChannelOnDisconnectBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnDisconnectBridgeRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnUnsubscribeAgentRequest(json: string): PrivateChannelOnUnsubscribeAgentRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnUnsubscribeAgentRequest"));
+    }
+
+    public static privateChannelOnUnsubscribeAgentRequestToJson(value: PrivateChannelOnUnsubscribeAgentRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnUnsubscribeAgentRequest")), null, 2);
+    }
+
+    public static toPrivateChannelOnUnsubscribeBridgeRequest(json: string): PrivateChannelOnUnsubscribeBridgeRequest {
+        return cast(JSON.parse(json), r("PrivateChannelOnUnsubscribeBridgeRequest"));
+    }
+
+    public static privateChannelOnUnsubscribeBridgeRequestToJson(value: PrivateChannelOnUnsubscribeBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("PrivateChannelOnUnsubscribeBridgeRequest")), null, 2);
+    }
+
+    public static toRaiseIntentAgentErrorResponse(json: string): RaiseIntentAgentErrorResponse {
+        return cast(JSON.parse(json), r("RaiseIntentAgentErrorResponse"));
+    }
+
+    public static raiseIntentAgentErrorResponseToJson(value: RaiseIntentAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentAgentErrorResponse")), null, 2);
+    }
+
+    public static toRaiseIntentAgentRequest(json: string): RaiseIntentAgentRequest {
+        return cast(JSON.parse(json), r("RaiseIntentAgentRequest"));
+    }
+
+    public static raiseIntentAgentRequestToJson(value: RaiseIntentAgentRequest): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentAgentRequest")), null, 2);
+    }
+
+    public static toRaiseIntentAgentResponse(json: string): RaiseIntentAgentResponse {
+        return cast(JSON.parse(json), r("RaiseIntentAgentResponse"));
+    }
+
+    public static raiseIntentAgentResponseToJson(value: RaiseIntentAgentResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentAgentResponse")), null, 2);
+    }
+
+    public static toRaiseIntentBridgeErrorResponse(json: string): RaiseIntentBridgeErrorResponse {
+        return cast(JSON.parse(json), r("RaiseIntentBridgeErrorResponse"));
+    }
+
+    public static raiseIntentBridgeErrorResponseToJson(value: RaiseIntentBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentBridgeErrorResponse")), null, 2);
+    }
+
+    public static toRaiseIntentBridgeRequest(json: string): RaiseIntentBridgeRequest {
+        return cast(JSON.parse(json), r("RaiseIntentBridgeRequest"));
+    }
+
+    public static raiseIntentBridgeRequestToJson(value: RaiseIntentBridgeRequest): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentBridgeRequest")), null, 2);
+    }
+
+    public static toRaiseIntentBridgeResponse(json: string): RaiseIntentBridgeResponse {
+        return cast(JSON.parse(json), r("RaiseIntentBridgeResponse"));
+    }
+
+    public static raiseIntentBridgeResponseToJson(value: RaiseIntentBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentBridgeResponse")), null, 2);
+    }
+
+    public static toRaiseIntentResultAgentErrorResponse(json: string): RaiseIntentResultAgentErrorResponse {
+        return cast(JSON.parse(json), r("RaiseIntentResultAgentErrorResponse"));
+    }
+
+    public static raiseIntentResultAgentErrorResponseToJson(value: RaiseIntentResultAgentErrorResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentResultAgentErrorResponse")), null, 2);
+    }
+
+    public static toRaiseIntentResultAgentResponse(json: string): RaiseIntentResultAgentResponse {
+        return cast(JSON.parse(json), r("RaiseIntentResultAgentResponse"));
+    }
+
+    public static raiseIntentResultAgentResponseToJson(value: RaiseIntentResultAgentResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentResultAgentResponse")), null, 2);
+    }
+
+    public static toRaiseIntentResultBridgeErrorResponse(json: string): RaiseIntentResultBridgeErrorResponse {
+        return cast(JSON.parse(json), r("RaiseIntentResultBridgeErrorResponse"));
+    }
+
+    public static raiseIntentResultBridgeErrorResponseToJson(value: RaiseIntentResultBridgeErrorResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentResultBridgeErrorResponse")), null, 2);
+    }
+
+    public static toRaiseIntentResultBridgeResponse(json: string): RaiseIntentResultBridgeResponse {
+        return cast(JSON.parse(json), r("RaiseIntentResultBridgeResponse"));
+    }
+
+    public static raiseIntentResultBridgeResponseToJson(value: RaiseIntentResultBridgeResponse): string {
+        return JSON.stringify(uncast(value, r("RaiseIntentResultBridgeResponse")), null, 2);
+    }
+}
+
+function invalidValue(typ: any, val: any, key: any, parent: any = ''): never {
+    const prettyTyp = prettyTypeName(typ);
+    const parentText = parent ? ` on ${parent}` : '';
+    const keyText = key ? ` for key "${key}"` : '';
+    throw Error(`Invalid value${keyText}${parentText}. Expected ${prettyTyp} but got ${JSON.stringify(val)}`);
+}
+
+function prettyTypeName(typ: any): string {
+    if (Array.isArray(typ)) {
+        if (typ.length === 2 && typ[0] === undefined) {
+            return `an optional ${prettyTypeName(typ[1])}`;
+        } else {
+            return `one of [${typ.map(a => { return prettyTypeName(a); }).join(", ")}]`;
+        }
+    } else if (typeof typ === "object" && typ.literal !== undefined) {
+        return typ.literal;
+    } else {
+        return typeof typ;
+    }
+}
+
+function jsonToJSProps(typ: any): any {
+    if (typ.jsonToJS === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.json] = { key: p.js, typ: p.typ });
+        typ.jsonToJS = map;
+    }
+    return typ.jsonToJS;
+}
+
+function jsToJSONProps(typ: any): any {
+    if (typ.jsToJSON === undefined) {
+        const map: any = {};
+        typ.props.forEach((p: any) => map[p.js] = { key: p.json, typ: p.typ });
+        typ.jsToJSON = map;
+    }
+    return typ.jsToJSON;
+}
+
+function transform(val: any, typ: any, getProps: any, key: any = '', parent: any = ''): any {
+    function transformPrimitive(typ: string, val: any): any {
+        if (typeof typ === typeof val) return val;
+        return invalidValue(typ, val, key, parent);
+    }
+
+    function transformUnion(typs: any[], val: any): any {
+        // val must validate against one typ in typs
+        const l = typs.length;
+        for (let i = 0; i < l; i++) {
+            const typ = typs[i];
+            try {
+                return transform(val, typ, getProps);
+            } catch (_) {}
+        }
+        return invalidValue(typs, val, key, parent);
+    }
+
+    function transformEnum(cases: string[], val: any): any {
+        if (cases.indexOf(val) !== -1) return val;
+        return invalidValue(cases.map(a => { return l(a); }), val, key, parent);
+    }
+
+    function transformArray(typ: any, val: any): any {
+        // val must be an array with no invalid elements
+        if (!Array.isArray(val)) return invalidValue(l("array"), val, key, parent);
+        return val.map(el => transform(el, typ, getProps));
+    }
+
+    function transformDate(val: any): any {
+        if (val === null) {
+            return null;
+        }
+        const d = new Date(val);
+        if (isNaN(d.valueOf())) {
+            return invalidValue(l("Date"), val, key, parent);
+        }
+        return d;
+    }
+
+    function transformObject(props: { [k: string]: any }, additional: any, val: any): any {
+        if (val === null || typeof val !== "object" || Array.isArray(val)) {
+            return invalidValue(l(ref || "object"), val, key, parent);
+        }
+        const result: any = {};
+        Object.getOwnPropertyNames(props).forEach(key => {
+            const prop = props[key];
+            const v = Object.prototype.hasOwnProperty.call(val, key) ? val[key] : undefined;
+            result[prop.key] = transform(v, prop.typ, getProps, key, ref);
+        });
+        Object.getOwnPropertyNames(val).forEach(key => {
+            if (!Object.prototype.hasOwnProperty.call(props, key)) {
+                result[key] = transform(val[key], additional, getProps, key, ref);
+            }
+        });
+        return result;
+    }
+
+    if (typ === "any") return val;
+    if (typ === null) {
+        if (val === null) return val;
+        return invalidValue(typ, val, key, parent);
+    }
+    if (typ === false) return invalidValue(typ, val, key, parent);
+    let ref: any = undefined;
+    while (typeof typ === "object" && typ.ref !== undefined) {
+        ref = typ.ref;
+        typ = typeMap[typ.ref];
+    }
+    if (Array.isArray(typ)) return transformEnum(typ, val);
+    if (typeof typ === "object") {
+        return typ.hasOwnProperty("unionMembers") ? transformUnion(typ.unionMembers, val)
+            : typ.hasOwnProperty("arrayItems")    ? transformArray(typ.arrayItems, val)
+            : typ.hasOwnProperty("props")         ? transformObject(getProps(typ), typ.additional, val)
+            : invalidValue(typ, val, key, parent);
+    }
+    // Numbers can be parsed by Date but shouldn't be.
+    if (typ === Date && typeof val !== "number") return transformDate(val);
+    return transformPrimitive(typ, val);
+}
+
+function cast<T>(val: any, typ: any): T {
+    return transform(val, typ, jsonToJSProps);
+}
+
+function uncast<T>(val: T, typ: any): any {
+    return transform(val, typ, jsToJSONProps);
+}
+
+function l(typ: any) {
+    return { literal: typ };
+}
+
+function a(typ: any) {
+    return { arrayItems: typ };
+}
+
+function u(...typs: any[]) {
+    return { unionMembers: typs };
+}
+
+function o(props: any[], additional: any) {
+    return { props, additional };
+}
+
+function m(additional: any) {
+    return { props: [], additional };
+}
+
+function r(name: string) {
+    return { ref: name };
+}
+
+const typeMap: any = {
+    "AgentErrorResponseMessage": o([
+        { json: "meta", js: "meta", typ: r("AgentResponseMetadata") },
+        { json: "payload", js: "payload", typ: r("ErrorResponseMessagePayload") },
+        { json: "type", js: "type", typ: r("ResponseMessageType") },
+    ], false),
+    "AgentResponseMetadata": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ErrorResponseMessagePayload": o([
+        { json: "error", js: "error", typ: r("ResponseErrorDetail") },
+    ], "any"),
+    "AgentRequestMessage": o([
+        { json: "meta", js: "meta", typ: r("AgentRequestMetadata") },
+        { json: "payload", js: "payload", typ: m("any") },
+        { json: "type", js: "type", typ: r("RequestMessageType") },
+    ], false),
+    "AgentRequestMetadata": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceIdentifier")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "BridgeParticipantIdentifier": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: u(undefined, "") },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "SourceIdentifier": o([
+        { json: "appId", js: "appId", typ: u(undefined, "") },
+        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "AgentResponseMessage": o([
+        { json: "meta", js: "meta", typ: r("AgentResponseMetadata") },
+        { json: "payload", js: "payload", typ: m("any") },
+        { json: "type", js: "type", typ: r("ResponseMessageType") },
+    ], false),
+    "BridgeErrorResponseMessage": o([
+        { json: "meta", js: "meta", typ: r("BridgeErrorResponseMessageMeta") },
+        { json: "payload", js: "payload", typ: r("ResponseErrorMessagePayload") },
+        { json: "type", js: "type", typ: "" },
+    ], false),
+    "BridgeErrorResponseMessageMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "DesktopAgentIdentifier": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+    ], "any"),
+    "ResponseErrorMessagePayload": o([
+        { json: "error", js: "error", typ: u(undefined, r("ResponseErrorDetail")) },
+    ], "any"),
+    "BridgeRequestMessage": o([
+        { json: "meta", js: "meta", typ: r("BridgeRequestMetadata") },
+        { json: "payload", js: "payload", typ: m("any") },
+        { json: "type", js: "type", typ: "" },
+    ], false),
+    "BridgeRequestMetadata": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("BridgeParticipantIdentifier") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "BridgeResponseMessage": o([
+        { json: "meta", js: "meta", typ: r("BridgeResponseMessageMeta") },
+        { json: "payload", js: "payload", typ: m("any") },
+        { json: "type", js: "type", typ: "" },
+    ], false),
+    "BridgeResponseMessageMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "BroadcastAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("BroadcastAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("BroadcastAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("BroadcastAgentRequestType") },
+    ], false),
+    "BroadcastAgentRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("SourceObject") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "SourceObject": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "BroadcastAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "context", js: "context", typ: r("Context") },
+    ], false),
+    "Context": o([
+        { json: "id", js: "id", typ: u(undefined, m("any")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "type", js: "type", typ: "" },
+    ], "any"),
+    "BroadcastBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("BroadcastBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("BroadcastBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("BroadcastAgentRequestType") },
+    ], false),
+    "BroadcastBridgeRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "MetaSource": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "BroadcastBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "context", js: "context", typ: r("Context") },
+    ], false),
+    "ConnectionStepMessage": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStepMetadata") },
+        { json: "payload", js: "payload", typ: m("any") },
+        { json: "type", js: "type", typ: r("ConnectionStepMessageType") },
+    ], false),
+    "ConnectionStepMetadata": o([
+        { json: "requestUuid", js: "requestUuid", typ: u(undefined, "") },
+        { json: "responseUuid", js: "responseUuid", typ: u(undefined, "") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ConnectionStep2Hello": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStep2HelloMeta") },
+        { json: "payload", js: "payload", typ: r("ConnectionStep2HelloPayload") },
+        { json: "type", js: "type", typ: r("ConnectionStep2HelloType") },
+    ], false),
+    "ConnectionStep2HelloMeta": o([
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ConnectionStep2HelloPayload": o([
+        { json: "authRequired", js: "authRequired", typ: true },
+        { json: "authToken", js: "authToken", typ: u(undefined, "") },
+        { json: "desktopAgentBridgeVersion", js: "desktopAgentBridgeVersion", typ: "" },
+        { json: "supportedFDC3Versions", js: "supportedFDC3Versions", typ: a("") },
+    ], false),
+    "ConnectionStep3Handshake": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStep3HandshakeMeta") },
+        { json: "payload", js: "payload", typ: r("ConnectionStep3HandshakePayload") },
+        { json: "type", js: "type", typ: r("ConnectionStep3HandshakeType") },
+    ], false),
+    "ConnectionStep3HandshakeMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ConnectionStep3HandshakePayload": o([
+        { json: "authToken", js: "authToken", typ: u(undefined, "") },
+        { json: "channelsState", js: "channelsState", typ: m(a(r("Context"))) },
+        { json: "implementationMetadata", js: "implementationMetadata", typ: r("ConnectingAgentImplementationMetadata") },
+        { json: "requestedName", js: "requestedName", typ: "" },
+    ], false),
+    "ConnectingAgentImplementationMetadata": o([
+        { json: "fdc3Version", js: "fdc3Version", typ: "" },
+        { json: "optionalFeatures", js: "optionalFeatures", typ: r("OptionalFeatures") },
+        { json: "provider", js: "provider", typ: "" },
+        { json: "providerVersion", js: "providerVersion", typ: u(undefined, "") },
+    ], false),
+    "OptionalFeatures": o([
+        { json: "DesktopAgentBridging", js: "DesktopAgentBridging", typ: true },
+        { json: "OriginatingAppMetadata", js: "OriginatingAppMetadata", typ: true },
+        { json: "UserChannelMembershipAPIs", js: "UserChannelMembershipAPIs", typ: true },
+    ], false),
+    "ConnectionStep4AuthenticationFailed": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStep4AuthenticationFailedMeta") },
+        { json: "payload", js: "payload", typ: r("ConnectionStep4AuthenticationFailedPayload") },
+        { json: "type", js: "type", typ: r("ConnectionStep4AuthenticationFailedType") },
+    ], false),
+    "ConnectionStep4AuthenticationFailedMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ConnectionStep4AuthenticationFailedPayload": o([
+        { json: "message", js: "message", typ: u(undefined, "") },
+    ], false),
+    "ConnectionStep6ConnectedAgentsUpdate": o([
+        { json: "meta", js: "meta", typ: r("ConnectionStep6ConnectedAgentsUpdateMeta") },
+        { json: "payload", js: "payload", typ: r("ConnectionStep6ConnectedAgentsUpdatePayload") },
+        { json: "type", js: "type", typ: r("ConnectionStep6ConnectedAgentsUpdateType") },
+    ], false),
+    "ConnectionStep6ConnectedAgentsUpdateMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "ConnectionStep6ConnectedAgentsUpdatePayload": o([
+        { json: "addAgent", js: "addAgent", typ: u(undefined, "") },
+        { json: "allAgents", js: "allAgents", typ: a(r("DesktopAgentImplementationMetadata")) },
+        { json: "channelsState", js: "channelsState", typ: u(undefined, m(a(r("Context")))) },
+        { json: "removeAgent", js: "removeAgent", typ: u(undefined, "") },
+    ], false),
+    "DesktopAgentImplementationMetadata": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "fdc3Version", js: "fdc3Version", typ: "" },
+        { json: "optionalFeatures", js: "optionalFeatures", typ: r("OptionalFeatures") },
+        { json: "provider", js: "provider", typ: "" },
+        { json: "providerVersion", js: "providerVersion", typ: u(undefined, "") },
+    ], false),
+    "FindInstancesAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindInstancesAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("PayloadClass") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentErrorResponseType") },
+    ], false),
+    "FindInstancesAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PayloadClass": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindInstancesAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("FindInstancesAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindInstancesAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentRequestType") },
+    ], false),
+    "FindInstancesAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceIdentifier")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "DestinationObject": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: u(undefined, "") },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "FindInstancesAgentRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppIdentifier") },
+    ], false),
+    "AppIdentifier": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "FindInstancesAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("AgentResponseMetadata") },
+        { json: "payload", js: "payload", typ: r("FindInstancesAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentErrorResponseType") },
+    ], false),
+    "FindInstancesAgentResponsePayload": o([
+        { json: "appIdentifiers", js: "appIdentifiers", typ: a(r("AppMetadata")) },
+    ], false),
+    "AppMetadata": o([
+        { json: "appId", js: "appId", typ: "" },
+        { json: "description", js: "description", typ: u(undefined, "") },
+        { json: "desktopAgent", js: "desktopAgent", typ: u(undefined, "") },
+        { json: "icons", js: "icons", typ: u(undefined, a(r("Icon"))) },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+        { json: "instanceMetadata", js: "instanceMetadata", typ: u(undefined, m("any")) },
+        { json: "name", js: "name", typ: u(undefined, "") },
+        { json: "resultType", js: "resultType", typ: u(undefined, u(null, "")) },
+        { json: "screenshots", js: "screenshots", typ: u(undefined, a(r("Image"))) },
+        { json: "title", js: "title", typ: u(undefined, "") },
+        { json: "tooltip", js: "tooltip", typ: u(undefined, "") },
+        { json: "version", js: "version", typ: u(undefined, "") },
+    ], false),
+    "Icon": o([
+        { json: "size", js: "size", typ: u(undefined, "") },
+        { json: "src", js: "src", typ: "" },
+        { json: "type", js: "type", typ: u(undefined, "") },
+    ], false),
+    "Image": o([
+        { json: "label", js: "label", typ: u(undefined, "") },
+        { json: "size", js: "size", typ: u(undefined, "") },
+        { json: "src", js: "src", typ: "" },
+        { json: "type", js: "type", typ: u(undefined, "") },
+    ], false),
+    "FindInstancesBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindInstancesBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("MessagePayload") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentErrorResponseType") },
+    ], false),
+    "FindInstancesBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "MessagePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindInstancesBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("FindInstancesBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindInstancesBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentRequestType") },
+    ], false),
+    "FindInstancesBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSourceObject") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "MetaSourceObject": o([
+        { json: "appId", js: "appId", typ: u(undefined, "") },
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "FindInstancesBridgeRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppIdentifier") },
+    ], false),
+    "FindInstancesBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("BridgeResponseMessageMeta") },
+        { json: "payload", js: "payload", typ: r("FindInstancesBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("FindInstancesAgentErrorResponseType") },
+    ], false),
+    "FindInstancesBridgeResponsePayload": o([
+        { json: "appIdentifiers", js: "appIdentifiers", typ: a(r("AppMetadata")) },
+    ], false),
+    "FindIntentAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentErrorResponseType") },
+    ], false),
+    "FindIntentAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindIntentAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("FindIntentAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentRequestType") },
+    ], false),
+    "FindIntentAgentRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceIdentifier")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+    ], false),
+    "FindIntentAgentRequestPayload": o([
+        { json: "context", js: "context", typ: u(undefined, r("Context")) },
+        { json: "intent", js: "intent", typ: "" },
+        { json: "resultType", js: "resultType", typ: u(undefined, "") },
+    ], false),
+    "FindIntentAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentErrorResponseType") },
+    ], false),
+    "FindIntentAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentAgentResponsePayload": o([
+        { json: "appIntent", js: "appIntent", typ: r("AppIntent") },
+    ], false),
+    "AppIntent": o([
+        { json: "apps", js: "apps", typ: a(r("AppMetadata")) },
+        { json: "intent", js: "intent", typ: r("IntentMetadata") },
+    ], false),
+    "IntentMetadata": o([
+        { json: "displayName", js: "displayName", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: "" },
+    ], false),
+    "FindIntentBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentErrorResponseType") },
+    ], false),
+    "FindIntentBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindIntentBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("FindIntentBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentRequestType") },
+    ], false),
+    "FindIntentBridgeRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("BridgeParticipantIdentifier") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+    ], false),
+    "FindIntentBridgeRequestPayload": o([
+        { json: "context", js: "context", typ: u(undefined, r("Context")) },
+        { json: "intent", js: "intent", typ: "" },
+        { json: "resultType", js: "resultType", typ: u(undefined, "") },
+    ], false),
+    "FindIntentBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentAgentErrorResponseType") },
+    ], false),
+    "FindIntentBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentBridgeResponsePayload": o([
+        { json: "appIntent", js: "appIntent", typ: r("AppIntent") },
+    ], false),
+    "FindIntentsByContextAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentErrorResponseType") },
+    ], false),
+    "FindIntentsByContextAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentsByContextAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindIntentsByContextAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentRequestType") },
+    ], false),
+    "FindIntentsByContextAgentRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+    ], false),
+    "FindIntentsByContextAgentRequestPayload": o([
+        { json: "context", js: "context", typ: r("Context") },
+        { json: "resultType", js: "resultType", typ: u(undefined, "") },
+    ], false),
+    "FindIntentsByContextAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentErrorResponseType") },
+    ], false),
+    "FindIntentsByContextAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentsByContextAgentResponsePayload": o([
+        { json: "appIntents", js: "appIntents", typ: a(r("AppIntent")) },
+    ], false),
+    "FindIntentsByContextBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentErrorResponseType") },
+    ], false),
+    "FindIntentsByContextBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentsByContextBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "FindIntentsByContextBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentRequestType") },
+    ], false),
+    "FindIntentsByContextBridgeRequestMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+        { json: "destination", js: "destination", typ: u(undefined, r("BridgeParticipantIdentifier")) },
+    ], false),
+    "FindIntentsByContextBridgeRequestPayload": o([
+        { json: "context", js: "context", typ: r("Context") },
+        { json: "resultType", js: "resultType", typ: u(undefined, "") },
+    ], false),
+    "FindIntentsByContextBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("FindIntentsByContextBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("FindIntentsByContextBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("FindIntentsByContextAgentErrorResponseType") },
+    ], false),
+    "FindIntentsByContextBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "FindIntentsByContextBridgeResponsePayload": o([
+        { json: "appIntents", js: "appIntents", typ: a(r("AppIntent")) },
+    ], false),
+    "GetAppMetadataAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentErrorResponseType") },
+    ], false),
+    "GetAppMetadataAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "GetAppMetadataAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentRequestType") },
+    ], false),
+    "GetAppMetadataAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceIdentifier")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataAgentRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppObject") },
+    ], false),
+    "AppObject": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "GetAppMetadataAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentErrorResponseType") },
+    ], false),
+    "GetAppMetadataAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataAgentResponsePayload": o([
+        { json: "appMetadata", js: "appMetadata", typ: r("AppMetadata") },
+    ], false),
+    "GetAppMetadataBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentErrorResponseType") },
+    ], false),
+    "GetAppMetadataBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "GetAppMetadataBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentRequestType") },
+    ], false),
+    "GetAppMetadataBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSourceObject") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataBridgeRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppObject") },
+    ], false),
+    "GetAppMetadataBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("GetAppMetadataBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("GetAppMetadataBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("GetAppMetadataAgentErrorResponseType") },
+    ], false),
+    "GetAppMetadataBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "GetAppMetadataBridgeResponsePayload": o([
+        { json: "appMetadata", js: "appMetadata", typ: r("AppMetadata") },
+    ], false),
+    "OpenAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("OpenAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("OpenAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("OpenAgentErrorResponseType") },
+    ], false),
+    "OpenAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("OpenErrorResponsePayload") },
+    ], false),
+    "OpenAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("OpenAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("OpenAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("OpenAgentRequestType") },
+    ], false),
+    "OpenAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("SourceObject") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenAgentRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppToOpen") },
+        { json: "context", js: "context", typ: u(undefined, r("Context")) },
+    ], false),
+    "AppToOpen": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "OpenAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("OpenAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("OpenAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("OpenAgentErrorResponseType") },
+    ], false),
+    "OpenAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenAgentResponsePayload": o([
+        { json: "appIdentifier", js: "appIdentifier", typ: r("AppIdentifier") },
+    ], false),
+    "OpenBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("OpenBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("OpenBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("OpenAgentErrorResponseType") },
+    ], false),
+    "OpenBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("OpenErrorResponsePayload") },
+    ], false),
+    "OpenBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("OpenBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("OpenBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("OpenAgentRequestType") },
+    ], false),
+    "OpenBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("DestinationObject")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenBridgeRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppToOpen") },
+        { json: "context", js: "context", typ: u(undefined, r("Context")) },
+    ], false),
+    "OpenBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("OpenBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("OpenBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("OpenAgentErrorResponseType") },
+    ], false),
+    "OpenBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "OpenBridgeResponsePayload": o([
+        { json: "appIdentifier", js: "appIdentifier", typ: r("AppIdentifier") },
+    ], false),
+    "PrivateChannelBroadcastAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelBroadcastAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelBroadcastAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelBroadcastAgentRequestType") },
+    ], false),
+    "PrivateChannelBroadcastAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "MetaDestination": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "PrivateChannelBroadcastAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "context", js: "context", typ: r("Context") },
+    ], false),
+    "PrivateChannelBroadcastBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelBroadcastBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelBroadcastBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelBroadcastAgentRequestType") },
+    ], false),
+    "PrivateChannelBroadcastBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelBroadcastBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "context", js: "context", typ: r("Context") },
+    ], false),
+    "PrivateChannelEventListenerAddedAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelEventListenerAddedAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelEventListenerAddedAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelEventListenerAddedAgentRequestType") },
+    ], false),
+    "PrivateChannelEventListenerAddedAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelEventListenerAddedAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "listenerType", js: "listenerType", typ: r("PrivateChannelEventListenerTypes") },
+    ], false),
+    "PrivateChannelEventListenerAddedBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelEventListenerAddedBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelEventListenerAddedBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelEventListenerAddedAgentRequestType") },
+    ], false),
+    "PrivateChannelEventListenerAddedBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelEventListenerAddedBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "listenerType", js: "listenerType", typ: r("PrivateChannelEventListenerTypes") },
+    ], false),
+    "PrivateChannelEventListenerRemovedAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelEventListenerRemovedAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelEventListenerRemovedAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelEventListenerRemovedAgentRequestType") },
+    ], false),
+    "PrivateChannelEventListenerRemovedAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelEventListenerRemovedAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "listenerType", js: "listenerType", typ: r("PrivateChannelEventListenerTypes") },
+    ], false),
+    "PrivateChannelEventListenerRemovedBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelEventListenerRemovedBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelEventListenerRemovedBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelEventListenerRemovedAgentRequestType") },
+    ], false),
+    "PrivateChannelEventListenerRemovedBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelEventListenerRemovedBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "listenerType", js: "listenerType", typ: r("PrivateChannelEventListenerTypes") },
+    ], false),
+    "PrivateChannelOnAddContextListenerAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelOnAddContextListenerAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnAddContextListenerAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnAddContextListenerAgentRequestType") },
+    ], false),
+    "PrivateChannelOnAddContextListenerAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnAddContextListenerAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "contextType", js: "contextType", typ: u(null, "") },
+    ], false),
+    "PrivateChannelOnAddContextListenerBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelOnAddContextListenerBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnAddContextListenerBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnAddContextListenerAgentRequestType") },
+    ], false),
+    "PrivateChannelOnAddContextListenerBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnAddContextListenerBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "contextType", js: "contextType", typ: u(null, "") },
+    ], false),
+    "PrivateChannelOnDisconnectAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelOnDisconnectAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnDisconnectAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnDisconnectAgentRequestType") },
+    ], false),
+    "PrivateChannelOnDisconnectAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnDisconnectAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+    ], false),
+    "PrivateChannelOnDisconnectBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelOnDisconnectBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnDisconnectBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnDisconnectAgentRequestType") },
+    ], false),
+    "PrivateChannelOnDisconnectBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnDisconnectBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+    ], false),
+    "PrivateChannelOnUnsubscribeAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("PrivateChannelOnUnsubscribeAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnUnsubscribeAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnUnsubscribeAgentRequestType") },
+    ], false),
+    "PrivateChannelOnUnsubscribeAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: u(undefined, r("SourceObject")) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnUnsubscribeAgentRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "contextType", js: "contextType", typ: u(null, "") },
+    ], false),
+    "PrivateChannelOnUnsubscribeBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("ERequestMetadata") },
+        { json: "payload", js: "payload", typ: r("PrivateChannelOnUnsubscribeBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("PrivateChannelOnUnsubscribeAgentRequestType") },
+    ], false),
+    "ERequestMetadata": o([
+        { json: "destination", js: "destination", typ: u(undefined, r("MetaDestination")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "PrivateChannelOnUnsubscribeBridgeRequestPayload": o([
+        { json: "channelId", js: "channelId", typ: "" },
+        { json: "contextType", js: "contextType", typ: u(null, "") },
+    ], false),
+    "RaiseIntentAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "RaiseIntentAgentRequest": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentAgentRequestMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentAgentRequestPayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentRequestType") },
+    ], false),
+    "RaiseIntentAgentRequestMeta": o([
+        { json: "destination", js: "destination", typ: r("MetaDestination") },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("SourceObject") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentAgentRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppDestinationIdentifier") },
+        { json: "context", js: "context", typ: r("Context") },
+        { json: "intent", js: "intent", typ: "" },
+    ], false),
+    "AppDestinationIdentifier": o([
+        { json: "desktopAgent", js: "desktopAgent", typ: "" },
+        { json: "appId", js: "appId", typ: "" },
+        { json: "instanceId", js: "instanceId", typ: u(undefined, "") },
+    ], "any"),
+    "RaiseIntentAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentAgentResponsePayload": o([
+        { json: "intentResolution", js: "intentResolution", typ: r("IntentResolution") },
+    ], false),
+    "IntentResolution": o([
+        { json: "intent", js: "intent", typ: "" },
+        { json: "source", js: "source", typ: r("AppIdentifier") },
+    ], false),
+    "RaiseIntentBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("FindInstancesErrors") },
+    ], false),
+    "RaiseIntentBridgeRequest": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentBridgeRequestMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentBridgeRequestPayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentRequestType") },
+    ], false),
+    "RaiseIntentBridgeRequestMeta": o([
+        { json: "destination", js: "destination", typ: r("MetaDestination") },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "source", js: "source", typ: r("MetaSource") },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentBridgeRequestPayload": o([
+        { json: "app", js: "app", typ: r("AppDestinationIdentifier") },
+        { json: "context", js: "context", typ: r("Context") },
+        { json: "intent", js: "intent", typ: "" },
+    ], false),
+    "RaiseIntentBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentBridgeResponsePayload": o([
+        { json: "intentResolution", js: "intentResolution", typ: r("IntentResolution") },
+    ], false),
+    "RaiseIntentResultAgentErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentResultAgentErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentResultAgentErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentResultAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentResultAgentErrorResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentResultAgentErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("RaiseIntentResultErrorMessage") },
+    ], false),
+    "RaiseIntentResultAgentResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentResultAgentResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentResultAgentResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentResultAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentResultAgentResponseMeta": o([
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentResultAgentResponsePayload": o([
+        { json: "intentResult", js: "intentResult", typ: r("IntentResult") },
+    ], false),
+    "IntentResult": o([
+        { json: "context", js: "context", typ: u(undefined, r("Context")) },
+        { json: "channel", js: "channel", typ: u(undefined, r("Channel")) },
+    ], false),
+    "Channel": o([
+        { json: "displayMetadata", js: "displayMetadata", typ: u(undefined, r("DisplayMetadata")) },
+        { json: "id", js: "id", typ: "" },
+        { json: "type", js: "type", typ: r("Type") },
+    ], false),
+    "DisplayMetadata": o([
+        { json: "color", js: "color", typ: u(undefined, "") },
+        { json: "glyph", js: "glyph", typ: u(undefined, "") },
+        { json: "name", js: "name", typ: u(undefined, "") },
+    ], false),
+    "RaiseIntentResultBridgeErrorResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentResultBridgeErrorResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentResultBridgeErrorResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentResultAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentResultBridgeErrorResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: a(r("ResponseErrorDetail")) },
+        { json: "errorSources", js: "errorSources", typ: a(r("DesktopAgentIdentifier")) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentResultBridgeErrorResponsePayload": o([
+        { json: "error", js: "error", typ: r("RaiseIntentResultErrorMessage") },
+    ], false),
+    "RaiseIntentResultBridgeResponse": o([
+        { json: "meta", js: "meta", typ: r("RaiseIntentResultBridgeResponseMeta") },
+        { json: "payload", js: "payload", typ: r("RaiseIntentResultBridgeResponsePayload") },
+        { json: "type", js: "type", typ: r("RaiseIntentResultAgentErrorResponseType") },
+    ], false),
+    "RaiseIntentResultBridgeResponseMeta": o([
+        { json: "errorDetails", js: "errorDetails", typ: u(undefined, a(r("ResponseErrorDetail"))) },
+        { json: "errorSources", js: "errorSources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "requestUuid", js: "requestUuid", typ: "" },
+        { json: "responseUuid", js: "responseUuid", typ: "" },
+        { json: "sources", js: "sources", typ: u(undefined, a(r("DesktopAgentIdentifier"))) },
+        { json: "timestamp", js: "timestamp", typ: Date },
+    ], false),
+    "RaiseIntentResultBridgeResponsePayload": o([
+        { json: "intentResult", js: "intentResult", typ: r("IntentResult") },
+    ], false),
+    "ResponseErrorDetail": [
+        "AccessDenied",
+        "AgentDisconnected",
+        "AppNotFound",
+        "AppTimeout",
+        "CreationFailed",
+        "DesktopAgentNotFound",
+        "ErrorOnLaunch",
+        "IntentDeliveryFailed",
+        "IntentHandlerRejected",
+        "MalformedContext",
+        "MalformedMessage",
+        "NoAppsFound",
+        "NoChannelFound",
+        "NoResultReturned",
+        "NotConnectedToBridge",
+        "ResolverTimeout",
+        "ResolverUnavailable",
+        "ResponseToBridgeTimedOut",
+        "TargetAppUnavailable",
+        "TargetInstanceUnavailable",
+        "UserCancelledResolution",
+    ],
+    "ResponseMessageType": [
+        "findInstancesResponse",
+        "findIntentResponse",
+        "findIntentsByContextResponse",
+        "getAppMetadataResponse",
+        "openResponse",
+        "raiseIntentResponse",
+        "raiseIntentResultResponse",
+    ],
+    "RequestMessageType": [
+        "broadcastRequest",
+        "findInstancesRequest",
+        "findIntentRequest",
+        "findIntentsByContextRequest",
+        "getAppMetadataRequest",
+        "openRequest",
+        "PrivateChannel.broadcast",
+        "PrivateChannel.eventListenerAdded",
+        "PrivateChannel.eventListenerRemoved",
+        "PrivateChannel.onAddContextListener",
+        "PrivateChannel.onDisconnect",
+        "PrivateChannel.onUnsubscribe",
+        "raiseIntentRequest",
+    ],
+    "BroadcastAgentRequestType": [
+        "broadcastRequest",
+    ],
+    "ConnectionStepMessageType": [
+        "authenticationFailed",
+        "connectedAgentsUpdate",
+        "handshake",
+        "hello",
+    ],
+    "ConnectionStep2HelloType": [
+        "hello",
+    ],
+    "ConnectionStep3HandshakeType": [
+        "handshake",
+    ],
+    "ConnectionStep4AuthenticationFailedType": [
+        "authenticationFailed",
+    ],
+    "ConnectionStep6ConnectedAgentsUpdateType": [
+        "connectedAgentsUpdate",
+    ],
+    "FindInstancesErrors": [
+        "AgentDisconnected",
+        "DesktopAgentNotFound",
+        "IntentDeliveryFailed",
+        "MalformedContext",
+        "MalformedMessage",
+        "NoAppsFound",
+        "NotConnectedToBridge",
+        "ResolverTimeout",
+        "ResolverUnavailable",
+        "ResponseToBridgeTimedOut",
+        "TargetAppUnavailable",
+        "TargetInstanceUnavailable",
+        "UserCancelledResolution",
+    ],
+    "FindInstancesAgentErrorResponseType": [
+        "findInstancesResponse",
+    ],
+    "FindInstancesAgentRequestType": [
+        "findInstancesRequest",
+    ],
+    "FindIntentAgentErrorResponseType": [
+        "findIntentResponse",
+    ],
+    "FindIntentAgentRequestType": [
+        "findIntentRequest",
+    ],
+    "FindIntentsByContextAgentErrorResponseType": [
+        "findIntentsByContextResponse",
+    ],
+    "FindIntentsByContextAgentRequestType": [
+        "findIntentsByContextRequest",
+    ],
+    "GetAppMetadataAgentErrorResponseType": [
+        "getAppMetadataResponse",
+    ],
+    "GetAppMetadataAgentRequestType": [
+        "getAppMetadataRequest",
+    ],
+    "OpenErrorResponsePayload": [
+        "AgentDisconnected",
+        "AppNotFound",
+        "AppTimeout",
+        "DesktopAgentNotFound",
+        "ErrorOnLaunch",
+        "MalformedContext",
+        "MalformedMessage",
+        "NotConnectedToBridge",
+        "ResolverUnavailable",
+        "ResponseToBridgeTimedOut",
+    ],
+    "OpenAgentErrorResponseType": [
+        "openResponse",
+    ],
+    "OpenAgentRequestType": [
+        "openRequest",
+    ],
+    "PrivateChannelBroadcastAgentRequestType": [
+        "PrivateChannel.broadcast",
+    ],
+    "PrivateChannelEventListenerTypes": [
+        "onAddContextListener",
+        "onDisconnect",
+        "onUnsubscribe",
+    ],
+    "PrivateChannelEventListenerAddedAgentRequestType": [
+        "PrivateChannel.eventListenerAdded",
+    ],
+    "PrivateChannelEventListenerRemovedAgentRequestType": [
+        "PrivateChannel.eventListenerRemoved",
+    ],
+    "PrivateChannelOnAddContextListenerAgentRequestType": [
+        "PrivateChannel.onAddContextListener",
+    ],
+    "PrivateChannelOnDisconnectAgentRequestType": [
+        "PrivateChannel.onDisconnect",
+    ],
+    "PrivateChannelOnUnsubscribeAgentRequestType": [
+        "PrivateChannel.onUnsubscribe",
+    ],
+    "RaiseIntentAgentErrorResponseType": [
+        "raiseIntentResponse",
+    ],
+    "RaiseIntentAgentRequestType": [
+        "raiseIntentRequest",
+    ],
+    "RaiseIntentResultErrorMessage": [
+        "AgentDisconnected",
+        "IntentHandlerRejected",
+        "MalformedMessage",
+        "NoResultReturned",
+        "NotConnectedToBridge",
+        "ResponseToBridgeTimedOut",
+    ],
+    "RaiseIntentResultAgentErrorResponseType": [
+        "raiseIntentResultResponse",
+    ],
+    "Type": [
+        "app",
+        "private",
+        "user",
+    ],
+};

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-jest": "28.8.3",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "globals": "^15.11.0",
+    "message-await": "^1.1.0",
     "quicktype": "23.0.78",
     "rimraf": "^6.0.1",
     "ts-jest": "29.2.5",

--- a/schemas/api/api.schema.json
+++ b/schemas/api/api.schema.json
@@ -30,7 +30,7 @@
             ]
         },
         "Icon": {
-            "description": "Describes an Icon images that may be used to represent the application.",
+            "description": "Describes an Icon image that may be used to represent the application.",
             "title": "Icon",
             "type": "object",
             "properties": {

--- a/schemas/api/getInfoRequest.schema.json
+++ b/schemas/api/getInfoRequest.schema.json
@@ -3,7 +3,7 @@
 	"$id": "https://fdc3.finos.org/schemas/next/api/getInfoRequest.schema.json",
 	"type": "object",
 	"title": "GetInfo Request",
-	"description": "Request to retrieve information about the FDC3 Desktop Agent implementation  and the metadata of the calling application according to the Desktop Agent.",
+	"description": "Request to retrieve information about the FDC3 Desktop Agent implementation and the metadata of the calling application according to the Desktop Agent.",
 	"allOf": [
 		{
 			"$ref": "appRequest.schema.json"

--- a/schemas/bridging/common.schema.json
+++ b/schemas/bridging/common.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://fdc3.finos.org/schemas/next/api/common.schema.json",
+  "$id": "https://fdc3.finos.org/schemas/next/bridging/common.schema.json",
   "title": "Bridge Common definitions",
   "type": "object",
   "description": "Common definitions that are referenced only in the Bridging wire protocol schemas",

--- a/schemas/bridging/common.schema.json
+++ b/schemas/bridging/common.schema.json
@@ -82,7 +82,7 @@
       "title": "Response Error Details",
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ErrorMessages"
+        "$ref": "../api/common.schema.json#/$defs/ErrorMessages"
       },
       "description": "Array of error message strings for responses that were not returned to the bridge before the timeout or because an error occurred. Should be the same length as the `errorSources` array and ordered the same. May be omitted if all sources responded without errors."
     },

--- a/src/bridging/BridgingTypes.ts
+++ b/src/bridging/BridgingTypes.ts
@@ -1379,7 +1379,7 @@ export interface AppMetadata {
 }
 
 /**
- * Describes an Icon images that may be used to represent the application.
+ * Describes an Icon image that may be used to represent the application.
  */
 export interface Icon {
     /**

--- a/toolbox/fdc3-for-web/reference-ui/src/channel_selector.ts
+++ b/toolbox/fdc3-for-web/reference-ui/src/channel_selector.ts
@@ -1,5 +1,5 @@
 import { IframeChannelsPayload, Channel } from "@kite9/fdc3-common";
-import { FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE, FDC3_USER_INTERFACE_CHANNELS_TYPE, FDC3_USER_INTERFACE_HANDSHAKE_TYPE, FDC3_USER_INTERFACE_HELLO_TYPE, FDC3_USER_INTERFACE_RESTYLE_TYPE, Fdc3UserInterfaceHello, Fdc3UserInterfaceRestyle, isFdc3UserInterfaceChannels, isFdc3UserInterfaceHandshake } from "@kite9/fdc3-schema/dist/generated/api/BrowserTypes";
+import { Fdc3UserInterfaceChannelSelected, Fdc3UserInterfaceHello, Fdc3UserInterfaceRestyle, isFdc3UserInterfaceChannels, isFdc3UserInterfaceHandshake } from "@kite9/fdc3-schema/dist/generated/api/BrowserTypes";
 
 const fillChannels = (data: Channel[], selected: string | null, messageClickedChannel: (s: string | null) => void) => {
   const list = document.getElementById('list')!!;
@@ -48,18 +48,19 @@ window.addEventListener("load", () => {
   myPort.onmessage = ({ data }) => {
     console.debug("Received message: ", data);
 
-    if (data.type == FDC3_USER_INTERFACE_HANDSHAKE_TYPE) {
+    if (isFdc3UserInterfaceHandshake(data)) {
       collapse();
-    } else if (data.type == FDC3_USER_INTERFACE_CHANNELS_TYPE) {
+    } else if (isFdc3UserInterfaceChannels(data)) {
       logo.removeEventListener("click", expand);
       const { userChannels, selected } = data.payload as IframeChannelsPayload;
       fillChannels(userChannels, selected, (channelStr) => {
-        myPort.postMessage({
-          type: FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE,
+        const message: Fdc3UserInterfaceChannelSelected = {
+          type: "Fdc3UserInterfaceChannelSelected",
           payload: {
             selected: channelStr || null
           }
-        });
+        };
+        myPort.postMessage(message);
         collapse();
       });
       const selectedChannel = userChannels.find((c) => c.id === selected);
@@ -70,7 +71,7 @@ window.addEventListener("load", () => {
   };
 
   const helloMessage: Fdc3UserInterfaceHello = {
-    type: FDC3_USER_INTERFACE_HELLO_TYPE,
+    type: "Fdc3UserInterfaceHello",
     payload: {
       implementationDetails: "",
       initialCSS: {
@@ -90,7 +91,7 @@ window.addEventListener("load", () => {
   const expand = () => {
     document.body.setAttribute("data-expanded", "true");
     const restyleMessage: Fdc3UserInterfaceRestyle = {
-      type: FDC3_USER_INTERFACE_RESTYLE_TYPE,
+      type: "Fdc3UserInterfaceRestyle",
       payload: {
         updatedCSS: {
           width: `100%`,
@@ -108,7 +109,7 @@ window.addEventListener("load", () => {
 
   const collapse = () => {
     const restyleMessage: Fdc3UserInterfaceRestyle = {
-      type: FDC3_USER_INTERFACE_RESTYLE_TYPE,
+      type: "Fdc3UserInterfaceRestyle",
       payload: {
         updatedCSS: {
           width: `${8 * 4}px`,

--- a/toolbox/fdc3-for-web/reference-ui/src/intent_resolver.ts
+++ b/toolbox/fdc3-for-web/reference-ui/src/intent_resolver.ts
@@ -1,7 +1,7 @@
 import { Icon } from "@kite9/fdc3";
 import { AppIntent } from "@kite9/fdc3";
 import { BrowserTypes } from "@kite9/fdc3-schema";
-import { FDC3_USER_INTERFACE_HELLO_TYPE, FDC3_USER_INTERFACE_RESOLVE_ACTION_TYPE, FDC3_USER_INTERFACE_RESTYLE_TYPE, isFdc3UserInterfaceResolve } from "@kite9/fdc3-schema/dist/generated/api/BrowserTypes";
+import { isFdc3UserInterfaceResolve } from "@kite9/fdc3-schema/dist/generated/api/BrowserTypes";
 
 type Fdc3UserInterfaceHello = BrowserTypes.Fdc3UserInterfaceHello;
 type Fdc3UserInterfaceRestyle = BrowserTypes.Fdc3UserInterfaceRestyle;
@@ -167,7 +167,7 @@ window.addEventListener("load", () => {
     console.debug("Received message: ", data);
     if (isFdc3UserInterfaceResolve(data)) {
       const restyleMessage: Fdc3UserInterfaceRestyle = {
-        type: FDC3_USER_INTERFACE_RESTYLE_TYPE,
+        type: "Fdc3UserInterfaceRestyle",
         payload: {
           updatedCSS: {
             width: "100%",
@@ -183,13 +183,13 @@ window.addEventListener("load", () => {
       setup(data.payload, (payload) => {
         document.querySelector("dialog")?.close();
         const resolveAction: Fdc3UserInterfaceResolveAction = {
-          type: FDC3_USER_INTERFACE_RESOLVE_ACTION_TYPE,
+          type: "Fdc3UserInterfaceResolveAction",
           payload
         }
         myPort.postMessage(resolveAction);
 
         const restyleMessage: Fdc3UserInterfaceRestyle = {
-          type: FDC3_USER_INTERFACE_RESTYLE_TYPE,
+          type: "Fdc3UserInterfaceRestyle",
           payload: {
             updatedCSS: {
               width: "0",
@@ -206,7 +206,7 @@ window.addEventListener("load", () => {
   };
 
   const helloMessage: Fdc3UserInterfaceHello = {
-    type: FDC3_USER_INTERFACE_HELLO_TYPE,
+    type: "Fdc3UserInterfaceHello",
     payload: {
       implementationDetails: "",
       initialCSS: {


### PR DESCRIPTION
## Describe your change

Supersedes #1444  (Reopened @Roaders' PR after merging into a FINOS repo branch)

Modification of the generate-type-predicates code to build unions types of interfaces not based on the interface name but based on the type declared in the interface. If type extends the RequestMessageType union then the interface is included in the RequestMessage union

### Related Issue
<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
