### PR TITLE
Match event listener names to event type names in fdc3 for web schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,9 +3342,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/schemas/api/common.schema.json
+++ b/schemas/api/common.schema.json
@@ -60,9 +60,9 @@
       "description": "Event listener type names for Private Channel events.",
       "type": "string",
       "enum": [
-        "onAddContextListener",
-        "onUnsubscribe",
-        "onDisconnect"
+        "addContextListener",
+        "unsubscribe",
+        "disconnect"
       ]
     }
   }

--- a/src/api/BrowserTypes.ts
+++ b/src/api/BrowserTypes.ts
@@ -1442,7 +1442,7 @@ export interface AppMetadata {
 }
 
 /**
- * Describes an Icon images that may be used to represent the application.
+ * Describes an Icon image that may be used to represent the application.
  */
 export interface Icon {
     /**
@@ -2107,7 +2107,7 @@ export interface GetCurrentContextResponsePayload {
  */
 
 /**
- * Request to retrieve information about the FDC3 Desktop Agent implementation  and the
+ * Request to retrieve information about the FDC3 Desktop Agent implementation and the
  * metadata of the calling application according to the Desktop Agent.
  *
  * A request message from an FDC3-enabled app to a Desktop Agent.
@@ -2919,7 +2919,7 @@ export interface TPayload {
  *
  * Event listener type names for Private Channel events.
  */
-export type PrivateChannelEventListenerTypes = "onAddContextListener" | "onUnsubscribe" | "onDisconnect";
+export type PrivateChannelEventListenerTypes = "addContextListener" | "unsubscribe" | "disconnect";
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -5780,9 +5780,9 @@ const typeMap: any = {
         "openResponse",
     ],
     "PrivateChannelEventListenerTypes": [
-        "onAddContextListener",
-        "onDisconnect",
-        "onUnsubscribe",
+        "addContextListener",
+        "disconnect",
+        "unsubscribe",
     ],
     "PrivateChannelAddEventListenerRequestType": [
         "privateChannelAddEventListenerRequest",


### PR DESCRIPTION
## Describe your change

The FDC3 for Web message schema for requesting the addition of an event listeners to a private channel use the names of the deprecated event handlers (e.g. `onAddContextListener`) rather than the type of the event that is fired (e.g. `addContextListener`), which are defined at: 
https://fdc3.finos.org/docs/next/api/ref/Events#privatechanneleventtypes

For the message definition, see:
- https://fdc3.finos.org/schemas/next/api/privateChannelOnAddContextListenerEvent.schema.json)
- https://fdc3.finos.org/schemas/next/api/common.schema.json

This will often require translation in implementations and should simply use the event types instead.

### Related Issue
Part of #1429

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- N/A (small adjustment to unreleased feature) **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [x] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [x] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
