### PR TITLE
fix: semgrep ignores for known (and acceptable) postmessage to unknown domains

### DIFF
--- a/packages/fdc3-get-agent/test/support/FrameTypes.ts
+++ b/packages/fdc3-get-agent/test/support/FrameTypes.ts
@@ -40,6 +40,7 @@ export function handleEmbeddedIframeComms(_value: string, parent: MockWindow, so
           intentResolverUrl: INTENT_RESOLVER_URL,
         },
       };
+      // nosemgrep
       eventSource.postMessage(message, '*', [connection!.externalPort]);
 
       window.removeEventListener('message', helloHandler);

--- a/toolbox/fdc3-for-web/demo/src/client/da/embed.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/da/embed.ts
@@ -68,6 +68,7 @@ const helloListener = (e: MessageEvent) => {
       const ui = UI_URLS[getUIKey()];
 
       // send the other end of the channel to the app
+      // nosemgrep
       appWindow.postMessage(
         {
           type: 'WCP3Handshake',

--- a/toolbox/fdc3-for-web/demo/src/client/ui/channel-selector.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/ui/channel-selector.ts
@@ -71,6 +71,7 @@ window.addEventListener('load', () => {
       implementationDetails: 'Demo Channel Selector v1.0',
     },
   };
+  // nosemgrep
   parent.postMessage(helloMessage, '*', [mc.port2]);
   debug('Sent hello message: ', helloMessage);
 

--- a/toolbox/fdc3-for-web/demo/src/client/ui/intent-resolver.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/ui/intent-resolver.ts
@@ -50,6 +50,7 @@ window.addEventListener('load', () => {
       implementationDetails: 'Demo Intent Resolver v1.0',
     },
   };
+  // nosemgrep
   parent.postMessage(helloMessage, '*', [mc.port2]);
   debug('Sent hello message: ', helloMessage);
 

--- a/toolbox/fdc3-for-web/reference-ui/src/channel_selector.ts
+++ b/toolbox/fdc3-for-web/reference-ui/src/channel_selector.ts
@@ -120,6 +120,7 @@ window.addEventListener('load', () => {
       },
     },
   };
+  // nosemgrep
   parent.postMessage(helloMessage, '*', [mc.port2]);
 
   const expand = () => {

--- a/toolbox/fdc3-for-web/reference-ui/src/intent_resolver.ts
+++ b/toolbox/fdc3-for-web/reference-ui/src/intent_resolver.ts
@@ -235,5 +235,6 @@ window.addEventListener('load', () => {
       },
     },
   };
+  // nosemgrep
   parent.postMessage(helloMessage, '*', [mc.port2]);
 });


### PR DESCRIPTION
## Describe your change

Adds a handful of semgrep ignores to stop static code analysis failing. We're aware of the use of the wildcard - it is expected.

### Related Issue

resolves #1552 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- N/A **CHANGELOG**: Is a *CHANGELOG.md* entry included?