### PR TITLE
Add InvalidArguments to OpenError, ChannelError and ResolveError enums

### DIFF
--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -2195,7 +2195,8 @@ export type FindInstancesErrors =
   | 'AgentDisconnected'
   | 'NotConnectedToBridge'
   | 'ResponseToBridgeTimedOut'
-  | 'MalformedMessage';
+  | 'MalformedMessage'
+  | 'InvalidArguments';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -797,7 +797,13 @@ export interface AddContextListenerResponsePayload {
  * `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the
  * DesktopAgent (`fdc3`).
  */
-export type PurpleError = 'AccessDenied' | 'CreationFailed' | 'MalformedContext' | 'NoChannelFound' | 'ApiTimeout';
+export type PurpleError =
+  | 'AccessDenied'
+  | 'CreationFailed'
+  | 'MalformedContext'
+  | 'NoChannelFound'
+  | 'ApiTimeout'
+  | 'InvalidArguments';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -893,6 +899,7 @@ export type ResponsePayloadError =
   | 'MalformedContext'
   | 'NoChannelFound'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'AppNotFound'
   | 'AppTimeout'
   | 'DesktopAgentNotFound'
@@ -998,6 +1005,7 @@ export interface PayloadObject {
 export type FluffyError =
   | 'MalformedContext'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'DesktopAgentNotFound'
   | 'ResolverUnavailable'
   | 'IntentDeliveryFailed'
@@ -2184,6 +2192,7 @@ export interface FindInstancesResponsePayload {
 export type FindInstancesErrors =
   | 'MalformedContext'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'DesktopAgentNotFound'
   | 'ResolverUnavailable'
   | 'IntentDeliveryFailed'
@@ -2195,8 +2204,7 @@ export type FindInstancesErrors =
   | 'AgentDisconnected'
   | 'NotConnectedToBridge'
   | 'ResponseToBridgeTimedOut'
-  | 'MalformedMessage'
-  | 'InvalidArguments';
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -3287,6 +3295,7 @@ export interface OpenResponsePayload {
 export type OpenErrorResponsePayload =
   | 'MalformedContext'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'AppNotFound'
   | 'AppTimeout'
   | 'DesktopAgentNotFound'
@@ -5972,7 +5981,14 @@ const typeMap: any = {
     'WCP6Goodbye',
   ],
   AddContextListenerRequestType: ['addContextListenerRequest'],
-  PurpleError: ['ApiTimeout', 'AccessDenied', 'CreationFailed', 'MalformedContext', 'NoChannelFound'],
+  PurpleError: [
+    'ApiTimeout',
+    'AccessDenied',
+    'CreationFailed',
+    'InvalidArguments',
+    'MalformedContext',
+    'NoChannelFound',
+  ],
   AddContextListenerResponseType: ['addContextListenerResponse'],
   FDC3EventType: ['USER_CHANNEL_CHANGED'],
   AddEventListenerRequestType: ['addEventListenerRequest'],
@@ -5987,6 +6003,7 @@ const typeMap: any = {
     'ErrorOnLaunch',
     'IntentDeliveryFailed',
     'IntentHandlerRejected',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NoAppsFound',
@@ -6006,6 +6023,7 @@ const typeMap: any = {
     'ApiTimeout',
     'DesktopAgentNotFound',
     'IntentDeliveryFailed',
+    'InvalidArguments',
     'MalformedContext',
     'NoAppsFound',
     'ResolverTimeout',
@@ -6119,6 +6137,7 @@ const typeMap: any = {
     'AgentDisconnected',
     'DesktopAgentNotFound',
     'IntentDeliveryFailed',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NoAppsFound',
@@ -6166,6 +6185,7 @@ const typeMap: any = {
     'AppTimeout',
     'DesktopAgentNotFound',
     'ErrorOnLaunch',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NotConnectedToBridge',

--- a/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
+++ b/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
@@ -1158,7 +1158,8 @@ export type FindInstancesErrors =
   | 'AgentDisconnected'
   | 'NotConnectedToBridge'
   | 'ResponseToBridgeTimedOut'
-  | 'MalformedMessage';
+  | 'MalformedMessage'
+  | 'InvalidArguments';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that

--- a/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
+++ b/packages/fdc3-schema/generated/bridging/BridgingTypes.ts
@@ -124,6 +124,7 @@ export type ResponseErrorDetail =
   | 'MalformedContext'
   | 'NoChannelFound'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'AppNotFound'
   | 'AppTimeout'
   | 'DesktopAgentNotFound'
@@ -1155,11 +1156,11 @@ export type FindInstancesErrors =
   | 'TargetInstanceUnavailable'
   | 'UserCancelledResolution'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'AgentDisconnected'
   | 'NotConnectedToBridge'
   | 'ResponseToBridgeTimedOut'
-  | 'MalformedMessage'
-  | 'InvalidArguments';
+  | 'MalformedMessage';
 
 /**
  * Identifies the type of the message and it is typically set to the FDC3 function name that
@@ -2583,6 +2584,7 @@ export type OpenErrorResponsePayload =
   | 'MalformedContext'
   | 'ResolverUnavailable'
   | 'ApiTimeout'
+  | 'InvalidArguments'
   | 'AgentDisconnected'
   | 'NotConnectedToBridge'
   | 'ResponseToBridgeTimedOut'
@@ -6487,6 +6489,7 @@ const typeMap: any = {
     'ErrorOnLaunch',
     'IntentDeliveryFailed',
     'IntentHandlerRejected',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NoAppsFound',
@@ -6535,6 +6538,7 @@ const typeMap: any = {
     'AgentDisconnected',
     'DesktopAgentNotFound',
     'IntentDeliveryFailed',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NoAppsFound',
@@ -6561,6 +6565,7 @@ const typeMap: any = {
     'AppTimeout',
     'DesktopAgentNotFound',
     'ErrorOnLaunch',
+    'InvalidArguments',
     'MalformedContext',
     'MalformedMessage',
     'NotConnectedToBridge',

--- a/packages/fdc3-schema/schemas/api/api.schema.json
+++ b/packages/fdc3-schema/schemas/api/api.schema.json
@@ -309,7 +309,8 @@
                 "ErrorOnLaunch",
                 "MalformedContext",
                 "ResolverUnavailable",
-                "ApiTimeout"
+                "ApiTimeout",
+                "InvalidArguments"
             ],
             "type": "string"
         },
@@ -326,7 +327,8 @@
                 "TargetAppUnavailable",
                 "TargetInstanceUnavailable",
                 "UserCancelledResolution",
-                "ApiTimeout"
+                "ApiTimeout",
+                "InvalidArguments"
             ],
             "type": "string"
         },
@@ -346,7 +348,8 @@
                 "CreationFailed",
                 "MalformedContext",
                 "NoChannelFound",
-                "ApiTimeout"
+                "ApiTimeout",
+                "InvalidArguments"
             ],
             "type": "string"
         },

--- a/packages/fdc3-standard/src/api/Errors.ts
+++ b/packages/fdc3-standard/src/api/Errors.ts
@@ -53,6 +53,9 @@ export enum OpenError {
 
   /** Returned if a timeout occurs before a call to open is resolved for any reason other than the not adding its context listener in time.*/
   ApiTimeout = 'ApiTimeout',
+
+  /** Returned when incorrect arguments are passed to API calls.*/
+  InvalidArguments = 'InvalidArguments',
 }
 
 /** Constants representing the errors that can be encountered when calling the `findIntent`, `findIntentsByContext`, `raiseIntent` or `raiseIntentForContext` methods on the DesktopAgent (`fdc3`). */
@@ -86,6 +89,9 @@ export enum ResolveError {
 
   /** Returned if a timeout occurs before the API call is resolved for any reason other than the resolver timing out (use ResolverTimeout) or an app launched by a raiseIntent function doesn't add its intent listener in time (use IntentDeliveryFailed).*/
   ApiTimeout = 'ApiTimeout',
+
+  /** Returned when incorrect arguments are passed to API calls.*/
+  InvalidArguments = 'InvalidArguments',
 }
 
 export enum ResultError {
@@ -114,6 +120,9 @@ export enum ChannelError {
 
   /** Returned if a timeout occurs before any Channel related API call is resolved.*/
   ApiTimeout = 'ApiTimeout',
+
+  /** Returned when incorrect arguments are passed to API calls.*/
+  InvalidArguments = 'InvalidArguments',
 }
 
 export enum BridgingError {

--- a/website/docs/api/ref/Errors.md
+++ b/website/docs/api/ref/Errors.md
@@ -77,7 +77,11 @@ enum ChannelError {
 
   /** Returned if a timeout occurs before any Channel related API call is resolved.
    */
-  ApiTimeout = 'ApiTimeout'
+  ApiTimeout = 'ApiTimeout',
+
+  /** Returned if invalid arugments are passed to the API call.
+   */
+  InvalidArguments = 'InvalidArguments'
 }
 ```
 
@@ -113,6 +117,10 @@ public static class ChannelError
     /// </summary>
     public static readonly string MalformedContext = nameof(MalformedContext);
 
+    /// <summary>
+    /// Returned if invalid arguments are passed to the api call.
+    /// </summary>
+    public static readonly string InvalidArguments = nameof(InvalidArguments);
 }
 ```
 
@@ -167,7 +175,11 @@ enum OpenError {
   /** Returned if a timeout occurs before a call to open is resolved for any
    *  reason other than the not adding its context listener in time.  
    */
-  ApiTimeout = 'ApiTimeout'
+  ApiTimeout = 'ApiTimeout',
+
+  /** Returned if invalid arugments are passed to the API call.
+   */
+  InvalidArguments = 'InvalidArguments'
 }
 ```
 
@@ -205,6 +217,11 @@ public static class OpenError
     /// that has a `String` value.
     /// </summary>
     public static readonly string MalformedContext = nameof(MalformedContext);
+
+    /// <summary>
+    /// Returned if invalid arguments are passed to the api call.
+    /// </summary>
+    public static readonly string InvalidArguments = nameof(InvalidArguments);
 }
 ```
 
@@ -277,7 +294,11 @@ export enum ResolveError {
    *  raiseIntent function doesn't add its intent listener in time (use 
    *  IntentDeliveryFailed).
    */
-  ApiTimeout = 'ApiTimeout'
+  ApiTimeout = 'ApiTimeout',
+
+  /** Returned if invalid arugments are passed to the API call.
+   */
+  InvalidArguments = 'InvalidArguments'
 }
 ```
 
@@ -337,6 +358,11 @@ public static class ResolveError
     /// field that has a `String` value.
     /// </summary>
     public static readonly string MalformedContext = nameof(MalformedContext);
+
+    /// <summary>
+    /// Returned if invalid arguments are passed to the api call.
+    /// </summary>
+    public static readonly string InvalidArguments = nameof(InvalidArguments);
 }
 ```
 


### PR DESCRIPTION
## Describe your change

Fixed https://github.com/finos/FDC3/issues/1490 by adding InvalidArguments inside OpenError, ChannelError and ResolveError enums

### Related Issue
Resolves #1490
https://github.com/finos/FDC3/issues/1490
## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
