### PR TITLE
Add linting step to CI workflow and set NODE_DEBUG to false in Vite c…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install dependencies
       run: npm install
 
+    - name: Lint
+      run: npm run lint
+
     - name: Run tests
       run: npm run test
 

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -1008,30 +1008,6 @@ export type FluffyError =
   | 'UserCancelledResolution';
 
 /**
- * Identifies the type of the message and it is typically set to the FDC3 function name that
- * the message relates to, e.g. 'findIntent', with 'Response' appended.
- */
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app representing an event.
- */
-export interface AgentEventMessage {
-  /**
-   * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
-   */
-  meta: AgentEventMessageMeta;
-  /**
-   * The message payload contains details of the event that the app is being notified about.
-   */
-  payload: { [key: string]: any };
-  /**
-   * Identifies the type of the message and it is typically set to the FDC3 function name that
-   * the message relates to, e.g. 'findIntent', with 'Response' appended.
-   */
-  type: EventMessageType;
-}
-
-/**
  * Metadata for messages sent by a Desktop Agent to an app notifying it of an event.
  */
 export interface AgentEventMessageMeta {
@@ -1052,28 +1028,6 @@ export type EventMessageType =
   | 'privateChannelOnAddContextListenerEvent'
   | 'privateChannelOnDisconnectEvent'
   | 'privateChannelOnUnsubscribeEvent';
-
-/**
- * A message from a Desktop Agent to an FDC3-enabled app responding to an API call. If the
- * payload contains an `error` property, the request was unsuccessful.
- */
-export interface AgentResponseMessage {
-  /**
-   * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
-   */
-  meta: AgentResponseMessageMeta;
-  /**
-   * A payload for a response to an API call that will contain any return values or an `error`
-   * property containing a standardized error message indicating that the request was
-   * unsuccessful.
-   */
-  payload: AgentResponseMessageResponsePayload;
-  /**
-   * Identifies the type of the message and it is typically set to the FDC3 function name that
-   * the message relates to, e.g. 'findIntent', with 'Response' appended.
-   */
-  type: ResponseMessageType;
-}
 
 /**
  * Metadata for messages sent by a Desktop Agent to an app in response to an API call.
@@ -1131,25 +1085,6 @@ export type ResponseMessageType =
   | 'raiseIntentForContextResponse'
   | 'raiseIntentResponse'
   | 'raiseIntentResultResponse';
-
-/**
- * A request message from an FDC3-enabled app to a Desktop Agent.
- */
-export interface AppRequestMessage {
-  /**
-   * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
-   */
-  meta: AppRequestMessageMeta;
-  /**
-   * The message payload typically contains the arguments to FDC3 API functions.
-   */
-  payload: { [key: string]: any };
-  /**
-   * Identifies the type of the message and it is typically set to the FDC3 function name that
-   * the message relates to, e.g. 'findIntent', with 'Request' appended.
-   */
-  type: RequestMessageType;
-}
 
 /**
  * Metadata for a request message sent by an FDC3-enabled app to a Desktop Agent.
@@ -6253,3 +6188,1725 @@ const typeMap: any = {
   RaiseIntentResponseType: ['raiseIntentResponse'],
   RaiseIntentResultResponseType: ['raiseIntentResultResponse'],
 };
+
+export type AppRequestMessage =
+  | AddContextListenerRequest
+  | AddEventListenerRequest
+  | AddIntentListenerRequest
+  | BroadcastRequest
+  | ContextListenerUnsubscribeRequest
+  | CreatePrivateChannelRequest
+  | EventListenerUnsubscribeRequest
+  | FindInstancesRequest
+  | FindIntentRequest
+  | FindIntentsByContextRequest
+  | GetAppMetadataRequest
+  | GetCurrentChannelRequest
+  | GetCurrentContextRequest
+  | GetInfoRequest
+  | GetOrCreateChannelRequest
+  | GetUserChannelsRequest
+  | HeartbeatAcknowledgementRequest
+  | IntentListenerUnsubscribeRequest
+  | IntentResultRequest
+  | JoinUserChannelRequest
+  | LeaveCurrentChannelRequest
+  | OpenRequest
+  | PrivateChannelAddEventListenerRequest
+  | PrivateChannelDisconnectRequest
+  | PrivateChannelUnsubscribeEventListenerRequest
+  | RaiseIntentForContextRequest
+  | RaiseIntentRequest;
+
+export type AgentResponseMessage =
+  | AddContextListenerResponse
+  | AddEventListenerResponse
+  | AddIntentListenerResponse
+  | BroadcastResponse
+  | ContextListenerUnsubscribeResponse
+  | CreatePrivateChannelResponse
+  | EventListenerUnsubscribeResponse
+  | FindInstancesResponse
+  | FindIntentResponse
+  | FindIntentsByContextResponse
+  | GetAppMetadataResponse
+  | GetCurrentChannelResponse
+  | GetCurrentContextResponse
+  | GetInfoResponse
+  | GetOrCreateChannelResponse
+  | GetUserChannelsResponse
+  | IntentListenerUnsubscribeResponse
+  | IntentResultResponse
+  | JoinUserChannelResponse
+  | LeaveCurrentChannelResponse
+  | OpenResponse
+  | PrivateChannelAddEventListenerResponse
+  | PrivateChannelDisconnectResponse
+  | PrivateChannelUnsubscribeEventListenerResponse
+  | RaiseIntentForContextResponse
+  | RaiseIntentResponse
+  | RaiseIntentResultResponse;
+
+export type AgentEventMessage =
+  | BroadcastEvent
+  | ChannelChangedEvent
+  | HeartbeatEvent
+  | IntentEvent
+  | PrivateChannelOnAddContextListenerEvent
+  | PrivateChannelOnDisconnectEvent
+  | PrivateChannelOnUnsubscribeEvent;
+
+/**
+ * Returns true if the value has a type property with value 'WCP1Hello'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+  return value != null && value.type === 'WCP1Hello';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol1Hello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol1Hello(value: any): value is WebConnectionProtocol1Hello {
+  try {
+    Convert.webConnectionProtocol1HelloToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL1_HELLO_TYPE = 'WebConnectionProtocol1Hello';
+
+/**
+ * Returns true if the value has a type property with value 'WCP2LoadUrl'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+  return value != null && value.type === 'WCP2LoadUrl';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol2LoadURL. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol2LoadURL(value: any): value is WebConnectionProtocol2LoadURL {
+  try {
+    Convert.webConnectionProtocol2LoadURLToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL2_LOAD_U_R_L_TYPE = 'WebConnectionProtocol2LoadURL';
+
+/**
+ * Returns true if the value has a type property with value 'WCP3Handshake'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+  return value != null && value.type === 'WCP3Handshake';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol3Handshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol3Handshake(value: any): value is WebConnectionProtocol3Handshake {
+  try {
+    Convert.webConnectionProtocol3HandshakeToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL3_HANDSHAKE_TYPE = 'WebConnectionProtocol3Handshake';
+
+/**
+ * Returns true if the value has a type property with value 'WCP4ValidateAppIdentity'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol4ValidateAppIdentity(
+  value: any
+): value is WebConnectionProtocol4ValidateAppIdentity {
+  return value != null && value.type === 'WCP4ValidateAppIdentity';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol4ValidateAppIdentity. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol4ValidateAppIdentity(
+  value: any
+): value is WebConnectionProtocol4ValidateAppIdentity {
+  try {
+    Convert.webConnectionProtocol4ValidateAppIdentityToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL4_VALIDATE_APP_IDENTITY_TYPE = 'WebConnectionProtocol4ValidateAppIdentity';
+
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityFailedResponse'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol5ValidateAppIdentityFailedResponse(
+  value: any
+): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+  return value != null && value.type === 'WCP5ValidateAppIdentityFailedResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentityFailedResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentityFailedResponse(
+  value: any
+): value is WebConnectionProtocol5ValidateAppIdentityFailedResponse {
+  try {
+    Convert.webConnectionProtocol5ValidateAppIdentityFailedResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_FAILED_RESPONSE_TYPE =
+  'WebConnectionProtocol5ValidateAppIdentityFailedResponse';
+
+/**
+ * Returns true if the value has a type property with value 'WCP5ValidateAppIdentityResponse'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol5ValidateAppIdentitySuccessResponse(
+  value: any
+): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+  return value != null && value.type === 'WCP5ValidateAppIdentityResponse';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol5ValidateAppIdentitySuccessResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol5ValidateAppIdentitySuccessResponse(
+  value: any
+): value is WebConnectionProtocol5ValidateAppIdentitySuccessResponse {
+  try {
+    Convert.webConnectionProtocol5ValidateAppIdentitySuccessResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL5_VALIDATE_APP_IDENTITY_SUCCESS_RESPONSE_TYPE =
+  'WebConnectionProtocol5ValidateAppIdentitySuccessResponse';
+
+/**
+ * Returns true if the value has a type property with value 'WCP6Goodbye'. This is a fast check that does not check the format of the message
+ */
+export function isWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+  return value != null && value.type === 'WCP6Goodbye';
+}
+
+/**
+ * Returns true if value is a valid WebConnectionProtocol6Goodbye. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocol6Goodbye(value: any): value is WebConnectionProtocol6Goodbye {
+  try {
+    Convert.webConnectionProtocol6GoodbyeToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL6_GOODBYE_TYPE = 'WebConnectionProtocol6Goodbye';
+
+/**
+ * Returns true if value is a valid WebConnectionProtocolMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidWebConnectionProtocolMessage(value: any): value is WebConnectionProtocolMessage {
+  try {
+    Convert.webConnectionProtocolMessageToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const WEB_CONNECTION_PROTOCOL_MESSAGE_TYPE = 'WebConnectionProtocolMessage';
+
+/**
+ * Returns true if the value has a type property with value 'addContextListenerRequest'. This is a fast check that does not check the format of the message
+ */
+export function isAddContextListenerRequest(value: any): value is AddContextListenerRequest {
+  return value != null && value.type === 'addContextListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerRequest(value: any): value is AddContextListenerRequest {
+  try {
+    Convert.addContextListenerRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_CONTEXT_LISTENER_REQUEST_TYPE = 'AddContextListenerRequest';
+
+/**
+ * Returns true if the value has a type property with value 'addContextListenerResponse'. This is a fast check that does not check the format of the message
+ */
+export function isAddContextListenerResponse(value: any): value is AddContextListenerResponse {
+  return value != null && value.type === 'addContextListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddContextListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddContextListenerResponse(value: any): value is AddContextListenerResponse {
+  try {
+    Convert.addContextListenerResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_CONTEXT_LISTENER_RESPONSE_TYPE = 'AddContextListenerResponse';
+
+/**
+ * Returns true if the value has a type property with value 'addEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
+export function isAddEventListenerRequest(value: any): value is AddEventListenerRequest {
+  return value != null && value.type === 'addEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerRequest(value: any): value is AddEventListenerRequest {
+  try {
+    Convert.addEventListenerRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_EVENT_LISTENER_REQUEST_TYPE = 'AddEventListenerRequest';
+
+/**
+ * Returns true if the value has a type property with value 'addEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
+export function isAddEventListenerResponse(value: any): value is AddEventListenerResponse {
+  return value != null && value.type === 'addEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddEventListenerResponse(value: any): value is AddEventListenerResponse {
+  try {
+    Convert.addEventListenerResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_EVENT_LISTENER_RESPONSE_TYPE = 'AddEventListenerResponse';
+
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerRequest'. This is a fast check that does not check the format of the message
+ */
+export function isAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
+  return value != null && value.type === 'addIntentListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerRequest(value: any): value is AddIntentListenerRequest {
+  try {
+    Convert.addIntentListenerRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_INTENT_LISTENER_REQUEST_TYPE = 'AddIntentListenerRequest';
+
+/**
+ * Returns true if the value has a type property with value 'addIntentListenerResponse'. This is a fast check that does not check the format of the message
+ */
+export function isAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
+  return value != null && value.type === 'addIntentListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid AddIntentListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidAddIntentListenerResponse(value: any): value is AddIntentListenerResponse {
+  try {
+    Convert.addIntentListenerResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const ADD_INTENT_LISTENER_RESPONSE_TYPE = 'AddIntentListenerResponse';
+
+/**
+ * Returns true if the value has a type property with value 'broadcastEvent'. This is a fast check that does not check the format of the message
+ */
+export function isBroadcastEvent(value: any): value is BroadcastEvent {
+  return value != null && value.type === 'broadcastEvent';
+}
+
+/**
+ * Returns true if value is a valid BroadcastEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastEvent(value: any): value is BroadcastEvent {
+  try {
+    Convert.broadcastEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const BROADCAST_EVENT_TYPE = 'BroadcastEvent';
+
+/**
+ * Returns true if the value has a type property with value 'broadcastRequest'. This is a fast check that does not check the format of the message
+ */
+export function isBroadcastRequest(value: any): value is BroadcastRequest {
+  return value != null && value.type === 'broadcastRequest';
+}
+
+/**
+ * Returns true if value is a valid BroadcastRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastRequest(value: any): value is BroadcastRequest {
+  try {
+    Convert.broadcastRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const BROADCAST_REQUEST_TYPE = 'BroadcastRequest';
+
+/**
+ * Returns true if the value has a type property with value 'broadcastResponse'. This is a fast check that does not check the format of the message
+ */
+export function isBroadcastResponse(value: any): value is BroadcastResponse {
+  return value != null && value.type === 'broadcastResponse';
+}
+
+/**
+ * Returns true if value is a valid BroadcastResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidBroadcastResponse(value: any): value is BroadcastResponse {
+  try {
+    Convert.broadcastResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const BROADCAST_RESPONSE_TYPE = 'BroadcastResponse';
+
+/**
+ * Returns true if the value has a type property with value 'channelChangedEvent'. This is a fast check that does not check the format of the message
+ */
+export function isChannelChangedEvent(value: any): value is ChannelChangedEvent {
+  return value != null && value.type === 'channelChangedEvent';
+}
+
+/**
+ * Returns true if value is a valid ChannelChangedEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidChannelChangedEvent(value: any): value is ChannelChangedEvent {
+  try {
+    Convert.channelChangedEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const CHANNEL_CHANGED_EVENT_TYPE = 'ChannelChangedEvent';
+
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
+export function isContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
+  return value != null && value.type === 'contextListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeRequest(value: any): value is ContextListenerUnsubscribeRequest {
+  try {
+    Convert.contextListenerUnsubscribeRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const CONTEXT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = 'ContextListenerUnsubscribeRequest';
+
+/**
+ * Returns true if the value has a type property with value 'contextListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
+export function isContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
+  return value != null && value.type === 'contextListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid ContextListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidContextListenerUnsubscribeResponse(value: any): value is ContextListenerUnsubscribeResponse {
+  try {
+    Convert.contextListenerUnsubscribeResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const CONTEXT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = 'ContextListenerUnsubscribeResponse';
+
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelRequest'. This is a fast check that does not check the format of the message
+ */
+export function isCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
+  return value != null && value.type === 'createPrivateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelRequest(value: any): value is CreatePrivateChannelRequest {
+  try {
+    Convert.createPrivateChannelRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const CREATE_PRIVATE_CHANNEL_REQUEST_TYPE = 'CreatePrivateChannelRequest';
+
+/**
+ * Returns true if the value has a type property with value 'createPrivateChannelResponse'. This is a fast check that does not check the format of the message
+ */
+export function isCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
+  return value != null && value.type === 'createPrivateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid CreatePrivateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidCreatePrivateChannelResponse(value: any): value is CreatePrivateChannelResponse {
+  try {
+    Convert.createPrivateChannelResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const CREATE_PRIVATE_CHANNEL_RESPONSE_TYPE = 'CreatePrivateChannelResponse';
+
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
+export function isEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
+  return value != null && value.type === 'eventListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeRequest(value: any): value is EventListenerUnsubscribeRequest {
+  try {
+    Convert.eventListenerUnsubscribeRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const EVENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = 'EventListenerUnsubscribeRequest';
+
+/**
+ * Returns true if the value has a type property with value 'eventListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
+export function isEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
+  return value != null && value.type === 'eventListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid EventListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidEventListenerUnsubscribeResponse(value: any): value is EventListenerUnsubscribeResponse {
+  try {
+    Convert.eventListenerUnsubscribeResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const EVENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = 'EventListenerUnsubscribeResponse';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannelSelected'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+  return value != null && value.type === 'Fdc3UserInterfaceChannelSelected';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannelSelected. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannelSelected(value: any): value is Fdc3UserInterfaceChannelSelected {
+  try {
+    Convert.fdc3UserInterfaceChannelSelectedToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_CHANNEL_SELECTED_TYPE = 'Fdc3UserInterfaceChannelSelected';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceChannels'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
+  return value != null && value.type === 'Fdc3UserInterfaceChannels';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceChannels. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceChannels(value: any): value is Fdc3UserInterfaceChannels {
+  try {
+    Convert.fdc3UserInterfaceChannelsToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_CHANNELS_TYPE = 'Fdc3UserInterfaceChannels';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceDrag'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
+  return value != null && value.type === 'Fdc3UserInterfaceDrag';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceDrag. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceDrag(value: any): value is Fdc3UserInterfaceDrag {
+  try {
+    Convert.fdc3UserInterfaceDragToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_DRAG_TYPE = 'Fdc3UserInterfaceDrag';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHandshake'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
+  return value != null && value.type === 'Fdc3UserInterfaceHandshake';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHandshake. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHandshake(value: any): value is Fdc3UserInterfaceHandshake {
+  try {
+    Convert.fdc3UserInterfaceHandshakeToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_HANDSHAKE_TYPE = 'Fdc3UserInterfaceHandshake';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceHello'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
+  return value != null && value.type === 'Fdc3UserInterfaceHello';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceHello. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceHello(value: any): value is Fdc3UserInterfaceHello {
+  try {
+    Convert.fdc3UserInterfaceHelloToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_HELLO_TYPE = 'Fdc3UserInterfaceHello';
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceMessage. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceMessage(value: any): value is Fdc3UserInterfaceMessage {
+  try {
+    Convert.fdc3UserInterfaceMessageToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_MESSAGE_TYPE = 'Fdc3UserInterfaceMessage';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolve'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
+  return value != null && value.type === 'Fdc3UserInterfaceResolve';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolve. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolve(value: any): value is Fdc3UserInterfaceResolve {
+  try {
+    Convert.fdc3UserInterfaceResolveToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_RESOLVE_TYPE = 'Fdc3UserInterfaceResolve';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceResolveAction'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
+  return value != null && value.type === 'Fdc3UserInterfaceResolveAction';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceResolveAction. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceResolveAction(value: any): value is Fdc3UserInterfaceResolveAction {
+  try {
+    Convert.fdc3UserInterfaceResolveActionToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_RESOLVE_ACTION_TYPE = 'Fdc3UserInterfaceResolveAction';
+
+/**
+ * Returns true if the value has a type property with value 'Fdc3UserInterfaceRestyle'. This is a fast check that does not check the format of the message
+ */
+export function isFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
+  return value != null && value.type === 'Fdc3UserInterfaceRestyle';
+}
+
+/**
+ * Returns true if value is a valid Fdc3UserInterfaceRestyle. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFdc3UserInterfaceRestyle(value: any): value is Fdc3UserInterfaceRestyle {
+  try {
+    Convert.fdc3UserInterfaceRestyleToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FDC3_USER_INTERFACE_RESTYLE_TYPE = 'Fdc3UserInterfaceRestyle';
+
+/**
+ * Returns true if the value has a type property with value 'findInstancesRequest'. This is a fast check that does not check the format of the message
+ */
+export function isFindInstancesRequest(value: any): value is FindInstancesRequest {
+  return value != null && value.type === 'findInstancesRequest';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesRequest(value: any): value is FindInstancesRequest {
+  try {
+    Convert.findInstancesRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INSTANCES_REQUEST_TYPE = 'FindInstancesRequest';
+
+/**
+ * Returns true if the value has a type property with value 'findInstancesResponse'. This is a fast check that does not check the format of the message
+ */
+export function isFindInstancesResponse(value: any): value is FindInstancesResponse {
+  return value != null && value.type === 'findInstancesResponse';
+}
+
+/**
+ * Returns true if value is a valid FindInstancesResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindInstancesResponse(value: any): value is FindInstancesResponse {
+  try {
+    Convert.findInstancesResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INSTANCES_RESPONSE_TYPE = 'FindInstancesResponse';
+
+/**
+ * Returns true if the value has a type property with value 'findIntentRequest'. This is a fast check that does not check the format of the message
+ */
+export function isFindIntentRequest(value: any): value is FindIntentRequest {
+  return value != null && value.type === 'findIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentRequest(value: any): value is FindIntentRequest {
+  try {
+    Convert.findIntentRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INTENT_REQUEST_TYPE = 'FindIntentRequest';
+
+/**
+ * Returns true if the value has a type property with value 'findIntentResponse'. This is a fast check that does not check the format of the message
+ */
+export function isFindIntentResponse(value: any): value is FindIntentResponse {
+  return value != null && value.type === 'findIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentResponse(value: any): value is FindIntentResponse {
+  try {
+    Convert.findIntentResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INTENT_RESPONSE_TYPE = 'FindIntentResponse';
+
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextRequest'. This is a fast check that does not check the format of the message
+ */
+export function isFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
+  return value != null && value.type === 'findIntentsByContextRequest';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextRequest(value: any): value is FindIntentsByContextRequest {
+  try {
+    Convert.findIntentsByContextRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INTENTS_BY_CONTEXT_REQUEST_TYPE = 'FindIntentsByContextRequest';
+
+/**
+ * Returns true if the value has a type property with value 'findIntentsByContextResponse'. This is a fast check that does not check the format of the message
+ */
+export function isFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
+  return value != null && value.type === 'findIntentsByContextResponse';
+}
+
+/**
+ * Returns true if value is a valid FindIntentsByContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidFindIntentsByContextResponse(value: any): value is FindIntentsByContextResponse {
+  try {
+    Convert.findIntentsByContextResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const FIND_INTENTS_BY_CONTEXT_RESPONSE_TYPE = 'FindIntentsByContextResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
+  return value != null && value.type === 'getAppMetadataRequest';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataRequest(value: any): value is GetAppMetadataRequest {
+  try {
+    Convert.getAppMetadataRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_APP_METADATA_REQUEST_TYPE = 'GetAppMetadataRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getAppMetadataResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
+  return value != null && value.type === 'getAppMetadataResponse';
+}
+
+/**
+ * Returns true if value is a valid GetAppMetadataResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetAppMetadataResponse(value: any): value is GetAppMetadataResponse {
+  try {
+    Convert.getAppMetadataResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_APP_METADATA_RESPONSE_TYPE = 'GetAppMetadataResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
+  return value != null && value.type === 'getCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelRequest(value: any): value is GetCurrentChannelRequest {
+  try {
+    Convert.getCurrentChannelRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_CURRENT_CHANNEL_REQUEST_TYPE = 'GetCurrentChannelRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
+  return value != null && value.type === 'getCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentChannelResponse(value: any): value is GetCurrentChannelResponse {
+  try {
+    Convert.getCurrentChannelResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_CURRENT_CHANNEL_RESPONSE_TYPE = 'GetCurrentChannelResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
+  return value != null && value.type === 'getCurrentContextRequest';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextRequest(value: any): value is GetCurrentContextRequest {
+  try {
+    Convert.getCurrentContextRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_CURRENT_CONTEXT_REQUEST_TYPE = 'GetCurrentContextRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getCurrentContextResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
+  return value != null && value.type === 'getCurrentContextResponse';
+}
+
+/**
+ * Returns true if value is a valid GetCurrentContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetCurrentContextResponse(value: any): value is GetCurrentContextResponse {
+  try {
+    Convert.getCurrentContextResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_CURRENT_CONTEXT_RESPONSE_TYPE = 'GetCurrentContextResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getInfoRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetInfoRequest(value: any): value is GetInfoRequest {
+  return value != null && value.type === 'getInfoRequest';
+}
+
+/**
+ * Returns true if value is a valid GetInfoRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoRequest(value: any): value is GetInfoRequest {
+  try {
+    Convert.getInfoRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_INFO_REQUEST_TYPE = 'GetInfoRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getInfoResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetInfoResponse(value: any): value is GetInfoResponse {
+  return value != null && value.type === 'getInfoResponse';
+}
+
+/**
+ * Returns true if value is a valid GetInfoResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetInfoResponse(value: any): value is GetInfoResponse {
+  try {
+    Convert.getInfoResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_INFO_RESPONSE_TYPE = 'GetInfoResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
+  return value != null && value.type === 'getOrCreateChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelRequest(value: any): value is GetOrCreateChannelRequest {
+  try {
+    Convert.getOrCreateChannelRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_OR_CREATE_CHANNEL_REQUEST_TYPE = 'GetOrCreateChannelRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getOrCreateChannelResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
+  return value != null && value.type === 'getOrCreateChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid GetOrCreateChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetOrCreateChannelResponse(value: any): value is GetOrCreateChannelResponse {
+  try {
+    Convert.getOrCreateChannelResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_OR_CREATE_CHANNEL_RESPONSE_TYPE = 'GetOrCreateChannelResponse';
+
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsRequest'. This is a fast check that does not check the format of the message
+ */
+export function isGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
+  return value != null && value.type === 'getUserChannelsRequest';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsRequest(value: any): value is GetUserChannelsRequest {
+  try {
+    Convert.getUserChannelsRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_USER_CHANNELS_REQUEST_TYPE = 'GetUserChannelsRequest';
+
+/**
+ * Returns true if the value has a type property with value 'getUserChannelsResponse'. This is a fast check that does not check the format of the message
+ */
+export function isGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
+  return value != null && value.type === 'getUserChannelsResponse';
+}
+
+/**
+ * Returns true if value is a valid GetUserChannelsResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidGetUserChannelsResponse(value: any): value is GetUserChannelsResponse {
+  try {
+    Convert.getUserChannelsResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const GET_USER_CHANNELS_RESPONSE_TYPE = 'GetUserChannelsResponse';
+
+/**
+ * Returns true if the value has a type property with value 'heartbeatAcknowledgementRequest'. This is a fast check that does not check the format of the message
+ */
+export function isHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
+  return value != null && value.type === 'heartbeatAcknowledgementRequest';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatAcknowledgementRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatAcknowledgementRequest(value: any): value is HeartbeatAcknowledgementRequest {
+  try {
+    Convert.heartbeatAcknowledgementRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const HEARTBEAT_ACKNOWLEDGEMENT_REQUEST_TYPE = 'HeartbeatAcknowledgementRequest';
+
+/**
+ * Returns true if the value has a type property with value 'heartbeatEvent'. This is a fast check that does not check the format of the message
+ */
+export function isHeartbeatEvent(value: any): value is HeartbeatEvent {
+  return value != null && value.type === 'heartbeatEvent';
+}
+
+/**
+ * Returns true if value is a valid HeartbeatEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidHeartbeatEvent(value: any): value is HeartbeatEvent {
+  try {
+    Convert.heartbeatEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const HEARTBEAT_EVENT_TYPE = 'HeartbeatEvent';
+
+/**
+ * Returns true if the value has a type property with value 'intentEvent'. This is a fast check that does not check the format of the message
+ */
+export function isIntentEvent(value: any): value is IntentEvent {
+  return value != null && value.type === 'intentEvent';
+}
+
+/**
+ * Returns true if value is a valid IntentEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentEvent(value: any): value is IntentEvent {
+  try {
+    Convert.intentEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const INTENT_EVENT_TYPE = 'IntentEvent';
+
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeRequest'. This is a fast check that does not check the format of the message
+ */
+export function isIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
+  return value != null && value.type === 'intentListenerUnsubscribeRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeRequest(value: any): value is IntentListenerUnsubscribeRequest {
+  try {
+    Convert.intentListenerUnsubscribeRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const INTENT_LISTENER_UNSUBSCRIBE_REQUEST_TYPE = 'IntentListenerUnsubscribeRequest';
+
+/**
+ * Returns true if the value has a type property with value 'intentListenerUnsubscribeResponse'. This is a fast check that does not check the format of the message
+ */
+export function isIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
+  return value != null && value.type === 'intentListenerUnsubscribeResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentListenerUnsubscribeResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentListenerUnsubscribeResponse(value: any): value is IntentListenerUnsubscribeResponse {
+  try {
+    Convert.intentListenerUnsubscribeResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const INTENT_LISTENER_UNSUBSCRIBE_RESPONSE_TYPE = 'IntentListenerUnsubscribeResponse';
+
+/**
+ * Returns true if the value has a type property with value 'intentResultRequest'. This is a fast check that does not check the format of the message
+ */
+export function isIntentResultRequest(value: any): value is IntentResultRequest {
+  return value != null && value.type === 'intentResultRequest';
+}
+
+/**
+ * Returns true if value is a valid IntentResultRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultRequest(value: any): value is IntentResultRequest {
+  try {
+    Convert.intentResultRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const INTENT_RESULT_REQUEST_TYPE = 'IntentResultRequest';
+
+/**
+ * Returns true if the value has a type property with value 'intentResultResponse'. This is a fast check that does not check the format of the message
+ */
+export function isIntentResultResponse(value: any): value is IntentResultResponse {
+  return value != null && value.type === 'intentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid IntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidIntentResultResponse(value: any): value is IntentResultResponse {
+  try {
+    Convert.intentResultResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const INTENT_RESULT_RESPONSE_TYPE = 'IntentResultResponse';
+
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelRequest'. This is a fast check that does not check the format of the message
+ */
+export function isJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
+  return value != null && value.type === 'joinUserChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelRequest(value: any): value is JoinUserChannelRequest {
+  try {
+    Convert.joinUserChannelRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const JOIN_USER_CHANNEL_REQUEST_TYPE = 'JoinUserChannelRequest';
+
+/**
+ * Returns true if the value has a type property with value 'joinUserChannelResponse'. This is a fast check that does not check the format of the message
+ */
+export function isJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
+  return value != null && value.type === 'joinUserChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid JoinUserChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidJoinUserChannelResponse(value: any): value is JoinUserChannelResponse {
+  try {
+    Convert.joinUserChannelResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const JOIN_USER_CHANNEL_RESPONSE_TYPE = 'JoinUserChannelResponse';
+
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelRequest'. This is a fast check that does not check the format of the message
+ */
+export function isLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
+  return value != null && value.type === 'leaveCurrentChannelRequest';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelRequest(value: any): value is LeaveCurrentChannelRequest {
+  try {
+    Convert.leaveCurrentChannelRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const LEAVE_CURRENT_CHANNEL_REQUEST_TYPE = 'LeaveCurrentChannelRequest';
+
+/**
+ * Returns true if the value has a type property with value 'leaveCurrentChannelResponse'. This is a fast check that does not check the format of the message
+ */
+export function isLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
+  return value != null && value.type === 'leaveCurrentChannelResponse';
+}
+
+/**
+ * Returns true if value is a valid LeaveCurrentChannelResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidLeaveCurrentChannelResponse(value: any): value is LeaveCurrentChannelResponse {
+  try {
+    Convert.leaveCurrentChannelResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const LEAVE_CURRENT_CHANNEL_RESPONSE_TYPE = 'LeaveCurrentChannelResponse';
+
+/**
+ * Returns true if the value has a type property with value 'openRequest'. This is a fast check that does not check the format of the message
+ */
+export function isOpenRequest(value: any): value is OpenRequest {
+  return value != null && value.type === 'openRequest';
+}
+
+/**
+ * Returns true if value is a valid OpenRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenRequest(value: any): value is OpenRequest {
+  try {
+    Convert.openRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const OPEN_REQUEST_TYPE = 'OpenRequest';
+
+/**
+ * Returns true if the value has a type property with value 'openResponse'. This is a fast check that does not check the format of the message
+ */
+export function isOpenResponse(value: any): value is OpenResponse {
+  return value != null && value.type === 'openResponse';
+}
+
+/**
+ * Returns true if value is a valid OpenResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidOpenResponse(value: any): value is OpenResponse {
+  try {
+    Convert.openResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const OPEN_RESPONSE_TYPE = 'OpenResponse';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelAddEventListenerRequest(value: any): value is PrivateChannelAddEventListenerRequest {
+  return value != null && value.type === 'privateChannelAddEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerRequest(
+  value: any
+): value is PrivateChannelAddEventListenerRequest {
+  try {
+    Convert.privateChannelAddEventListenerRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_REQUEST_TYPE = 'PrivateChannelAddEventListenerRequest';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelAddEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelAddEventListenerResponse(value: any): value is PrivateChannelAddEventListenerResponse {
+  return value != null && value.type === 'privateChannelAddEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelAddEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelAddEventListenerResponse(
+  value: any
+): value is PrivateChannelAddEventListenerResponse {
+  try {
+    Convert.privateChannelAddEventListenerResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_ADD_EVENT_LISTENER_RESPONSE_TYPE = 'PrivateChannelAddEventListenerResponse';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectRequest'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
+  return value != null && value.type === 'privateChannelDisconnectRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectRequest(value: any): value is PrivateChannelDisconnectRequest {
+  try {
+    Convert.privateChannelDisconnectRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_DISCONNECT_REQUEST_TYPE = 'PrivateChannelDisconnectRequest';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelDisconnectResponse'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
+  return value != null && value.type === 'privateChannelDisconnectResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelDisconnectResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelDisconnectResponse(value: any): value is PrivateChannelDisconnectResponse {
+  try {
+    Convert.privateChannelDisconnectResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_DISCONNECT_RESPONSE_TYPE = 'PrivateChannelDisconnectResponse';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnAddContextListenerEvent'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelOnAddContextListenerEvent(
+  value: any
+): value is PrivateChannelOnAddContextListenerEvent {
+  return value != null && value.type === 'privateChannelOnAddContextListenerEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnAddContextListenerEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnAddContextListenerEvent(
+  value: any
+): value is PrivateChannelOnAddContextListenerEvent {
+  try {
+    Convert.privateChannelOnAddContextListenerEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_ON_ADD_CONTEXT_LISTENER_EVENT_TYPE = 'PrivateChannelOnAddContextListenerEvent';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnDisconnectEvent'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
+  return value != null && value.type === 'privateChannelOnDisconnectEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnDisconnectEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnDisconnectEvent(value: any): value is PrivateChannelOnDisconnectEvent {
+  try {
+    Convert.privateChannelOnDisconnectEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_ON_DISCONNECT_EVENT_TYPE = 'PrivateChannelOnDisconnectEvent';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelOnUnsubscribeEvent'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
+  return value != null && value.type === 'privateChannelOnUnsubscribeEvent';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelOnUnsubscribeEvent. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelOnUnsubscribeEvent(value: any): value is PrivateChannelOnUnsubscribeEvent {
+  try {
+    Convert.privateChannelOnUnsubscribeEventToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_ON_UNSUBSCRIBE_EVENT_TYPE = 'PrivateChannelOnUnsubscribeEvent';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerRequest'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelUnsubscribeEventListenerRequest(
+  value: any
+): value is PrivateChannelUnsubscribeEventListenerRequest {
+  return value != null && value.type === 'privateChannelUnsubscribeEventListenerRequest';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerRequest(
+  value: any
+): value is PrivateChannelUnsubscribeEventListenerRequest {
+  try {
+    Convert.privateChannelUnsubscribeEventListenerRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_REQUEST_TYPE = 'PrivateChannelUnsubscribeEventListenerRequest';
+
+/**
+ * Returns true if the value has a type property with value 'privateChannelUnsubscribeEventListenerResponse'. This is a fast check that does not check the format of the message
+ */
+export function isPrivateChannelUnsubscribeEventListenerResponse(
+  value: any
+): value is PrivateChannelUnsubscribeEventListenerResponse {
+  return value != null && value.type === 'privateChannelUnsubscribeEventListenerResponse';
+}
+
+/**
+ * Returns true if value is a valid PrivateChannelUnsubscribeEventListenerResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidPrivateChannelUnsubscribeEventListenerResponse(
+  value: any
+): value is PrivateChannelUnsubscribeEventListenerResponse {
+  try {
+    Convert.privateChannelUnsubscribeEventListenerResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const PRIVATE_CHANNEL_UNSUBSCRIBE_EVENT_LISTENER_RESPONSE_TYPE =
+  'PrivateChannelUnsubscribeEventListenerResponse';
+
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextRequest'. This is a fast check that does not check the format of the message
+ */
+export function isRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
+  return value != null && value.type === 'raiseIntentForContextRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextRequest(value: any): value is RaiseIntentForContextRequest {
+  try {
+    Convert.raiseIntentForContextRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const RAISE_INTENT_FOR_CONTEXT_REQUEST_TYPE = 'RaiseIntentForContextRequest';
+
+/**
+ * Returns true if the value has a type property with value 'raiseIntentForContextResponse'. This is a fast check that does not check the format of the message
+ */
+export function isRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
+  return value != null && value.type === 'raiseIntentForContextResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentForContextResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentForContextResponse(value: any): value is RaiseIntentForContextResponse {
+  try {
+    Convert.raiseIntentForContextResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const RAISE_INTENT_FOR_CONTEXT_RESPONSE_TYPE = 'RaiseIntentForContextResponse';
+
+/**
+ * Returns true if the value has a type property with value 'raiseIntentRequest'. This is a fast check that does not check the format of the message
+ */
+export function isRaiseIntentRequest(value: any): value is RaiseIntentRequest {
+  return value != null && value.type === 'raiseIntentRequest';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentRequest. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentRequest(value: any): value is RaiseIntentRequest {
+  try {
+    Convert.raiseIntentRequestToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const RAISE_INTENT_REQUEST_TYPE = 'RaiseIntentRequest';
+
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResponse'. This is a fast check that does not check the format of the message
+ */
+export function isRaiseIntentResponse(value: any): value is RaiseIntentResponse {
+  return value != null && value.type === 'raiseIntentResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResponse(value: any): value is RaiseIntentResponse {
+  try {
+    Convert.raiseIntentResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const RAISE_INTENT_RESPONSE_TYPE = 'RaiseIntentResponse';
+
+/**
+ * Returns true if the value has a type property with value 'raiseIntentResultResponse'. This is a fast check that does not check the format of the message
+ */
+export function isRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
+  return value != null && value.type === 'raiseIntentResultResponse';
+}
+
+/**
+ * Returns true if value is a valid RaiseIntentResultResponse. This checks the type against the json schema for the message and will be slower
+ */
+export function isValidRaiseIntentResultResponse(value: any): value is RaiseIntentResultResponse {
+  try {
+    Convert.raiseIntentResultResponseToJson(value);
+    return true;
+  } catch (_e: any) {
+    return false;
+  }
+}
+
+export const RAISE_INTENT_RESULT_RESPONSE_TYPE = 'RaiseIntentResultResponse';

--- a/toolbox/fdc3-workbench/vite.config.ts
+++ b/toolbox/fdc3-workbench/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     outDir: 'build',
   },
   define: {
+    'process.env.NODE_DEBUG': 'false',
     'process.env': 'import.meta.env',
     'global.process': 'globalThis.process',
   },


### PR DESCRIPTION
…onfig

## Describe your change

resolves #1567 

### Related Issue
<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
