### PR TITLE
Workbench: don't destructure injected DAs when retrieving channels

### DIFF
--- a/toolbox/fdc3-workbench/src/store/ChannelStore.ts
+++ b/toolbox/fdc3-workbench/src/store/ChannelStore.ts
@@ -55,8 +55,13 @@ class ChannelStore {
     //defer retrieving channels until fdc3 API is ready
     try {
       //backwards compatibility for FDC3 < 2.0
-      const getChannels = agent.getUserChannels ?? agent.getSystemChannels;
-      const userChannels = await getChannels();
+      //  don't destructure DA implementations in case their context is not bound
+      let userChannels: Channel[];
+      if (agent.getUserChannels) {
+        userChannels = await agent.getUserChannels();
+      } else {
+        userChannels = await agent.getSystemChannels();
+      }
       const currentUserChannel = await agent.getCurrentChannel();
 
       runInAction(() => {

--- a/toolbox/fdc3-workbench/src/store/ChannelStore.ts
+++ b/toolbox/fdc3-workbench/src/store/ChannelStore.ts
@@ -86,9 +86,13 @@ class ChannelStore {
   async joinUserChannel(channelId: string) {
     const agent = await getWorkbenchAgent();
     try {
-      //backwards compatability for 1.2
-      const joinUserChannel = agent.joinUserChannel ?? agent.joinChannel;
-      await joinUserChannel(channelId);
+      //backwards compatibility for 1.2
+      if (agent.joinUserChannel) {
+        await agent.joinUserChannel(channelId);
+      } else {
+        await agent.joinChannel(channelId);
+      }
+
       const currentUserChannel = await agent.getCurrentChannel();
       const isSuccess = currentUserChannel !== null;
 


### PR DESCRIPTION
## Describe your change

Attempt at fixing channel retrieval in FDC3 workbench by not desctructuring the Desktop Agent API when retrieving channels.

### Related Issue

resolves #1569 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
