### PR TITLE
Update semgrep.yml to run on ubuntu-latest

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   semgrep:
     name: run-semgrep
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
     steps:


### PR DESCRIPTION
## Describe your change

The static code analysis job has stopped running as the ubuntu version it was configured for has been discontinued in GitHub.  This PR switches it to run on ubuntu-latest

### Related Issue
resolves #1578

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
