### PR TITLE
(WIP) Get sub agent proposal placeholder

### DIFF
--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -25,6 +25,8 @@ interface DesktopAgent {
   open(app: AppIdentifier, context?: Context): Promise<AppIdentifier>;
   findInstances(app: AppIdentifier): Promise<Array<AppIdentifier>>;
   getAppMetadata(app: AppIdentifier): Promise<AppMetadata>;
+  // TODO: add getSubAgent
+  // TODO: add a close or disconnect function (for subAgents or maybe all agents?)
 
   // context
   broadcast(context: Context): Promise<void>;
@@ -411,6 +413,10 @@ _desktopAgent.Broadcast(instrument);
 **See also:**
 
 - [addContextListener](#addcontextlistener)
+
+### `close`
+
+ <!-- TODO: add close or disconnect content -->
 
 ### `createPrivateChannel`
 
@@ -1104,6 +1110,10 @@ var redChannel = userChannels.First(c => c.Id == "red");
 **See also:**
 
 - [`Channel`](Channel)
+
+### `getSubAgent`
+
+ <!-- TODO: add getSubAgent content -->
 
 ### `joinUserChannel`
 

--- a/website/docs/api/spec.md
+++ b/website/docs/api/spec.md
@@ -121,6 +121,8 @@ An FDC3 Standard compliant Desktop Agent implementation **MUST**:
 - Provide details of whether they implement optional features of the Desktop Agent API in the `optionalFeatures` property of the [`ImplementationMetadata`](ref/Metadata#implementationmetadata) object returned by the [`fdc3.getInfo()`](ref/DesktopAgent#getinfo) function.
 - Allow, by default, at least a 15 second timeout for an application, launched via [`fdc3.open`](../api/ref/DesktopAgent#open), [`fdc3.raiseIntent`](../api/ref/DesktopAgent#raiseintent) or [`fdc3.raiseIntentForContext`](../api/ref/DesktopAgent#raiseintentforcontext) to add any context listener (via [`fdc3.addContextListener`](../api/ref/DesktopAgent#addcontextlistener)) or intent listener (via [`fdc3.addIntentListener`](../api/ref/DesktopAgent#addintentlistener)) necessary to deliver context or intent and context to it on launch. This timeout only applies to listeners needed to receive context on launch; further intent and context listeners not required on launch MAY be added later.
 
+<!-- TODO: add any new requirements for subAgents or disconnection functions -->
+
 An FDC3 Standard compliant Desktop Agent implementation **SHOULD**:
 
 - Support connection to one or more App Directories meeting the [FDC3 App Directory Standard](../app-directory/overview).
@@ -131,6 +133,8 @@ An FDC3 Standard compliant Desktop Agent implementation **SHOULD**:
 - Make metadata about each context message or intent and context message received (including the app that originated the message) available to the receiving application.
 - Prevent external apps from listening or publishing on a [`PrivateChannel`](ref/PrivateChannel) that they did not request or provide.
 - Enforce compliance with the expected behavior of intents (where Intents specify a contract that is enforceable by schema, for example, return object types) and return an error if the interface is not met.
+
+<!-- TODO: add any new recommendations for subAgents or disconnection functions -->
 
 An FDC3 Standard compliant Desktop Agent implementation **MAY**:
 
@@ -233,6 +237,12 @@ From version 2.0 of the FDC3 Standard, Desktop Agent functions that reference or
 Additional metadata for an application can be retrieved via the [`fdc3.getAppMetadata(appIdentifier)`](ref/DesktopAgent#getappmetadata) function, which returns an [`AppMetadata`](ref/Metadata#appmetadata) object. The additional metadata may include a title, description, icons, etc., which may be used for display purposes.
 
 Identifiers for instances of an application may be retrieved via the [`fdc3.findInstances(appIdentifier)`](ref/DesktopAgent#findinstances) function.
+
+### Start sub-applications with their own identity
+
+<!-- TODO: Describe the use-case for sub-agents without being overly focused on a particular platform (could make sense in web apps and monolithic apps built in other languages.
+Ensure routing of channel messages and intent resolution are covered.
+-->
 
 ## Raising Intents
 
@@ -843,3 +853,7 @@ To facilitate context linking in such situations it is recommended that applicat
 ### Originating App Metadata
 
 Optional metadata about each context message received, including the app that originated the message, SHOULD be provided by the desktop agent implementation to registered context handlers on all types of channel. As this metadata is optional, apps making use of it MUST handle cases where it is not provided.
+
+## Sub-applications
+
+<!-- Add content describing how sub applications are created with their own identity -->

--- a/website/docs/api/specs/browserResidentDesktopAgents.md
+++ b/website/docs/api/specs/browserResidentDesktopAgents.md
@@ -263,3 +263,7 @@ Communication between the `DesktopAgentProxy` and the iframes it injects is achi
 A further set of messages are provided for working with the injected user interfaces over their `MessageChannel` as part of the DACP, these are: `Fdc3UserInterfaceRestyle`, `Fdc3UserInterfaceDrag`, `Fdc3UserInterfaceChannels`, `Fdc3UserInterfaceChannelSelected`, `Fdc3UserInterfaceResolve` and `Fdc3UserInterfaceResolveAction`.
 
 See the [Desktop Agent Communication Protocol](./desktopAgentCommunicationProtocol) (DACP) for more details.
+
+## Requesting a sub-agent for an embedded application
+
+<!-- Add content on how sub agent requests are handled through the WCP and DACP - include a diagram of the process -->

--- a/website/docs/api/specs/desktopAgentCommunicationProtocol.md
+++ b/website/docs/api/specs/desktopAgentCommunicationProtocol.md
@@ -280,6 +280,10 @@ Request and response used to implement the [`getUserChannels()`](../ref/DesktopA
 - [`getUserChannelsRequest`](pathname:///schemas/next/api/getUserChannelsRequest.schema.json)
 - [`getUserChannelsResponse`](pathname:///schemas/next/api/getUserChannelsResponse.schema.json)
 
+#### `getSubAgent()`
+
+<!-- Add details of any DACP messages used by getSubAgent -->
+
 #### `joinUserChannel()`
 
 Request and response used to implement the [`joinUserChannel()`](../ref/DesktopAgent#joinuserchannel) API call:
@@ -462,6 +466,10 @@ As a Desktop Agent initiated exchange, it is initiated with an `AgentEvent` mess
 Additional procedures are defined in the [Browser Resident Desktop Agents specification](./browserResidentDesktopAgents#disconnects) and [Web Connection Protocol](./webConnectionProtocol#step-5-disconnection) for the detection of app disconnection or closure. Implementations will often need to make use of multiple procedures to catch all forms of disconnection in a web browser.
 
 :::
+
+### Requesting a sub-agent
+
+<!-- Discuss DACP role in requesting a subagent and attachment of of another port to the message, before switching to WCP. Other languages will need to handle that handover somehow -->
 
 ### Controlling Injected User Interfaces
 

--- a/website/docs/api/specs/preloadDesktopAgents.md
+++ b/website/docs/api/specs/preloadDesktopAgents.md
@@ -26,3 +26,7 @@ However, implementors SHOULD also ensure that the global is made available as so
 Prior to FDC3 2.2, apps were advised to check for the existence of the FDC3 API at `window.fdc3` and then add a listener for the `fdc3Ready` event if it was not found. This has since been superseded by the recommendation to use `getAgent()`, which handles those steps internally, alongside supporting FDC3 in web browsers ( via the [Browser Resident Desktop Agent spec](./browserResidentDesktopAgents)).
 
 :::
+
+## Requesting a sub-agent for an embedded application
+
+<!-- Add content on how sub agent requests should be handled by preload DAs -->

--- a/website/docs/api/specs/webConnectionProtocol.md
+++ b/website/docs/api/specs/webConnectionProtocol.md
@@ -393,3 +393,7 @@ The WCP allows applications to indicate to the `getAgent()` implementation wheth
 - [`WCP3Handshake`](pathname:///schemas/next/api/WCP3Handshake.schema.json): Response sent by the Desktop Agent and incorporating `payload.intentResolverUrl` and `payload.channelSelectorUrl` fields, which should be set to the URL for each UI implementation that should be loaded into an iframe to provide the UI (defaults to URLs for reference UI implementations provided by the FDC3 project), or set to `false` to indicate that the respective UI is not needed. Setting these fields to `true` will cause the `getAgent()` implementation to use its default URLs representing a reference implementation of each UI.
 
 When UI iframes are created, the user interfaces may use the `Fdc3UserInterface` messages incorporated into the [Desktop Agent Communication Protocol (DACP)](./desktopAgentCommunicationProtocol#controlling-injected-user-interfaces) to communicate with the `getAgent()` implementation and through it the Desktop Agent.
+
+### Requesting a sub-agent
+
+<!-- Add content on WCP message (re)use in requesting and connecting a subagent -->


### PR DESCRIPTION
## Describe your change

Proposal for getSub

### Related Issue
<!--- This project prefers to accept pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please [link to the issue here](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) by writing "resolves #123456" here: -->

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [ ] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
