### PR TITLE
Revert fdc3.timeRange and fdc3.interaction oneOf back to anyOf and add example validation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Fixed
+* Add unit tests to the fdc3-context package for validating context examples are valid schema.
+* Revert schema of `fdc3.timeRange` context type back to use anyOf in place of oneOf for the `startTime` and `endTime` property combinations.  This will allow existence of one of either, or both, and pass schema validation.  When defined with oneOf, validation would fail due to multiple entries being valid and it could not identify which to apply. ([#1592](https://github.com/finos/FDC3/issues/1592))
+* Revert schema of `fdc3.interaction` context type back to use anyOf in place of oneOf for the `interactionType` property.  Since it could be a string enum or a string, validation could not differentiate. ([#1598](https://github.com/finos/FDC3/issues/1598))
+* Fix `fdc3.timeRange` context example to use correctly formatted dateTime. ([#1599](https://github.com/finos/FDC3/issues/1599))
 
 ## [FDC3 Standard 2.2](https://github.com/finos/FDC3/compare/v2.1..v2.2) - 2025-03-12
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4788,6 +4788,7 @@
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -16694,6 +16695,8 @@
         "@types/jest": "29.5.13",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "28.8.3",
@@ -16706,6 +16709,28 @@
         "tslib": "^2.7.0",
         "typescript": "^5.6.3"
       }
+    },
+    "packages/fdc3-context/node_modules/ajv": {
+      "version": "8.17.1",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/fdc3-context/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "packages/fdc3-context/node_modules/mkdirp": {
       "version": "3.0.1",

--- a/packages/fdc3-context/jest.config.js
+++ b/packages/fdc3-context/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  moduleFileExtensions: ['js', 'ts'],
+  globals: {},
+  transform: {
+    '^.+\\.ts?$': ['ts-jest', { isolatedModules: true }],
+  },
+  testRegex: '.+\\.test\\.ts?$',
+};

--- a/packages/fdc3-context/package.json
+++ b/packages/fdc3-context/package.json
@@ -22,7 +22,7 @@
     "generate": "npm run mkdirs && npm run typegen && npm run lint",
     "build": "npm run generate && tsc --module es2022",
     "lint": "eslint generated/ --fix && npx prettier generated/ --write",
-    "test": "npm run generate && tsc",
+    "test": "npm run generate && tsc && jest",
     "typegen": "cd schemas && node ../s2tQuicktypeUtil.js context ../generated/context/ContextTypes.ts"
   },
   "devDependencies": {
@@ -31,6 +31,8 @@
     "@types/jest": "29.5.13",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jest": "28.8.3",

--- a/packages/fdc3-context/schemas/context/interaction.schema.json
+++ b/packages/fdc3-context/schemas/context/interaction.schema.json
@@ -46,7 +46,7 @@
         "interactionType": {
           "title": "Interaction Type",
           "description": "`interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or `'Meeting'` although other string values are permitted.",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "enum": [

--- a/packages/fdc3-context/schemas/context/timeRange.schema.json
+++ b/packages/fdc3-context/schemas/context/timeRange.schema.json
@@ -26,7 +26,7 @@
     },
     { "$ref": "context.schema.json#/definitions/BaseContext" }
   ],
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "startTime",
@@ -48,7 +48,7 @@
     {
       "type": "fdc3.timeRange",
       "startTime": "2022-03-30T15:44:44Z",
-      "endTime": "2022-04-30T23:59:59ZS"
+      "endTime": "2022-04-30T23:59:59Z"
     },
     {
       "type": "fdc3.timeRange",

--- a/packages/fdc3-context/test/validate-schema-examples.test.ts
+++ b/packages/fdc3-context/test/validate-schema-examples.test.ts
@@ -1,0 +1,112 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright FINOS FDC3 contributors - see NOTICE file
+ */
+
+// This test validates that all examples in each JSON schema in schemas/context are valid according to their schema.
+import fs from 'fs';
+import path from 'path';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+describe('FDC3 Context Schema Example Validation', () => {
+  const schemasDir = path.join(__dirname, '../schemas/context');
+  const schemaFiles = fs.readdirSync(schemasDir).filter(f => f.endsWith('.schema.json'));
+  const ajv = new Ajv({ strict: false });
+  addFormats(ajv);
+
+  // Utility to recursively rewrite $ref values in a schema to use absolute $id URLs
+  // This is necessary because many of the schema use relative paths like `../api/api.schema.json`
+  // and we want to rewrite them to use the absolute $id URLs defined in the API schemas.
+  function rewriteRefs(schema: any, refMap: Record<string, string>) {
+    if (Array.isArray(schema)) {
+      schema.forEach(item => rewriteRefs(item, refMap));
+    } else if (typeof schema === 'object' && schema !== null) {
+      for (const key of Object.keys(schema)) {
+        if (key === '$ref' && typeof schema[key] === 'string') {
+          const ref = schema[key];
+          // Normalize path
+          const normRef = ref.replace(/\\/g, '/');
+          // Match ../api/api.schema.json or ..\\api\\api.schema.json
+          const match = normRef.match(/^\.\.\/api\/(.+\.schema\.json)(#.*)?$/i);
+          if (match) {
+            const file = match[1];
+            const fragment = match[2] || '';
+            if (refMap[file]) {
+              schema[key] = refMap[file] + fragment;
+            }
+          }
+        } else {
+          rewriteRefs(schema[key], refMap);
+        }
+      }
+    }
+  }
+
+  // Load and map all API schemas
+  // Use workspace root to resolve api schemas path
+  const workspaceRoot = path.resolve(__dirname, '../../../');
+  const apiSchemasDir = path.join(workspaceRoot, 'packages', 'fdc3-schema', 'schemas', 'api');
+  let apiSchemas: { schemaFile: string; schema: any }[] = [];
+  const refMap: Record<string, string> = {};
+  if (fs.existsSync(apiSchemasDir)) {
+    const apiSchemaFiles = fs.readdirSync(apiSchemasDir).filter(f => f.endsWith('.schema.json'));
+    apiSchemas = apiSchemaFiles.map(schemaFile => {
+      const schemaPath = path.join(apiSchemasDir, schemaFile);
+      const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+      if (schema.$id) {
+        refMap[schemaFile] = schema.$id;
+      }
+      return { schemaFile, schema };
+    });
+  }
+
+  // Load and map all context schemas
+  const schemas = schemaFiles.map(schemaFile => {
+    const schemaPath = path.join(schemasDir, schemaFile);
+    const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
+    if (schema.$id) {
+      refMap[schemaFile] = schema.$id;
+    }
+    return { schemaFile, schema };
+  });
+
+  // Rewrite $ref in all schemas to remove relative paths and use absolute $id URLs
+  [...apiSchemas, ...schemas].forEach(({ schema }) => rewriteRefs(schema, refMap));
+
+  // Register all schemas with Ajv
+  [...apiSchemas, ...schemas].forEach(({ schemaFile, schema }) => {
+    ajv.addSchema(schema, schema.$id || schemaFile);
+  });
+
+  schemas.forEach(({ schemaFile, schema }) => {
+    const examples = schema.examples || (schema.example ? [schema.example] : []);
+    // Use getSchema if $id is present, otherwise compile
+    const validate = schema.$id ? ajv.getSchema(schema.$id) : ajv.compile(schema);
+
+    if (examples.length === 0 && schemaFile !== 'context.schema.json') {
+      // context.schema.json is the main schema and has no examples
+      test(`${schemaFile} has no examples`, () => {
+        fail(`${schemaFile} has no examples to validate.`);
+      });
+      return;
+    }
+
+    if (!validate) {
+      test(`${schemaFile} validator could not be found`, () => {
+        fail(`Validator for ${schemaFile} could not be found. Check if $id is set and schema was added to Ajv.`);
+      });
+      return;
+    }
+
+    examples.forEach((example: any, idx: number) => {
+      test(`${schemaFile} example #${idx + 1} should be valid`, () => {
+        const valid = validate(example);
+        if (!valid) {
+          console.error(validate.errors);
+        }
+        expect(valid).toBe(true);
+      });
+    });
+  });
+});

--- a/packages/fdc3-context/test/validate-schema-examples.test.ts
+++ b/packages/fdc3-context/test/validate-schema-examples.test.ts
@@ -9,6 +9,8 @@ import path from 'path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 
+const sanitizeFilename = (filename: string) => filename.replace(/^(\.\.(\/|\\|$))+/, '');
+
 describe('FDC3 Context Schema Example Validation', () => {
   const schemasDir = path.join(__dirname, '../schemas/context');
   const schemaFiles = fs.readdirSync(schemasDir).filter(f => f.endsWith('.schema.json'));
@@ -52,7 +54,7 @@ describe('FDC3 Context Schema Example Validation', () => {
   if (fs.existsSync(apiSchemasDir)) {
     const apiSchemaFiles = fs.readdirSync(apiSchemasDir).filter(f => f.endsWith('.schema.json'));
     apiSchemas = apiSchemaFiles.map(schemaFile => {
-      const schemaPath = path.join(apiSchemasDir, schemaFile);
+      const schemaPath = path.join(apiSchemasDir, sanitizeFilename(schemaFile));
       const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
       if (schema.$id) {
         refMap[schemaFile] = schema.$id;
@@ -63,7 +65,7 @@ describe('FDC3 Context Schema Example Validation', () => {
 
   // Load and map all context schemas
   const schemas = schemaFiles.map(schemaFile => {
-    const schemaPath = path.join(schemasDir, schemaFile);
+    const schemaPath = path.join(schemasDir, sanitizeFilename(schemaFile));
     const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf-8'));
     if (schema.$id) {
       refMap[schemaFile] = schema.$id;

--- a/packages/fdc3-context/tsconfig.json
+++ b/packages/fdc3-context/tsconfig.json
@@ -10,10 +10,11 @@
     "include": [
         "src/**/*.ts",
         "generated/**/*",
-        "schemas/**/*.json"
+        "schemas/**/*.json",
     ],
     "exclude": [
-        "dist/**"
+        "dist/**",
+        "test/**"
     ],
     "references": []
 }

--- a/website/docs/context/ref/Interaction.md
+++ b/website/docs/context/ref/Interaction.md
@@ -77,7 +77,7 @@ The time range over which the interaction occurred
 <details>
   <summary><code>interactionType</code> <strong>(required)</strong></summary>
 
-**One of:**
+**Any of:**
 
 - **type**: `string` with values:
 - `Instant Message`,

--- a/website/docs/context/ref/TimeRange.md
+++ b/website/docs/context/ref/TimeRange.md
@@ -59,7 +59,7 @@ The end time of the range, encoded according to [ISO 8601-1:2019](https://www.is
 {
   "type": "fdc3.timeRange",
   "startTime": "2022-03-30T15:44:44Z",
-  "endTime": "2022-04-30T23:59:59ZS"
+  "endTime": "2022-04-30T23:59:59Z"
 }
 ```
 

--- a/website/static/schemas/2.2/context/interaction.schema.json
+++ b/website/static/schemas/2.2/context/interaction.schema.json
@@ -46,7 +46,7 @@
         "interactionType": {
           "title": "Interaction Type",
           "description": "`interactionType` SHOULD be one of `'Instant Message'`, `'Email'`, `'Call'`, or `'Meeting'` although other string values are permitted.",
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "enum": [

--- a/website/static/schemas/2.2/context/timeRange.schema.json
+++ b/website/static/schemas/2.2/context/timeRange.schema.json
@@ -26,7 +26,7 @@
     },
     { "$ref": "context.schema.json#/definitions/BaseContext" }
   ],
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "startTime",
@@ -48,7 +48,7 @@
     {
       "type": "fdc3.timeRange",
       "startTime": "2022-03-30T15:44:44Z",
-      "endTime": "2022-04-30T23:59:59ZS"
+      "endTime": "2022-04-30T23:59:59Z"
     },
     {
       "type": "fdc3.timeRange",

--- a/website/versioned_docs/version-2.2/context/ref/Interaction.md
+++ b/website/versioned_docs/version-2.2/context/ref/Interaction.md
@@ -77,7 +77,7 @@ The time range over which the interaction occurred
 <details>
   <summary><code>interactionType</code> <strong>(required)</strong></summary>
 
-**One of:**
+**Any of:**
 
 - **type**: `string` with values:
 - `Instant Message`,

--- a/website/versioned_docs/version-2.2/context/ref/TimeRange.md
+++ b/website/versioned_docs/version-2.2/context/ref/TimeRange.md
@@ -59,7 +59,7 @@ The end time of the range, encoded according to [ISO 8601-1:2019](https://www.is
 {
   "type": "fdc3.timeRange",
   "startTime": "2022-03-30T15:44:44Z",
-  "endTime": "2022-04-30T23:59:59ZS"
+  "endTime": "2022-04-30T23:59:59Z"
 }
 ```
 


### PR DESCRIPTION
## Describe your change

* Add unit tests to the fdc3-context package for validating context examples are valid schema.
* Revert schema of `fdc3.timeRange` context type back to use anyOf in place of oneOf for the `startTime` and `endTime` property combinations.  This will allow existence of one of either, or both, and pass schema validation.  When defined with oneOf, validation would fail due to multiple entries being valid and it could not identify which to apply.
* Revert schema of `fdc3.interaction` context type back to use anyOf in place of oneOf for the `interactionType` property.  Since it could be a string enum or a string, validation could not differentiate.
* Fix `fdc3.timeRange` context example to use correctly formatted dateTime.

### Related Issues
Resolves #1592
Resolves #1598 
Resolves #1599

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [X] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [X] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [X] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [X] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [X] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [x] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [x] Was at least one example provided?
  - [x] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?


---
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.
 
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.