### PR TITLE
Add intent with context listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * resolves ([#1487](https://github.com/finos/FDC3/issues/1487))
   * resolves ([#1488](https://github.com/finos/FDC3/issues/1488))
 * Adjusted reference Desktop Agent implementation for FDC3 for Web to open a new app instance when raiseIntent is called with an appId but no instanceId ([#1556](https://github.com/finos/FDC3/pull/1556))
+* Added `addIntentWithContextListener` to `DesktopAgent` and implemented in `DesktopAgentProxy`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * resolves ([#1487](https://github.com/finos/FDC3/issues/1487))
   * resolves ([#1488](https://github.com/finos/FDC3/issues/1488))
 * Adjusted reference Desktop Agent implementation for FDC3 for Web to open a new app instance when raiseIntent is called with an appId but no instanceId ([#1556](https://github.com/finos/FDC3/pull/1556))
-* Added `addIntentListenerWithContext` to `DesktopAgent` and implemented in `DesktopAgentProxy`. Added handling of optional `contextTypes` to reference implementation
+* Added `addIntentListenerWithContext` to `DesktopAgent` and implemented it in `DesktopAgentProxy`. Added an optional `contextTypes` field to the `addIntentListenerRequest` DACP message and handling of it in the reference Desktop Agent implementation (`@finos/fdc3-web-impl`) so that listeners are only invoked for matching context types during intent resolution and delivery. Added documentation in `DesktopAgent.md` and the Desktop Agent Communication Protocol spec, plus Cucumber test coverage in both `@finos/fdc3-agent-proxy` and `@finos/fdc3-web-impl`. Workbench updated to expose the new API.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+* Added advanced conformance tests (`fdc3.intentListenerConflict`) covering intent listener conflicts, verifying that `addIntentListener`/`addIntentListenerWithContext` reject with `ResolveError.IntentListenerConflict` for conflicting listeners (unfiltered, or overlapping context types) and allow non-overlapping filtered listeners, listeners for different intents, and re-adding after `unsubscribe()`. Added the corresponding test definitions to the "Avoiding Adding Multiple Intent Listeners" section of the Intents conformance docs.
 * Added a classification field to Instrument context type ([#1665](https://github.com/finos/FDC3/pull/1665))
 * Added Go language binding. ([#1483](https://github.com/finos/FDC3/pull/1483))
 * Added FDC3 API Metadata support to the Go language binding. ([#1905](https://github.com/finos/FDC3/pull/1905))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+* The `fdc3-agent-proxy` now enforces intent listener conflicts on the client side: `addIntentListener` and `addIntentListenerWithContext` reject with `ResolveError.IntentListenerConflict` when a new listener conflicts with an existing one for the same intent (either listener being unfiltered, or their context types overlapping). Multiple filtered listeners for the same intent with non-overlapping context types are now allowed, and the `addIntentListener`/`addIntentListenerWithContext` documentation was updated accordingly.
+
 * DACP `ContextMetadata` in `api.schema.json` now allows optional `antiReplay` claims on the wire (e.g. merged into `raiseIntentResultResponse.resultMetadata`). The agent proxy and reference web implementation forward `antiReplay` from app metadata on `raiseIntent` / `raiseIntentForContext` and merge it from `intentResultRequest` metadata into the intent result delivered to the raising app. Cucumber steps and features cover `iat` / `exp` / `jti` alongside signatures.
 * Updated "Releasing FDC3 to NPM" instructions in README to reflect the current GitHub Actions release workflow. ([#1864](https://github.com/finos/FDC3/pull/1864))
 * Improved loading of example applications, fdc3-conformance and fdc3-workbench in the FDC3 for Web reference implementation demo. ([#1924](https://github.com/finos/FDC3/pull/1924))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * resolves ([#1487](https://github.com/finos/FDC3/issues/1487))
   * resolves ([#1488](https://github.com/finos/FDC3/issues/1488))
 * Adjusted reference Desktop Agent implementation for FDC3 for Web to open a new app instance when raiseIntent is called with an appId but no instanceId ([#1556](https://github.com/finos/FDC3/pull/1556))
-* Added `addIntentWithContextListener` to `DesktopAgent` and implemented in `DesktopAgentProxy`
+* Added `addIntentListenerWithContext` to `DesktopAgent` and implemented in `DesktopAgentProxy`. Added handling of optional `contextTypes` to reference implementation
 
 ### Changed
 

--- a/packages/fdc3-agent-proxy/src/DesktopAgentProxy.ts
+++ b/packages/fdc3-agent-proxy/src/DesktopAgentProxy.ts
@@ -67,6 +67,7 @@ export class DesktopAgentProxy implements DesktopAgent, Connectable {
     this.findIntentsByContext = this.findIntentsByContext.bind(this);
     this.raiseIntent = this.raiseIntent.bind(this);
     this.addIntentListener = this.addIntentListener.bind(this);
+    this.addIntentListenerWithContext = this.addIntentListenerWithContext.bind(this);
     this.raiseIntentForContext = this.raiseIntentForContext.bind(this);
     this.open = this.open.bind(this);
     this.findInstances = this.findInstances.bind(this);
@@ -181,6 +182,10 @@ export class DesktopAgentProxy implements DesktopAgent, Connectable {
 
   addIntentListener(intent: string, handler: IntentHandler) {
     return this.intents.addIntentListener(intent, handler);
+  }
+
+  addIntentListenerWithContext(intent: string, contextType: string | string[], handler: IntentHandler) {
+    return this.intents.addIntentListenerWithContext(intent, contextType, handler);
   }
 
   raiseIntentForContext(

--- a/packages/fdc3-agent-proxy/src/intents/DefaultIntentSupport.ts
+++ b/packages/fdc3-agent-proxy/src/intents/DefaultIntentSupport.ts
@@ -272,7 +272,23 @@ export class DefaultIntentSupport implements IntentSupport {
   }
 
   async addIntentListener(intent: string, handler: IntentHandler): Promise<Listener> {
-    const out = new DefaultIntentListener(this.messaging, intent, handler, this.messageExchangeTimeout);
+    const out = new DefaultIntentListener(this.messaging, intent, undefined, handler, this.messageExchangeTimeout);
+    await out.register();
+    return out;
+  }
+
+  async addIntentListenerWithContext(
+    intent: string,
+    contextType: string | string[],
+    handler: IntentHandler
+  ): Promise<Listener> {
+    const out = new DefaultIntentListener(
+      this.messaging,
+      intent,
+      Array.isArray(contextType) ? contextType : [contextType],
+      handler,
+      this.messageExchangeTimeout
+    );
     await out.register();
     return out;
   }

--- a/packages/fdc3-agent-proxy/src/intents/DefaultIntentSupport.ts
+++ b/packages/fdc3-agent-proxy/src/intents/DefaultIntentSupport.ts
@@ -74,6 +74,7 @@ export class DefaultIntentSupport implements IntentSupport {
   readonly intentResolver: IntentResolver;
   readonly messageExchangeTimeout: number;
   readonly appLaunchTimeout: number;
+  private readonly intentListeners: DefaultIntentListener[] = [];
 
   constructor(
     messaging: Messaging,
@@ -272,9 +273,7 @@ export class DefaultIntentSupport implements IntentSupport {
   }
 
   async addIntentListener(intent: string, handler: IntentHandler): Promise<Listener> {
-    const out = new DefaultIntentListener(this.messaging, intent, undefined, handler, this.messageExchangeTimeout);
-    await out.register();
-    return out;
+    return this.registerIntentListener(intent, undefined, handler);
   }
 
   async addIntentListenerWithContext(
@@ -282,14 +281,52 @@ export class DefaultIntentSupport implements IntentSupport {
     contextType: string | string[],
     handler: IntentHandler
   ): Promise<Listener> {
+    return this.registerIntentListener(intent, Array.isArray(contextType) ? contextType : [contextType], handler);
+  }
+
+  private async registerIntentListener(
+    intent: string,
+    contextTypes: string[] | undefined,
+    handler: IntentHandler
+  ): Promise<Listener> {
+    this.throwIfConflicting(intent, contextTypes);
+
     const out = new DefaultIntentListener(
       this.messaging,
       intent,
-      Array.isArray(contextType) ? contextType : [contextType],
+      contextTypes,
       handler,
-      this.messageExchangeTimeout
+      this.messageExchangeTimeout,
+      () => {
+        const index = this.intentListeners.indexOf(out);
+        if (index !== -1) {
+          this.intentListeners.splice(index, 1);
+        }
+      }
     );
     await out.register();
+    this.intentListeners.push(out);
     return out;
+  }
+
+  /**
+   * A new intent listener conflicts with an existing one registered for the same intent when either
+   * listener is unfiltered (no context types, so it handles all contexts) or their declared context
+   * types overlap.
+   */
+  private throwIfConflicting(intent: string, contextTypes: string[] | undefined): void {
+    const conflict = this.intentListeners.some(existing => {
+      if (existing.intent !== intent) {
+        return false;
+      }
+      if (existing.contextTypes == null || contextTypes == null) {
+        return true;
+      }
+      return existing.contextTypes.some(ct => contextTypes.includes(ct));
+    });
+
+    if (conflict) {
+      throw new Error(ResolveError.IntentListenerConflict);
+    }
   }
 }

--- a/packages/fdc3-agent-proxy/src/intents/IntentSupport.ts
+++ b/packages/fdc3-agent-proxy/src/intents/IntentSupport.ts
@@ -23,4 +23,9 @@ export interface IntentSupport {
     metadata?: AppProvidableContextMetadata
   ): Promise<IntentResolution>;
   addIntentListener(intent: string, handler: IntentHandler): Promise<Listener>;
+  addIntentListenerWithContext(
+    intent: string,
+    contextType: string | string[],
+    handler: IntentHandler
+  ): Promise<Listener>;
 }

--- a/packages/fdc3-agent-proxy/src/listeners/DefaultIntentListener.ts
+++ b/packages/fdc3-agent-proxy/src/listeners/DefaultIntentListener.ts
@@ -20,10 +20,11 @@ import { v4 } from 'uuid';
 export class DefaultIntentListener extends AbstractListener<IntentHandler, AddIntentListenerRequest> {
   constructor(
     messaging: Messaging,
-    private readonly intent: string,
-    private readonly contextTypes: string[] | undefined,
+    readonly intent: string,
+    readonly contextTypes: string[] | undefined,
     action: IntentHandler,
-    messageExchangeTimeout: number
+    messageExchangeTimeout: number,
+    private readonly onUnsubscribe?: () => void
   ) {
     super(
       messaging,
@@ -35,6 +36,11 @@ export class DefaultIntentListener extends AbstractListener<IntentHandler, AddIn
       'intentListenerUnsubscribeRequest',
       'intentListenerUnsubscribeResponse'
     );
+  }
+
+  override async unsubscribe(): Promise<void> {
+    await super.unsubscribe();
+    this.onUnsubscribe?.();
   }
 
   filter(m: IntentEvent): boolean {
@@ -74,7 +80,7 @@ export class DefaultIntentListener extends AbstractListener<IntentHandler, AddIn
         intentEventUuid: m.meta.eventUuid,
         raiseIntentRequestUuid: m.payload.raiseIntentRequestUuid,
         ...(appMetadata !== undefined && { metadata: appMetadata }),
-      }
+      },
     };
 
     return out;

--- a/packages/fdc3-agent-proxy/src/listeners/DefaultIntentListener.ts
+++ b/packages/fdc3-agent-proxy/src/listeners/DefaultIntentListener.ts
@@ -18,24 +18,31 @@ import {
 import { v4 } from 'uuid';
 
 export class DefaultIntentListener extends AbstractListener<IntentHandler, AddIntentListenerRequest> {
-  readonly intent: string;
-
-  constructor(messaging: Messaging, intent: string, action: IntentHandler, messageExchangeTimeout: number) {
+  constructor(
+    messaging: Messaging,
+    private readonly intent: string,
+    private readonly contextTypes: string[] | undefined,
+    action: IntentHandler,
+    messageExchangeTimeout: number
+  ) {
     super(
       messaging,
       messageExchangeTimeout,
-      { intent },
+      { intent, contextTypes },
       action,
       'addIntentListenerRequest',
       'addIntentListenerResponse',
       'intentListenerUnsubscribeRequest',
       'intentListenerUnsubscribeResponse'
     );
-    this.intent = intent;
   }
 
   filter(m: IntentEvent): boolean {
-    return m.type == 'intentEvent' && m.payload.intent == this.intent;
+    return (
+      m.type == 'intentEvent' &&
+      m.payload.intent == this.intent &&
+      (this.contextTypes == null || this.contextTypes.includes(m.payload.context.type))
+    );
   }
 
   action(m: IntentEvent): void {

--- a/packages/fdc3-agent-proxy/test/features/intent-listener.feature
+++ b/packages/fdc3-agent-proxy/test/features/intent-listener.feature
@@ -17,6 +17,38 @@ Feature: Intent Listeners
       | type                |
       | intentResultRequest |
 
+  Scenario: Intent Listeners With non-matching Context does not handle message
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.order" and "{resultHandler}"
+    And messaging receives "{intentMessageOne}"
+    Then "{intents}" is an array of objects with the following contents
+      | context.type    | context.name | metadata.source.appId |
+    And messaging will have posts
+      | type                |
+
+  Scenario: Intent Listeners With matching Context string does handle message
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    And messaging receives "{intentMessageOne}"
+    Then "{intents}" is an array of objects with the following contents
+      | context.type    | context.name | metadata.source.appId |
+      | fdc3.instrument | Apple        | some-app-id           |
+    And messaging will have posts
+      | type                |
+      | intentResultRequest |
+
+  Scenario: Intent Listeners With matching Context array does handle message
+    Given "resultHandler" pipes intent to "intents"
+    And "contextArray" is an array of contexts including "fdc3.instrument" and "fdc3.instrumentList"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "{contextArray}" and "{resultHandler}"
+    And messaging receives "{intentMessageOne}"
+    Then "{intents}" is an array of objects with the following contents
+      | context.type    | context.name | metadata.source.appId |
+      | fdc3.instrument | Apple        | some-app-id           |
+    And messaging will have posts
+      | type                |
+      | intentResultRequest |
+
   Scenario: Intent Listeners Can Return Results (Context)
     Given "resultHandler" returns a context item
     When I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"

--- a/packages/fdc3-agent-proxy/test/features/intent-listener.feature
+++ b/packages/fdc3-agent-proxy/test/features/intent-listener.feature
@@ -32,7 +32,7 @@ Feature: Intent Listeners
     And messaging receives "{intentMessageOne}"
     Then "{intents}" is an array of objects with the following contents
       | context.type    | context.name | metadata.source.appId |
-      | fdc3.instrument | Apple        | some-app-id           |
+      | fdc3.instrument | Apple        | cucumber-app          |
     And messaging will have posts
       | type                |
       | intentResultRequest |
@@ -44,7 +44,7 @@ Feature: Intent Listeners
     And messaging receives "{intentMessageOne}"
     Then "{intents}" is an array of objects with the following contents
       | context.type    | context.name | metadata.source.appId |
-      | fdc3.instrument | Apple        | some-app-id           |
+      | fdc3.instrument | Apple        | cucumber-app          |
     And messaging will have posts
       | type                |
       | intentResultRequest |

--- a/packages/fdc3-agent-proxy/test/features/intent-listener.feature
+++ b/packages/fdc3-agent-proxy/test/features/intent-listener.feature
@@ -72,3 +72,56 @@ Feature: Intent Listeners
     Then messaging will have posts
       | type                | payload.intentResult.channel | payload.intentResult.context |
       | intentResultRequest | {empty}                      | {empty}                      |
+
+  Scenario: Adding a second unfiltered intent listener for the same intent throws a conflict
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    Then "{result}" is an error with message "IntentListenerConflict"
+
+  Scenario: Adding a filtered intent listener when an unfiltered one exists throws a conflict
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    Then "{result}" is an error with message "IntentListenerConflict"
+
+  Scenario: Adding an unfiltered intent listener when a filtered one exists throws a conflict
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    Then "{result}" is an error with message "IntentListenerConflict"
+
+  Scenario: Adding a filtered intent listener with an overlapping context type throws a conflict
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    Then "{result}" is an error with message "IntentListenerConflict"
+
+  Scenario: Adding filtered intent listeners for the same intent with different context types is allowed
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.instrument" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListenerWithContext" with parameters "BuyStock" and "fdc3.order" and "{resultHandler}"
+    Then messaging will have posts
+      | type                     |
+      | addIntentListenerRequest |
+      | addIntentListenerRequest |
+
+  Scenario: Adding an intent listener for a different intent is allowed
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    And I call "{api1}" with "addIntentListener" with parameters "SellStock" and "{resultHandler}"
+    Then messaging will have posts
+      | type                     |
+      | addIntentListenerRequest |
+      | addIntentListenerRequest |
+
+  Scenario: An intent listener can be re-added once the conflicting listener is unsubscribed
+    Given "resultHandler" pipes intent to "intents"
+    When I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    And I refer to "{result}" as "firstListener"
+    And I call "{firstListener}" with "unsubscribe"
+    And I call "{api1}" with "addIntentListener" with parameters "BuyStock" and "{resultHandler}"
+    Then "{result}" is not null
+    And messaging will have posts
+      | type                     |
+      | addIntentListenerRequest |

--- a/packages/fdc3-get-agent/test/step-definitions/desktop-agent.steps.ts
+++ b/packages/fdc3-get-agent/test/step-definitions/desktop-agent.steps.ts
@@ -220,6 +220,7 @@ Given('A Dummy Desktop Agent in {string}', async (world: CustomWorld, field: str
     raiseIntent: notImplemented,
     raiseIntentForContext: notImplemented,
     addIntentListener: notImplemented,
+    addIntentListenerWithContext: notImplemented,
     addContextListener: notImplemented,
     addEventListener: notImplemented,
     getUserChannels: notImplemented,

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -944,7 +944,8 @@ export interface AddIntentListenerRequest {
  */
 export interface AddIntentListenerRequestPayload {
   /**
-   * The types of context to listen for.
+   * Optional list of context types that the listener should be invoked for. If omitted, the
+   * listener will be invoked for all context types that match the intent.
    */
   contextTypes?: string[];
   /**

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -944,6 +944,10 @@ export interface AddIntentListenerRequest {
  */
 export interface AddIntentListenerRequestPayload {
   /**
+   * The types of context to listen for.
+   */
+  contextTypes?: string[];
+  /**
    * The name of the intent to listen for.
    */
   intent: string;
@@ -5298,7 +5302,13 @@ const typeMap: any = {
     ],
     false
   ),
-  AddIntentListenerRequestPayload: o([{ json: 'intent', js: 'intent', typ: '' }], false),
+  AddIntentListenerRequestPayload: o(
+    [
+      { json: 'contextTypes', js: 'contextTypes', typ: u(undefined, a('')) },
+      { json: 'intent', js: 'intent', typ: '' },
+    ],
+    false
+  ),
   AddIntentListenerResponse: o(
     [
       { json: 'meta', js: 'meta', typ: r('AddContextListenerResponseMeta') },

--- a/packages/fdc3-schema/schemas/api/addIntentListenerRequest.schema.json
+++ b/packages/fdc3-schema/schemas/api/addIntentListenerRequest.schema.json
@@ -1,46 +1,54 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://fdc3.finos.org/schemas/next/api/addIntentListenerRequest.schema.json",
-	"type": "object",
-	"title": "AddIntentListener Request",
-	"description": "A request to add an Intent listener for a specified intent type.",
-	"allOf": [
-		{
-			"$ref": "appRequest.schema.json"
-		},
-		{
-			"type": "object",
-			"properties": {
-				"type": {
-					"$ref": "#/$defs/AddIntentListenerRequestType"
-				},
-				"payload": {
-					"$ref": "#/$defs/AddIntentListenerRequestPayload"
-				},
-				"meta": true
-			},
-			"additionalProperties": false
-		}
-	],
-	"$defs": {
-		"AddIntentListenerRequestType": {
-			"title": "AddIntentListener Request Message Type",
-			"const": "addIntentListenerRequest"
-		},
-		"AddIntentListenerRequestPayload": {
-			"title": "AddIntentListener Request Payload",
-			"type": "object",
-			"properties": {
-				"intent": {
-					"title": "Intent name",
-					"description": "The name of the intent to listen for.",
-					"type": "string"
-				}
-			},
-			"additionalProperties": false,
-			"required": [
-				"intent"
-			]
-		}
-	}
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://fdc3.finos.org/schemas/next/api/addIntentListenerRequest.schema.json",
+    "type": "object",
+    "title": "AddIntentListener Request",
+    "description": "A request to add an Intent listener for a specified intent type.",
+    "allOf": [
+        {
+            "$ref": "appRequest.schema.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "$ref": "#/$defs/AddIntentListenerRequestType"
+                },
+                "payload": {
+                    "$ref": "#/$defs/AddIntentListenerRequestPayload"
+                },
+                "meta": true
+            },
+            "additionalProperties": false
+        }
+    ],
+    "$defs": {
+        "AddIntentListenerRequestType": {
+            "title": "AddIntentListener Request Message Type",
+            "const": "addIntentListenerRequest"
+        },
+        "AddIntentListenerRequestPayload": {
+            "title": "AddIntentListener Request Payload",
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "title": "Intent name",
+                    "description": "The name of the intent to listen for.",
+                    "type": "string"
+                },
+                "contextTypes": {
+                    "title": "Context types",
+                    "description": "The types of context to listen for.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "intent"
+            ]
+        }
+    }
 }

--- a/packages/fdc3-schema/schemas/api/addIntentListenerRequest.schema.json
+++ b/packages/fdc3-schema/schemas/api/addIntentListenerRequest.schema.json
@@ -1,54 +1,54 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://fdc3.finos.org/schemas/next/api/addIntentListenerRequest.schema.json",
-    "type": "object",
-    "title": "AddIntentListener Request",
-    "description": "A request to add an Intent listener for a specified intent type.",
-    "allOf": [
-        {
-            "$ref": "appRequest.schema.json"
-        },
-        {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "$ref": "#/$defs/AddIntentListenerRequestType"
-                },
-                "payload": {
-                    "$ref": "#/$defs/AddIntentListenerRequestPayload"
-                },
-                "meta": true
-            },
-            "additionalProperties": false
-        }
-    ],
-    "$defs": {
-        "AddIntentListenerRequestType": {
-            "title": "AddIntentListener Request Message Type",
-            "const": "addIntentListenerRequest"
-        },
-        "AddIntentListenerRequestPayload": {
-            "title": "AddIntentListener Request Payload",
-            "type": "object",
-            "properties": {
-                "intent": {
-                    "title": "Intent name",
-                    "description": "The name of the intent to listen for.",
-                    "type": "string"
-                },
-                "contextTypes": {
-                    "title": "Context types",
-                    "description": "The types of context to listen for.",
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "intent"
-            ]
-        }
-    }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://fdc3.finos.org/schemas/next/api/addIntentListenerRequest.schema.json",
+	"type": "object",
+	"title": "AddIntentListener Request",
+	"description": "A request to add an Intent listener for a specified intent type.",
+	"allOf": [
+		{
+			"$ref": "appRequest.schema.json"
+		},
+		{
+			"type": "object",
+			"properties": {
+				"type": {
+					"$ref": "#/$defs/AddIntentListenerRequestType"
+				},
+				"payload": {
+					"$ref": "#/$defs/AddIntentListenerRequestPayload"
+				},
+				"meta": true
+			},
+			"additionalProperties": false
+		}
+	],
+	"$defs": {
+		"AddIntentListenerRequestType": {
+			"title": "AddIntentListener Request Message Type",
+			"const": "addIntentListenerRequest"
+		},
+		"AddIntentListenerRequestPayload": {
+			"title": "AddIntentListener Request Payload",
+			"type": "object",
+			"properties": {
+				"intent": {
+					"title": "Intent name",
+					"description": "The name of the intent to listen for.",
+					"type": "string"
+				},
+				"contextTypes": {
+					"title": "Context types",
+					"description": "Optional list of context types that the listener should be invoked for. If omitted, the listener will be invoked for all context types that match the intent.",
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"intent"
+			]
+		}
+	}
 }

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -384,15 +384,28 @@ export interface DesktopAgent {
   addIntentListener(intent: Intent, handler: IntentHandler): Promise<Listener>;
 
   /**
-   * Adds a listener for incoming intents raised by other applications, via calls to `fdc3.raiseIntent` or `fdc3.raiseIntentForContext, but filters intents for one or more context types. See `addIntentListener` for details and restrictions for both usage and implementation.
+   * Adds a listener for incoming intents raised by other applications, via calls to `fdc3.raiseIntent` or `fdc3.raiseIntentForContext`, but filtered to one or more context types. The handler will only be invoked when the incoming intent's context `type` matches one of the supplied `contextType` values.
    *
-   * //Handle a raised intent
-   * const listener = fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {
-   *     // start chat has been requested by another application
-   *     return;
+   * The `contextType` parameter MAY be either a single context type string or an array of context type strings. See `addIntentListener` for details and restrictions for both usage and implementation that also apply to this method.
+   *
+   * ```js
+   * //Handle a raised intent filtered to a single context type
+   * const listener = await fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {
+   *   // start chat has been requested by another application
+   *   return;
    * });
+   *
+   * //Handle a raised intent filtered to multiple context types
+   * const listener = await fdc3.addIntentListenerWithContext(
+   *   'ViewChart',
+   *   ['fdc3.instrument', 'fdc3.instrumentList'],
+   *   context => {
+   *     // view chart has been requested by another application
+   *     return;
+   *   }
+   * );
+   * ```
    */
-
   addIntentListenerWithContext(
     intent: Intent,
     contextType: string | string[],

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -384,8 +384,7 @@ export interface DesktopAgent {
   addIntentListener(intent: Intent, handler: IntentHandler): Promise<Listener>;
 
   /**
-   * Like `addIntentListener`, but allows filtering by one or more context types.
-   * The listener will only be triggered for the specified intent and context type(s).
+   * Adds a listener for incoming intents raised by other applications, via calls to `fdc3.raiseIntent` or `fdc3.raiseIntentForContext, but filters intents for one or more context types. See `addIntentListener` for details and restrictions for both usage and implementation.
    *
    * //Handle a raised intent
    * const listener = fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -336,7 +336,7 @@ export interface DesktopAgent {
    *
    * Optional metadata about the raised intent, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
    *
-   * Adding multiple intent listeners on the same type MUST be rejected with the `ResolveError.IntentListenerConflict`, unless the previous listener was removed first though `listener.unsubscribe()`
+   * Multiple intent listeners MAY be added for the same intent, provided they are filtered to different context types (see `addIntentListenerWithContext`). Adding an intent listener that conflicts with an existing listener for the same intent MUST be rejected with the `ResolveError.IntentListenerConflict`, unless the conflicting listener was removed first through `listener.unsubscribe()`. A new listener conflicts with an existing one for the same intent when either listener is unfiltered (added via `addIntentListener`, and so handles all context types) or when their declared context types overlap.
    *
    * ```javascript
    * //Handle a raised intent

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -384,6 +384,23 @@ export interface DesktopAgent {
   addIntentListener(intent: Intent, handler: IntentHandler): Promise<Listener>;
 
   /**
+   * Like `addIntentListener`, but allows filtering by one or more context types.
+   * The listener will only be triggered for the specified intent and context type(s).
+   *
+   * //Handle a raised intent
+   * const listener = fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {
+   *     // start chat has been requested by another application
+   *     return;
+   * });
+   */
+
+  addIntentListenerWithContext(
+    intent: Intent,
+    contextType: string | string[],
+    handler: IntentHandler
+  ): Promise<Listener>;
+
+  /**
    * Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or `fdc3.open`API call. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
    *
    * Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from channels. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.

--- a/packages/testing/src/steps/generic.steps.ts
+++ b/packages/testing/src/steps/generic.steps.ts
@@ -4,6 +4,13 @@ import { PropsWorldLike } from '../world/PropsWorldLike.js';
 import * as impl from './generic.impl.js';
 
 export function setupGenericSteps(schemaBasePath: string): void {
+  Given(
+    '{string} is an array of contexts including {string} and {string}',
+    (world: PropsWorldLike, field: string, valueOne: string, valueTwo: string) => {
+      world.props[field] = [valueOne, valueTwo];
+    }
+  );
+
   Then('the promise {string} should resolve', async (world: PropsWorldLike, field: string) => {
     await impl.promiseShouldResolve(world, field);
   });

--- a/toolbox/fdc3-conformance/src/test/advanced/fdc3.intent-listener-conflict.ts
+++ b/toolbox/fdc3-conformance/src/test/advanced/fdc3.intent-listener-conflict.ts
@@ -1,0 +1,139 @@
+import { Context, DesktopAgent, Listener, ResolveError, getAgent } from '@finos/fdc3';
+import { assert, expect } from 'chai';
+import { APIDocumentation } from '../support/apiDocuments';
+
+const documentation = '\r\nDocumentation: ' + APIDocumentation.addIntentListener + '\r\nCause';
+
+const handler = (info: Context) => {
+  console.log(`Intent listener triggered with result ${info}`);
+};
+
+/**
+ * Conformance tests covering `ResolveError.IntentListenerConflict`.
+ *
+ * Adding an intent listener that conflicts with an existing listener for the same intent MUST be
+ * rejected with `ResolveError.IntentListenerConflict`. A new listener conflicts with an existing
+ * one for the same intent when either listener is unfiltered (added via `addIntentListener`, so it
+ * handles all context types) or when their declared context types overlap. Filtered listeners for
+ * the same intent with non-overlapping context types, and listeners for different intents, are
+ * allowed.
+ */
+export default async () =>
+  describe('fdc3.intentListenerConflict', () => {
+    let fdc3: DesktopAgent;
+    const listeners: Listener[] = [];
+
+    beforeEach(async () => {
+      fdc3 = await getAgent();
+    });
+
+    afterEach(async () => {
+      // Tidy up any listeners added during the test so they don't conflict with later tests.
+      for (const listener of listeners.splice(0)) {
+        try {
+          await listener.unsubscribe();
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    const intent = 'aTestingIntent1';
+
+    const MultipleAddingOfTheSameIntentListenerCausesIntentListenerConflict =
+      '(MultipleAddingOfTheSameIntentListenerCausesIntentListenerConflict) Adding a second unfiltered intent listener for the same intent MUST be rejected with ResolveError.IntentListenerConflict';
+    it(MultipleAddingOfTheSameIntentListenerCausesIntentListenerConflict, async () => {
+      listeners.push(await fdc3.addIntentListener(intent, handler));
+      try {
+        listeners.push(await fdc3.addIntentListener(intent, handler));
+        assert.fail('Expected the second addIntentListener to be rejected but no error was thrown');
+      } catch (ex) {
+        expect(ex, documentation).to.have.property('message', ResolveError.IntentListenerConflict);
+      }
+    });
+
+    const AddingFilteredIntentListenerWhenUnfilteredExistsCausesIntentListenerConflict =
+      '(AddingFilteredIntentListenerWhenUnfilteredExistsCausesIntentListenerConflict) Adding a filtered intent listener when an unfiltered listener exists for the same intent MUST be rejected with ResolveError.IntentListenerConflict';
+    it(AddingFilteredIntentListenerWhenUnfilteredExistsCausesIntentListenerConflict, async () => {
+      listeners.push(await fdc3.addIntentListener(intent, handler));
+      try {
+        listeners.push(await fdc3.addIntentListenerWithContext(intent, 'fdc3.instrument', handler));
+        assert.fail('Expected the addIntentListenerWithContext to be rejected but no error was thrown');
+      } catch (ex) {
+        expect(ex, documentation).to.have.property('message', ResolveError.IntentListenerConflict);
+      }
+    });
+
+    const AddingUnfilteredIntentListenerWhenFilteredExistsCausesIntentListenerConflict =
+      '(AddingUnfilteredIntentListenerWhenFilteredExistsCausesIntentListenerConflict) Adding an unfiltered intent listener when a filtered listener exists for the same intent MUST be rejected with ResolveError.IntentListenerConflict';
+    it(AddingUnfilteredIntentListenerWhenFilteredExistsCausesIntentListenerConflict, async () => {
+      listeners.push(await fdc3.addIntentListenerWithContext(intent, 'fdc3.instrument', handler));
+      try {
+        listeners.push(await fdc3.addIntentListener(intent, handler));
+        assert.fail('Expected the addIntentListener to be rejected but no error was thrown');
+      } catch (ex) {
+        expect(ex, documentation).to.have.property('message', ResolveError.IntentListenerConflict);
+      }
+    });
+
+    const AddingFilteredIntentListenerWithOverlappingContextCausesIntentListenerConflict =
+      '(AddingFilteredIntentListenerWithOverlappingContextCausesIntentListenerConflict) Adding a filtered intent listener with an overlapping context type for the same intent MUST be rejected with ResolveError.IntentListenerConflict';
+    it(AddingFilteredIntentListenerWithOverlappingContextCausesIntentListenerConflict, async () => {
+      listeners.push(await fdc3.addIntentListenerWithContext(intent, ['fdc3.instrument', 'fdc3.contact'], handler));
+      try {
+        listeners.push(await fdc3.addIntentListenerWithContext(intent, ['fdc3.contact', 'fdc3.order'], handler));
+        assert.fail('Expected the conflicting addIntentListenerWithContext to be rejected but no error was thrown');
+      } catch (ex) {
+        expect(ex, documentation).to.have.property('message', ResolveError.IntentListenerConflict);
+      }
+    });
+
+    const AddingFilteredIntentListenersWithDifferentContextsIsAllowed =
+      '(AddingFilteredIntentListenersWithDifferentContextsIsAllowed) Adding filtered intent listeners for the same intent with non-overlapping context types MUST be allowed';
+    it(AddingFilteredIntentListenersWithDifferentContextsIsAllowed, async () => {
+      try {
+        listeners.push(await fdc3.addIntentListenerWithContext(intent, 'fdc3.instrument', handler));
+        listeners.push(await fdc3.addIntentListenerWithContext(intent, 'fdc3.order', handler));
+      } catch (ex) {
+        assert.fail(
+          `Expected non-overlapping filtered intent listeners to be allowed but an error was thrown: ${
+            (ex as Error)?.message
+          }${documentation}`
+        );
+      }
+      expect(listeners.length, documentation).to.equal(2);
+    });
+
+    const AddingIntentListenersForDifferentIntentsIsAllowed =
+      '(AddingIntentListenersForDifferentIntentsIsAllowed) Adding intent listeners for different intents MUST be allowed';
+    it(AddingIntentListenersForDifferentIntentsIsAllowed, async () => {
+      try {
+        listeners.push(await fdc3.addIntentListener(intent, handler));
+        listeners.push(await fdc3.addIntentListener(intent + '2', handler));
+      } catch (ex) {
+        assert.fail(
+          `Expected intent listeners for different intents to be allowed but an error was thrown: ${
+            (ex as Error)?.message
+          }${documentation}`
+        );
+      }
+      expect(listeners.length, documentation).to.equal(2);
+    });
+
+    const MultipleAddingOfTheSameIntentListenerAfterUnsubscribe =
+      '(MultipleAddingOfTheSameIntentListenerAfterUnsubscribe) An intent listener can be re-added once the conflicting listener is removed with unsubscribe';
+    it(MultipleAddingOfTheSameIntentListenerAfterUnsubscribe, async () => {
+      const first = await fdc3.addIntentListener(intent, handler);
+      await first.unsubscribe();
+      try {
+        listeners.push(await fdc3.addIntentListener(intent, handler));
+      } catch (ex) {
+        assert.fail(
+          `Expected the intent listener to be re-addable after unsubscribe but an error was thrown: ${
+            (ex as Error)?.message
+          }${documentation}`
+        );
+      }
+      expect(listeners.length, documentation).to.equal(1);
+    });
+  });

--- a/toolbox/fdc3-conformance/src/test/testSuite.ts
+++ b/toolbox/fdc3-conformance/src/test/testSuite.ts
@@ -13,6 +13,7 @@ import fdc3AppChannels from './advanced/fdc3.app-channels';
 import fdc3UserChannels from './advanced/fdc3.user-channels';
 import fdc3ContextMetadata from './advanced/fdc3.context-metadata';
 import fdc3IntentContextMetadata from './advanced/fdc3.intent-context-metadata';
+import fdc3IntentListenerConflict from './advanced/fdc3.intent-listener-conflict';
 import {
   fdc3BasicGetAgent,
   fdc3BasicCL1,
@@ -62,6 +63,7 @@ const advancedSuite: testSet = {
   'fdc3.raiseIntent (throws error)': [fdc3RaiseIntent_NoAppsFound],
   'fdc3.contextMetadata': [fdc3ContextMetadata],
   'fdc3.intentContextMetadata': [fdc3IntentContextMetadata],
+  'fdc3.intentListenerConflict': [fdc3IntentListenerConflict],
 };
 
 const ambiguousTests: testSet = {

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
@@ -295,8 +295,15 @@ export class IntentHandler implements MessageHandler {
     }
   }
 
-  hasListener(instanceId: string, intentName: string): boolean {
-    return this.registrations.find(r => r.instanceId == instanceId && r.intentName == intentName) != null;
+  hasListener(instanceId: string, intentName: string, contextType?: string): boolean {
+    return (
+      this.registrations.find(
+        r =>
+          r.instanceId == instanceId &&
+          r.intentName == intentName &&
+          (contextType == undefined || r.contextTypes == null || r.contextTypes.includes(contextType))
+      ) != null
+    );
   }
 
   async startWithPendingIntent(
@@ -328,7 +335,7 @@ export class IntentHandler implements MessageHandler {
       );
     }
 
-    const requestsWithListeners = arg0.filter(r => this.hasListener(target.instanceId, r.intent));
+    const requestsWithListeners = arg0.filter(r => this.hasListener(target.instanceId, r.intent, r.context.type));
 
     if (requestsWithListeners.length == 0) {
       this.createPendingIntentIfAllowed(arg0[0], sc, target);

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
@@ -28,6 +28,7 @@ type ListenerRegistration = {
   appId: string;
   instanceId: string;
   intentName: string;
+  contextTypes?: string[];
   listenerUUID: string;
 };
 
@@ -123,6 +124,7 @@ class PendingIntent {
     if (
       arg0.appId == this.appId.appId &&
       arg0.intentName == this.r.intent &&
+      (arg0.contextTypes == undefined || arg0.contextTypes.includes(this.r.context.type)) &&
       (arg0.instanceId == this.appId.instanceId || this.appId.instanceId == undefined)
     ) {
       this.complete = true;
@@ -269,6 +271,7 @@ export class IntentHandler implements MessageHandler {
       appId: from.appId,
       instanceId: from.instanceId,
       intentName: arg0.payload.intent,
+      contextTypes: arg0.payload.contextTypes,
       listenerUUID: sc.createUUID(),
     };
 
@@ -417,7 +420,11 @@ export class IntentHandler implements MessageHandler {
   async raiseIntentToAnyApp(arg0: IntentRequest[], sc: ServerContext<AppRegistration>): Promise<void> {
     const connectedApps = await sc.getConnectedApps();
     const matchingIntents = arg0.flatMap(i => this.directory.retrieveIntents(i.context.type, i.intent, undefined));
-    const matchingRegistrations = arg0.flatMap(i => this.registrations.filter(r => r.intentName == i.intent));
+    const matchingRegistrations = arg0.flatMap(i =>
+      this.registrations.filter(
+        r => r.intentName == i.intent && (r.contextTypes == null || r.contextTypes.includes(i.context.type))
+      )
+    ); // Get a list of intent listeners that match the intent and context type
     const uniqueIntentNames = [
       ...matchingIntents.map(i => i.intentName),
       ...matchingRegistrations.map(r => r.intentName),

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent.feature
@@ -171,3 +171,26 @@ Feature: Raising Intents
     Then messaging will have outgoing posts
       | msg.payload.error | msg.type            |
       | NoAppsFound       | raiseIntentResponse |
+
+  Scenario: Listener registered with matching contextType receives the raised intent
+    When "App2/a2" registers an intent listener for "borrowBook" with contextType "fdc3.book"
+    And "App1/a1" raises an intent for "borrowBook" with contextType "fdc3.book" on app "App2/a2"
+    Then messaging will have outgoing posts
+      | msg.matches_type    | msg.payload.context.type | msg.payload.intent | to.instanceId | to.appId |
+      | intentEvent         | fdc3.book                | borrowBook         | a2            | App2     |
+      | raiseIntentResponse | {null}                   | {null}             | a1            | App1     |
+
+  Scenario: Listener registered with non-matching contextType is skipped during direct intent delivery
+    When "App2/a2" registers an intent listener for "borrowBook" with contextType "fdc3.magazine"
+    And "App1/a1" raises an intent for "borrowBook" with contextType "fdc3.book" on app "App2/a2"
+    Then messaging will have outgoing posts
+      | msg.type            | msg.payload.error |
+      | raiseIntentResponse | NoAppsFound       |
+
+  Scenario: Listener registered with multiple contextTypes receives the raised intent for any of them
+    When "App2/a2" registers an intent listener for "borrowBook" with contextTypes "fdc3.book" and "fdc3.magazine"
+    And "App1/a1" raises an intent for "borrowBook" with contextType "fdc3.magazine" on app "App2/a2"
+    Then messaging will have outgoing posts
+      | msg.matches_type    | msg.payload.context.type | msg.payload.intent | to.instanceId | to.appId |
+      | intentEvent         | fdc3.magazine            | borrowBook         | a2            | App2     |
+      | raiseIntentResponse | {null}                   | {null}             | a1            | App1     |

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/step-definitions/intents.steps.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/step-definitions/intents.steps.ts
@@ -129,7 +129,24 @@ Given(
       meta,
       payload: {
         intent: handleResolve(intent, world),
-        contextType: handleResolve(contextType, world),
+        contextTypes: [handleResolve(contextType, world)],
+      },
+    } as AddIntentListenerRequest;
+    await world.server.receive(message, uuid);
+  }
+);
+
+Given(
+  '{string} registers an intent listener for {string} with contextTypes {string} and {string}',
+  async (world: CustomWorld, appStr: string, intent: string, contextType1: string, contextType2: string) => {
+    const meta = createMeta(world, appStr);
+    const uuid = world.sc.getInstanceUUID(meta.source)!;
+    const message = {
+      type: 'addIntentListenerRequest',
+      meta,
+      payload: {
+        intent: handleResolve(intent, world),
+        contextTypes: [handleResolve(contextType1, world), handleResolve(contextType2, world)],
       },
     } as AddIntentListenerRequest;
     await world.server.receive(message, uuid);

--- a/toolbox/fdc3-workbench/src/components/ContextTemplates.tsx
+++ b/toolbox/fdc3-workbench/src/components/ContextTemplates.tsx
@@ -3,7 +3,7 @@
  * Copyright FINOS FDC3 contributors - see NOTICE file
  */
 
-import React, { HTMLAttributes, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, HTMLAttributes, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { observer } from 'mobx-react';
 import { Grid, Autocomplete } from '@mui/material';
 import { createFilterOptions } from '@mui/material/Autocomplete';
@@ -19,6 +19,10 @@ interface FilterOptionsState<T> {
 interface OptionType {
   title: string;
   value: string;
+}
+
+export interface ContextTemplatesHandle {
+  reset: () => void;
 }
 
 type SetValue = (value: OptionType | null) => void;
@@ -48,17 +52,23 @@ const styles = {
 const contextFilter = createFilterOptions<OptionType>();
 
 export const ContextTemplates = observer(
-  ({
-    handleTabChange,
-    contextStateSetter,
-    channel,
-  }: {
-    handleTabChange: (event: React.ChangeEvent<object> | null, newValue: number, contextName?: string) => void;
-    contextStateSetter: (context: ContextType | null, channel?: string) => void;
-    channel?: string;
-  }) => {
+  forwardRef<
+    ContextTemplatesHandle,
+    {
+      handleTabChange: (event: React.ChangeEvent<object> | null, newValue: number, contextName?: string) => void;
+      contextStateSetter: (context: ContextType | null, channel?: string) => void;
+      channel?: string;
+    }
+  >(({ handleTabChange, contextStateSetter, channel }, ref) => {
     const [context, setContext] = useState<OptionType | null>(null);
     const [contextError, setContextError] = useState<string | false>(false);
+
+    useImperativeHandle(ref, () => ({
+      reset: () => {
+        setContext(null);
+        setContextError(false);
+      },
+    }));
     const contextsOptions: OptionType[] = contextStore.contextsList.map(({ id }) => {
       return {
         title: id,
@@ -113,7 +123,7 @@ export const ContextTemplates = observer(
         isInitialMount.current = false;
       } else {
         const selectedContext = contextStore.contextsList.find(({ id }) => id === context?.value);
-        if (!selectedContext) handleTabChange(null, 0, context?.value);
+        if (context != null && !selectedContext) handleTabChange(null, 0, context?.value);
       }
     }, [context]);
 
@@ -158,5 +168,5 @@ export const ContextTemplates = observer(
         </Grid>
       </div>
     );
-  }
+  })
 );

--- a/toolbox/fdc3-workbench/src/components/Intents.tsx
+++ b/toolbox/fdc3-workbench/src/components/Intents.tsx
@@ -3,7 +3,7 @@
  * Copyright FINOS FDC3 contributors - see NOTICE file
  */
 
-import React, { ChangeEvent, ReactElement, useEffect, useState } from 'react';
+import React, { ChangeEvent, ReactElement, useEffect, useRef, useState } from 'react';
 import {
   AppMetadata,
   ContextType,
@@ -43,7 +43,7 @@ import { createFilterOptions } from '@mui/material/Autocomplete';
 import { observer } from 'mobx-react';
 import FileCopyIcon from '@mui/icons-material/FileCopy';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
-import { ContextTemplates } from '../components/ContextTemplates.js';
+import { ContextTemplates, ContextTemplatesHandle } from '../components/ContextTemplates.js';
 import intentStore from '../store/IntentStore.js';
 import { codeExamples } from '../fixtures/codeExamples.js';
 import { openApiDocsLink } from '../fixtures/openApiDocs.js';
@@ -210,6 +210,7 @@ export const Intents = observer(
     const [targetOptionsforContext, setTargetOptionsforContext] = useState<ReactElement[]>([]);
     const [filterByContext, setFilterByContext] = useState<boolean>(false);
     const [listenerContext, setListenerContext] = useState<ContextType | null>(null);
+    const listenerContextRef = useRef<ContextTemplatesHandle>(null);
 
     const handleRaiseIntent = async () => {
       setIntentResolution(null);
@@ -473,6 +474,8 @@ export const Intents = observer(
           sendIntentResult && resultType === 'channel-result' ? resultOverChannelContextDelays : undefined
         );
         setIntentListener(null);
+        setListenerContext(null);
+        listenerContextRef.current?.reset();
       }
       setSendIntentResult(false);
     };
@@ -915,7 +918,11 @@ export const Intents = observer(
             </Grid>
             {filterByContext && (
               <Grid item xs={12} sx={styles.indentLeft}>
-                <ContextTemplates handleTabChange={handleTabChange} contextStateSetter={setListenerContext} />
+                <ContextTemplates
+                  ref={listenerContextRef}
+                  handleTabChange={handleTabChange}
+                  contextStateSetter={setListenerContext}
+                />
               </Grid>
             )}
             {window.fdc3Version === '2.0' && (

--- a/toolbox/fdc3-workbench/src/components/Intents.tsx
+++ b/toolbox/fdc3-workbench/src/components/Intents.tsx
@@ -463,6 +463,7 @@ export const Intents = observer(
       } else {
         intentStore.addIntentListener(
           intentListener.value,
+          undefined,
           sendIntentResult && resultType === 'context-result' ? toJS(resultTypeContext) : null,
           sendIntentResult && resultType === 'channel-result' ? currentAppChannelId : undefined,
           sendIntentResult && resultType === 'channel-result' ? channelType === 'private-channel' : undefined,

--- a/toolbox/fdc3-workbench/src/components/Intents.tsx
+++ b/toolbox/fdc3-workbench/src/components/Intents.tsx
@@ -208,6 +208,8 @@ export const Intents = observer(
     const [currentAppChannelId, setCurrentAppChannelId] = useState<string>('');
     const [targetOptions, setTargetOptions] = useState<ReactElement[]>([]);
     const [targetOptionsforContext, setTargetOptionsforContext] = useState<ReactElement[]>([]);
+    const [filterByContext, setFilterByContext] = useState<boolean>(false);
+    const [listenerContext, setListenerContext] = useState<ContextType | null>(null);
 
     const handleRaiseIntent = async () => {
       setIntentResolution(null);
@@ -463,7 +465,7 @@ export const Intents = observer(
       } else {
         intentStore.addIntentListener(
           intentListener.value,
-          undefined,
+          filterByContext ? toJS(listenerContext) : undefined,
           sendIntentResult && resultType === 'context-result' ? toJS(resultTypeContext) : null,
           sendIntentResult && resultType === 'channel-result' ? currentAppChannelId : undefined,
           sendIntentResult && resultType === 'channel-result' ? channelType === 'private-channel' : undefined,
@@ -863,7 +865,9 @@ export const Intents = observer(
                     aria-label="Copy code example"
                     color="primary"
                     onClick={() => {
-                      let exampleToUse = codeExamples.intentListener;
+                      let exampleToUse = filterByContext
+                        ? codeExamples.intentListenerWithContext
+                        : codeExamples.intentListener;
                       if (resultType === 'context-result') {
                         exampleToUse = codeExamples.intentListenerWithContextResult;
                       } else if (resultType === 'channel-result') {
@@ -889,6 +893,31 @@ export const Intents = observer(
                 </Link>
               </Grid>
             </Grid>
+            <Grid item xs={12}>
+              <FormGroup>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      sx={styles.input}
+                      color="default"
+                      checked={filterByContext}
+                      onChange={e => {
+                        setFilterByContext(e.target.checked);
+                        if (!e.target.checked) {
+                          setListenerContext(null);
+                        }
+                      }}
+                    />
+                  }
+                  label="Filter by context type"
+                />
+              </FormGroup>
+            </Grid>
+            {filterByContext && (
+              <Grid item xs={12} sx={styles.indentLeft}>
+                <ContextTemplates handleTabChange={handleTabChange} contextStateSetter={setListenerContext} />
+              </Grid>
+            )}
             {window.fdc3Version === '2.0' && (
               <Grid item xs={12}>
                 <FormGroup>

--- a/toolbox/fdc3-workbench/src/fixtures/codeExamples.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/codeExamples.ts
@@ -106,6 +106,10 @@ const listener = fdc3.addIntentListener('StartChat', context => {
 	return channel;
 });`,
 
+  intentListenerWithContext: `const listener = fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {
+  // start chat has been requested by another application
+});`,
+
   raiseIntentForContext: (context: string) =>
     `let context = ${
       context !== 'null' ? context : '{type: "fdc3.instrument", name: "Tesla, inc.", id: {ticker: "TSLA"}}'

--- a/toolbox/fdc3-workbench/src/store/IntentStore.ts
+++ b/toolbox/fdc3-workbench/src/store/IntentStore.ts
@@ -39,7 +39,7 @@ class IntentStore {
 
   async addIntentListener(
     intent: string,
-    context?: ContextType,
+    context?: ContextType | null,
     resultContext?: ContextType | null,
     channelName?: string | null,
     isPrivate?: boolean,
@@ -51,58 +51,13 @@ class IntentStore {
 
       const agent = await getWorkbenchAgent();
 
-      const intentListener = await agent.addIntentListener(
-        intent,
-        async (context: ContextType, metaData?: ContextMetadata): Promise<IntentResult> => {
-          const currentListener = this.intentListeners.find(({ id }) => id === listenerId);
-          let channel: Channel | undefined;
+      const handler = async (handlerContext: ContextType, metaData?: ContextMetadata): Promise<IntentResult> => {
+        const currentListener = this.intentListeners.find(({ id }) => id === listenerId);
+        let channel: Channel | undefined;
 
-          //app channel
-          if (channelName && !isPrivate) {
-            channel = await appChannelStore.getOrCreateChannel(channelName);
-          }
-
-          //private channel
-          if (isPrivate && !channelName) {
-            channel = await privateChannelStore.createPrivateChannel();
-            privateChannelStore.addChannelListener(<PrivateChannel>channel, 'all');
-
-            privateChannelStore.onDisconnect(<PrivateChannel>channel);
-            privateChannelStore.onUnsubscribe(<PrivateChannel>channel);
-            privateChannelStore.onAddContextListener(<PrivateChannel>channel, channelContexts, channelContextDelay);
-          }
-
-          if (!isPrivate && channel) {
-            if (channelContexts && Object.keys(channelContexts).length !== 0) {
-              Object.keys(channelContexts).forEach(key => {
-                const broadcast = setTimeout(async () => {
-                  appChannelStore.broadcast(<Channel>channel, channelContexts[key]);
-                  clearTimeout(broadcast);
-                }, channelContextDelay?.[key] ?? 0);
-              });
-            } else {
-              await channel.broadcast(context);
-            }
-          }
-
-          runInAction(() => {
-            if (currentListener) {
-              currentListener.lastReceivedContext = context;
-              currentListener.metaData = metaData;
-            }
-          });
-
-          systemLogStore.addLog({
-            name: 'receivedIntentListener',
-            type: 'info',
-            value: intent,
-            variant: 'code',
-            body: JSON.stringify(context, null, 4),
-          });
-
-          const result: IntentResult = channel || (resultContext ?? undefined);
-
-          return result;
+        //app channel
+        if (channelName && !isPrivate) {
+          channel = await appChannelStore.getOrCreateChannel(channelName);
         }
 
         //private channel
@@ -116,21 +71,21 @@ class IntentStore {
         }
 
         if (!isPrivate && channel) {
-          if (Object.keys(channelContexts).length !== 0) {
+          if (channelContexts && Object.keys(channelContexts).length !== 0) {
             Object.keys(channelContexts).forEach(key => {
-              let broadcast = setTimeout(async () => {
+              const broadcast = setTimeout(async () => {
                 appChannelStore.broadcast(<Channel>channel, channelContexts[key]);
                 clearTimeout(broadcast);
-              }, channelContextDelay[key]);
+              }, channelContextDelay?.[key] ?? 0);
             });
           } else {
-            await channel.broadcast(context);
+            await channel.broadcast(handlerContext);
           }
         }
 
         runInAction(() => {
           if (currentListener) {
-            currentListener.lastReceivedContext = context;
+            currentListener.lastReceivedContext = handlerContext;
             currentListener.metaData = metaData;
           }
         });
@@ -140,7 +95,7 @@ class IntentStore {
           type: 'info',
           value: intent,
           variant: 'code',
-          body: JSON.stringify(context, null, 4),
+          body: JSON.stringify(handlerContext, null, 4),
         });
 
         const result: IntentResult = channel || (resultContext ?? undefined);
@@ -148,13 +103,10 @@ class IntentStore {
         return result;
       };
 
-      let intentListener: Listener;
-
-      if (context == null) {
-        intentListener = await agent.addIntentListener(intent, handler);
-      } else {
-        intentListener = await agent.addIntentListenerWithContext(intent, context.type, handler);
-      }
+      const intentListener =
+        context == null
+          ? await agent.addIntentListener(intent, handler)
+          : await agent.addIntentListenerWithContext(intent, context.type, handler);
 
       runInAction(() => {
         systemLogStore.addLog({

--- a/toolbox/fdc3-workbench/src/store/IntentStore.ts
+++ b/toolbox/fdc3-workbench/src/store/IntentStore.ts
@@ -115,7 +115,11 @@ class IntentStore {
           value: intent,
           variant: 'text',
         });
-        this.intentListeners.push({ id: listenerId, type: intent, listener: intentListener });
+        this.intentListeners.push({
+          id: listenerId,
+          type: context?.type != null ? `${intent} (${context.type})` : intent,
+          listener: intentListener,
+        });
       });
     } catch (e) {
       systemLogStore.addLog({

--- a/toolbox/fdc3-workbench/src/store/IntentStore.ts
+++ b/toolbox/fdc3-workbench/src/store/IntentStore.ts
@@ -39,6 +39,7 @@ class IntentStore {
 
   async addIntentListener(
     intent: string,
+    context?: ContextType,
     resultContext?: ContextType | null,
     channelName?: string | null,
     isPrivate?: boolean,
@@ -103,7 +104,57 @@ class IntentStore {
 
           return result;
         }
-      );
+
+        //private channel
+        if (isPrivate && !channelName) {
+          channel = await privateChannelStore.createPrivateChannel();
+          privateChannelStore.addChannelListener(<PrivateChannel>channel, 'all');
+
+          privateChannelStore.onDisconnect(<PrivateChannel>channel);
+          privateChannelStore.onUnsubscribe(<PrivateChannel>channel);
+          privateChannelStore.onAddContextListener(<PrivateChannel>channel, channelContexts, channelContextDelay);
+        }
+
+        if (!isPrivate && channel) {
+          if (Object.keys(channelContexts).length !== 0) {
+            Object.keys(channelContexts).forEach(key => {
+              let broadcast = setTimeout(async () => {
+                appChannelStore.broadcast(<Channel>channel, channelContexts[key]);
+                clearTimeout(broadcast);
+              }, channelContextDelay[key]);
+            });
+          } else {
+            await channel.broadcast(context);
+          }
+        }
+
+        runInAction(() => {
+          if (currentListener) {
+            currentListener.lastReceivedContext = context;
+            currentListener.metaData = metaData;
+          }
+        });
+
+        systemLogStore.addLog({
+          name: 'receivedIntentListener',
+          type: 'info',
+          value: intent,
+          variant: 'code',
+          body: JSON.stringify(context, null, 4),
+        });
+
+        const result: IntentResult = channel || (resultContext ?? undefined);
+
+        return result;
+      };
+
+      let intentListener: Listener;
+
+      if (context == null) {
+        intentListener = await agent.addIntentListener(intent, handler);
+      } else {
+        intentListener = await agent.addIntentListenerWithContext(intent, context.type, handler);
+      }
 
       runInAction(() => {
         systemLogStore.addLog({

--- a/website/docs/api/conformance/Intents-Tests.md
+++ b/website/docs/api/conformance/Intents-Tests.md
@@ -335,6 +335,45 @@ As the methods of resolving ambiguous intents are often user interactive, it is 
 
 - `MultipleAddingOfTheSameIntentListenerCausesIntentListenerConflict` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps to which should cause `IntentListenerConflict` error.
 
+A new listener conflicts with an existing one for the same intent when either listener is **unfiltered** (added via `addIntentListener`, so it handles all context types) or when their declared context types **overlap**. The following cases all cause an `IntentListenerConflict` error:
+
+| App  | Step                      | Details |
+|------|---------------------------|---------|
+| Test | 1. Add Intent Listener            | App performs `fdc3.addIntentListener("aTestingIntent1")`. |
+| Test | 2. Add filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", "fdc3.instrument")`. |
+
+- `AddingFilteredIntentListenerWhenUnfilteredExistsCausesIntentListenerConflict` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should cause an `IntentListenerConflict` error (the existing unfiltered listener handles all context types).
+
+| App  | Step                      | Details |
+|------|---------------------------|---------|
+| Test | 1. Add filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", "fdc3.instrument")`. |
+| Test | 2. Add Intent Listener | App performs `fdc3.addIntentListener("aTestingIntent1")`. |
+
+- `AddingUnfilteredIntentListenerWhenFilteredExistsCausesIntentListenerConflict` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should cause an `IntentListenerConflict` error (the new unfiltered listener handles all context types, overlapping the existing filtered listener).
+
+| App  | Step                      | Details |
+|------|---------------------------|---------|
+| Test | 1. Add filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", ["fdc3.instrument", "fdc3.contact"])`. |
+| Test | 2. Add overlapping filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", ["fdc3.contact", "fdc3.order"])`. |
+
+- `AddingFilteredIntentListenerWithOverlappingContextCausesIntentListenerConflict` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should cause an `IntentListenerConflict` error (the declared context types overlap on `fdc3.contact`).
+
+Filtered listeners for the same intent with **non-overlapping** context types, and listeners for **different** intents, MUST be allowed:
+
+| App  | Step                      | Details |
+|------|---------------------------|---------|
+| Test | 1. Add filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", "fdc3.instrument")`. |
+| Test | 2. Add non-overlapping filtered Intent Listener | App performs `fdc3.addIntentListenerWithContext("aTestingIntent1", "fdc3.order")`. |
+
+- `AddingFilteredIntentListenersWithDifferentContextsIsAllowed` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should successfully add both listeners (no error thrown).
+
+| App  | Step                      | Details |
+|------|---------------------------|---------|
+| Test | 1. Add Intent Listener | App performs `fdc3.addIntentListener("aTestingIntent1")`. |
+| Test | 2. Add Intent Listener for a different intent | App performs `fdc3.addIntentListener("aTestingIntent12")`. |
+
+- `AddingIntentListenersForDifferentIntentsIsAllowed` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should successfully add both listeners (no error thrown).
+
 | App  | Step                      | Details |
 |------|---------------------------|---------|
 | Test | 1. Add Intent Listener            | App performs `fdc3.addIntentListener("aTestingIntent1")` and saves listener. |

--- a/website/docs/api/conformance/Intents-Tests.md
+++ b/website/docs/api/conformance/Intents-Tests.md
@@ -358,7 +358,9 @@ A new listener conflicts with an existing one for the same intent when either li
 
 - `AddingFilteredIntentListenerWithOverlappingContextCausesIntentListenerConflict` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should cause an `IntentListenerConflict` error (the declared context types overlap on `fdc3.contact`).
 
-Filtered listeners for the same intent with **non-overlapping** context types, and listeners for **different** intents, MUST be allowed:
+### Allowed Intent Listener Combinations
+
+Filtered listeners for the same intent whose declared context types do not overlap MUST be allowed:
 
 | App  | Step                      | Details |
 |------|---------------------------|---------|
@@ -367,6 +369,8 @@ Filtered listeners for the same intent with **non-overlapping** context types, a
 
 - `AddingFilteredIntentListenersWithDifferentContextsIsAllowed` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should successfully add both listeners (no error thrown).
 
+Listeners for **different** intents MUST be allowed, regardless of whether they are filtered or unfiltered:
+
 | App  | Step                      | Details |
 |------|---------------------------|---------|
 | Test | 1. Add Intent Listener | App performs `fdc3.addIntentListener("aTestingIntent1")`. |
@@ -374,10 +378,14 @@ Filtered listeners for the same intent with **non-overlapping** context types, a
 
 - `AddingIntentListenersForDifferentIntentsIsAllowed` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps which should successfully add both listeners (no error thrown).
 
+### Re-adding an Intent Listener after Unsubscribe
+
+Unsubscribing an intent listener MUST remove it as a source of conflict, so that a new listener that would previously have been rejected with an `IntentListenerConflict` error can be added successfully. This ensures an application can replace a listener for an intent (for example to change the context types it handles) without restarting:
+
 | App  | Step                      | Details |
 |------|---------------------------|---------|
-| Test | 1. Add Intent Listener            | App performs `fdc3.addIntentListener("aTestingIntent1")` and saves listener. |
-| Test | 2. Unsubscribe from the intent | App performs `listener.unsubscribe()`. |
-| Test | 2. Perform Step 1 again | App performs `fdc3.addIntentListener("aTestingIntent1")` again. |
+| Test | 1. Add Intent Listener            | App performs `const listener = await fdc3.addIntentListener("aTestingIntent1")`, saving the returned `Listener` object. |
+| Test | 2. Unsubscribe from the intent | App removes the listener by performing `await listener.unsubscribe()`. |
+| Test | 3. Add Intent Listener again | App performs `fdc3.addIntentListener("aTestingIntent1")` again. As the previous listener has been removed there is no longer a conflict, so this MUST resolve successfully (no `IntentListenerConflict` error is thrown) and return a new `Listener`. |
 
-- `MultipleAddingOfTheSameIntentListenerAfterUnsubscribe` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps to which should successfully add the listener again.
+- `MultipleAddingOfTheSameIntentListenerAfterUnsubscribe` ![3.0+](https://img.shields.io/badge/FDC3-3.0+-purple): Perform above steps, which should successfully add the listener again without an `IntentListenerConflict` error being thrown.

--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -36,6 +36,7 @@ interface DesktopAgent {
   raiseIntent(intent: string, context: Context, app?: AppIdentifier | null, metadata?: AppProvidableContextMetadata): Promise<IntentResolution>;
   raiseIntentForContext(context: Context, app?: AppIdentifier | null, metadata?: AppProvidableContextMetadata): Promise<IntentResolution>;
   addIntentListener(intent: string, handler: IntentHandler): Promise<Listener>;
+  addIntentListenerWithContext(intent: string, contextType: string | string[], handler: IntentHandler): Promise<Listener>;
 
   // channels
   getOrCreateChannel(channelId: string): Promise<Channel>;
@@ -471,6 +472,62 @@ listenerResult := <-desktopAgent.AddIntentListener("fdc3.contact", func(context 
 
 - [Register an Intent Handler](../spec#register-an-intent-handler)
 - [`PrivateChannel`](PrivateChannel)
+- [`Listener`](Types#listener)
+- [`Context`](Types#context)
+- [`IntentHandler`](Types#intenthandler)
+- [`ResolveError`](Errors#resolveerror)
+
+### `addIntentListenerWithContext`
+
+<Tabs groupId="lang">
+<TabItem value="ts" label="TypeScript/JavaScript">
+
+```ts
+addIntentListenerWithContext(
+  intent: string,
+  contextType: string | string[],
+  handler: IntentHandler
+): Promise<Listener>;
+```
+
+</TabItem>
+</Tabs>
+
+Adds a listener for incoming intents raised by other applications, via calls to [`fdc3.raiseIntent`](#raiseintent) or [`fdc3.raiseIntentForContext`](#raiseintentforcontext), filtered by one or more context types. The handler will only be invoked when the incoming intent's context `type` matches one of the supplied `contextType` values; all other behaviour is identical to [`addIntentListener`](#addintentlistener) — see that section for details, restrictions and result handling that also apply here.
+
+The `contextType` parameter MAY be either a single context type string or an array of context type strings. Adding multiple intent listeners on the same intent MUST be rejected with the [`ResolveError.IntentListenerConflict`](Errors#resolveerror), regardless of whether the listeners are added with `addIntentListener` or `addIntentListenerWithContext`, unless the previous listener was removed first through [`listener.unsubscribe`](Types#unsubscribe).
+
+Desktop Agents MUST forward `contextTypes` declared on the listener to intent resolution so that the listener is only considered for raised intents whose context type matches.
+
+**Examples:**
+
+<Tabs groupId="lang">
+<TabItem value="ts" label="TypeScript/JavaScript">
+
+```js
+//Handle a raised intent filtered to a single context type
+const listener = await fdc3.addIntentListenerWithContext('StartChat', 'fdc3.contact', context => {
+  // start chat has been requested by another application
+  return;
+});
+
+//Handle a raised intent filtered to multiple context types
+const listener = await fdc3.addIntentListenerWithContext(
+  'ViewChart',
+  ['fdc3.instrument', 'fdc3.instrumentList'],
+  context => {
+    // view chart has been requested by another application
+    return;
+  }
+);
+```
+
+</TabItem>
+</Tabs>
+
+**See also:**
+
+- [`addIntentListener`](#addintentlistener)
 - [`Listener`](Types#listener)
 - [`Context`](Types#context)
 - [`IntentHandler`](Types#intenthandler)

--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -370,7 +370,7 @@ The [`PrivateChannel`](PrivateChannel) type is provided to support synchronizati
 
 Metadata about each intent & context message received, including the app that originated the message and a timestamp, MUST be provided by the Desktop Agent implementation. Apps raising intents MAY provide additional metadata (such as a traceId, signature or custom metadata), which the Desktop Agent MUST pass on to the handler.
 
- Adding multiple intent listeners on the same type MUST be rejected with the [`ResolveError.IntentListenerConflict`](Errors#resolveerror), unless the previous listener was removed first though [`listener.unsubscribe`](Types#unsubscribe)
+ Multiple intent listeners MAY be added for the same intent, provided they are filtered to different context types (see [`addIntentListenerWithContext`](#addintentlistenerwithcontext)). Adding an intent listener that conflicts with an existing listener for the same intent MUST be rejected with the [`ResolveError.IntentListenerConflict`](Errors#resolveerror), unless the conflicting listener was removed first through [`listener.unsubscribe`](Types#unsubscribe). A new listener conflicts with an existing one for the same intent when either listener is unfiltered (added via [`addIntentListener`](#addintentlistener), and so handles all context types) or when their declared context types overlap.
 
 **Examples:**
 
@@ -495,7 +495,7 @@ addIntentListenerWithContext(
 
 Adds a listener for incoming intents raised by other applications, via calls to [`fdc3.raiseIntent`](#raiseintent) or [`fdc3.raiseIntentForContext`](#raiseintentforcontext), filtered by one or more context types. The handler will only be invoked when the incoming intent's context `type` matches one of the supplied `contextType` values; all other behaviour is identical to [`addIntentListener`](#addintentlistener) — see that section for details, restrictions and result handling that also apply here.
 
-The `contextType` parameter MAY be either a single context type string or an array of context type strings. Adding multiple intent listeners on the same intent MUST be rejected with the [`ResolveError.IntentListenerConflict`](Errors#resolveerror), regardless of whether the listeners are added with `addIntentListener` or `addIntentListenerWithContext`, unless the previous listener was removed first through [`listener.unsubscribe`](Types#unsubscribe).
+The `contextType` parameter MAY be either a single context type string or an array of context type strings. Multiple intent listeners MAY be added for the same intent, provided they are filtered to different (non-overlapping) context types. Adding an intent listener that conflicts with an existing listener for the same intent MUST be rejected with the [`ResolveError.IntentListenerConflict`](Errors#resolveerror), regardless of whether the listeners are added with `addIntentListener` or `addIntentListenerWithContext`, unless the conflicting listener was removed first through [`listener.unsubscribe`](Types#unsubscribe). A new listener conflicts with an existing one for the same intent when either listener is unfiltered (added via `addIntentListener`, and so handles all context types) or when their declared context types overlap.
 
 Desktop Agents MUST forward `contextTypes` declared on the listener to intent resolution so that the listener is only considered for raised intents whose context type matches.
 

--- a/website/docs/api/specs/desktopAgentCommunicationProtocol.md
+++ b/website/docs/api/specs/desktopAgentCommunicationProtocol.md
@@ -149,12 +149,14 @@ Request and response for removing the event listener ([`Listener.unsubscribe()`]
 - [`eventListenerUnsubscribeRequest`](pathname:///schemas/next/api/eventListenerUnsubscribeRequest.schema.json)
 - [`eventListenerUnsubscribeResponse`](pathname:///schemas/next/api/eventListenerUnsubscribeResponse.schema.json)
 
-#### `addIntentListener()`
+#### `addIntentListener()` / `addIntentListenerWithContext()`
 
-Request and response used to implement the [`addIntentListener()`](../ref/DesktopAgent#addintentlistener) API call:
+Request and response used to implement both the [`addIntentListener()`](../ref/DesktopAgent#addintentlistener) and [`addIntentListenerWithContext()`](../ref/DesktopAgent#addintentlistenerwithcontext) API calls:
 
 - [`addIntentListenerRequest`](pathname:///schemas/next/api/addIntentListenerRequest.schema.json)
 - [`addIntentListenerResponse`](pathname:///schemas/next/api/addIntentListenerResponse.schema.json)
+
+The `addIntentListenerRequest` payload includes an optional `contextTypes` field (an array of context type strings) used to restrict the listener to incoming intents whose context type matches one of the supplied values. When `addIntentListener()` is used the field is omitted (meaning all context types match); when `addIntentListenerWithContext()` is used the field MUST be populated. Desktop Agents MUST use this field both when matching intent listeners during intent resolution and when delivering raised intents, so that listeners are only invoked for matching context types.
 
 Event message used to a raised intent and context object from another app to the listener:
 


### PR DESCRIPTION
## Describe your change

Adds a new function `addIntentWithContextListener` to the `DesktopAgent` interfaces and implements it within `DesktopAgentProxy`

### Related Issue
resolves #1545
recreating #1590 - to be closed

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [x] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
