### PR TITLE
Support Dynamic intent handler registrations in FDC3 web reference implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Add a notes field to Trade type ([#1563](https://github.com/finos/FDC3/pull/1563))
 * Add a notes field to Order and Product types ([#1597](https://github.com/finos/FDC3/pull/1597))
 * Added Go language binding. ([#1483](https://github.com/finos/FDC3/pull/1483))
+* Added dynamic intent listener support to the reference Desktop Agent implementation ([#1613](https://github.com/finos/FDC3/pull/1613))
 * Added details of and procedures for resolving fully-qualified appIds and unqualified appIds in the API and Bridging Parts of the Standard. ([#1523](https://github.com/finos/FDC3/pull/1523))
 * Added clarification regarding expected behavior upon repeated calls to `addContextListener` on same or overlapping types (allowed) and `addIntentListener` on same intent (rejected; new error type added). ([#1394](https://github.com/finos/FDC3/pull/1394))
 * Ported FDC3 Conformance Project as-is into the FDC3 Monorepo, just including minimal fixes for typescript compilation. ([#1576](https://github.com/finos/FDC3/pull/1576))

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
@@ -383,15 +383,15 @@ export class IntentHandler implements MessageHandler {
       ...matchingRegistrations.map(r => r.intentName),
     ].filter((v, i, a) => a.indexOf(v) === i);
 
+    const allIntents = this.directory.retrieveAllIntents();
+
     const appIntents: AppIntent[] = uniqueIntentNames.map(i => {
       const directoryAppsWithIntent = matchingIntents.filter(mi => mi.intentName == i).map(mi => mi.appId);
       const runningDirectoryApps = connectedApps.filter(ca => directoryAppsWithIntent.includes(ca.appId));
       const appRegistrations = matchingRegistrations
         .filter(registration => registration.intentName === i) // filter registrations for the current intent
         .map(listener => ({ appId: listener.appId, instanceId: listener.instanceId, state: State.Connected }))
-        .filter(appRegistration =>
-          runningDirectoryApps.every(runningApp => runningApp.instanceId !== appRegistration.instanceId)
-        ); // filter out apps that are already included from the directory listing
+        .filter(appRegistration => allIntents.every(intent => intent.appId !== appRegistration.appId)); // filter out apps that have intents registered in the directory
 
       const runningApps: AppRegistration[] = [...runningDirectoryApps, ...appRegistrations];
 

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
@@ -1,5 +1,5 @@
 import { MessageHandler } from '../BasicFDC3Server';
-import { AppRegistration, InstanceID, ServerContext } from '../ServerContext';
+import { AppRegistration, InstanceID, ServerContext, State } from '../ServerContext';
 import { Directory, DirectoryIntent } from '../directory/DirectoryInterface';
 import { Context } from '@finos/fdc3-context';
 import { AppIntent, ResolveError, AppIdentifier } from '@finos/fdc3-standard';
@@ -377,11 +377,23 @@ export class IntentHandler implements MessageHandler {
   async raiseIntentToAnyApp(arg0: IntentRequest[], sc: ServerContext<AppRegistration>): Promise<void> {
     const connectedApps = await sc.getConnectedApps();
     const matchingIntents = arg0.flatMap(i => this.directory.retrieveIntents(i.context.type, i.intent, undefined));
-    const uniqueIntentNames = matchingIntents.map(i => i.intentName).filter((v, i, a) => a.indexOf(v) === i);
+    const matchingRegistrations = arg0.flatMap(i => this.registrations.filter(r => r.intentName == i.intent));
+    const uniqueIntentNames = [
+      ...matchingIntents.map(i => i.intentName),
+      ...matchingRegistrations.map(r => r.intentName),
+    ].filter((v, i, a) => a.indexOf(v) === i);
 
     const appIntents: AppIntent[] = uniqueIntentNames.map(i => {
       const directoryAppsWithIntent = matchingIntents.filter(mi => mi.intentName == i).map(mi => mi.appId);
-      const runningApps = connectedApps.filter(ca => directoryAppsWithIntent.includes(ca.appId));
+      const runningDirectoryApps = connectedApps.filter(ca => directoryAppsWithIntent.includes(ca.appId));
+      const appRegistrations = matchingRegistrations
+        .filter(registration => registration.intentName === i) // filter registrations for the current intent
+        .map(listener => ({ appId: listener.appId, instanceId: listener.instanceId, state: State.Connected }))
+        .filter(appRegistration =>
+          runningDirectoryApps.every(runningApp => runningApp.instanceId !== appRegistration.instanceId)
+        ); // filter out apps that are already included from the directory listing
+
+      const runningApps: AppRegistration[] = [...runningDirectoryApps, ...appRegistrations];
 
       return {
         intent: {

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent-with-context.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent-with-context.feature
@@ -83,3 +83,22 @@ Scenario: Raising An Intent With Context To An Invalid Instance
     Then messaging will have outgoing posts
       | msg.payload.appIntents[1].apps[2].appId | msg.payload.appIntents[1].apps[2].instanceId |
       | listenerApp                             | {null}                                       |
+
+Scenario: Dynamic registrations are displayed in the app resolver
+    When "App2/a2" registers an intent listener for "returnBook" with contextType "fdc3.book"
+    When "App1/a1" raises an intent with contextType "fdc3.book"
+    Then messaging will have outgoing posts
+      | msg.type                      | msg.payload.appIntents[0].intent.name | msg.payload.appIntents[1].intent.name | to.instanceId | to.appId |
+      | raiseIntentForContextResponse | returnBook                            | borrowBook                            | a1            | App1     |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntents[0].apps[0].appId | msg.payload.appIntents[0].apps[0].instanceId |
+      | App2                                    | a2                                           |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntents[1].apps[0].appId | msg.payload.appIntents[1].apps[0].instanceId |
+      | listenerApp                             | b1                                           |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntents[1].apps[1].appId | msg.payload.appIntents[1].apps[1].instanceId |
+      | libraryApp                              | {null}                                       |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntents[1].apps[2].appId | msg.payload.appIntents[1].apps[2].instanceId |
+      | listenerApp                             | {null}                                       |

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/raise-intent.feature
@@ -131,6 +131,26 @@ Feature: Raising Intents
       | msg.payload.appIntent.apps[2].appId | msg.payload.appIntent.apps[2].instanceId |
       | listenerApp                         | {null}                                   |
 
+
+  Scenario: Dynamic registrations are displayed in the app resolver
+    When "App2/a2" registers an intent listener for "borrowBook" with contextType "fdc3.book"
+    When "App1/a1" raises an intent for "borrowBook" with contextType "fdc3.book"
+    Then messaging will have outgoing posts
+      | msg.type            | msg.payload.appIntent.intent.name | msg.payload.appIntent.intent.displayName | to.instanceId | to.appId |
+      | raiseIntentResponse | borrowBook                        | borrowBook                               | a1            | App1     |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntent.apps[0].appId | msg.payload.appIntent.apps[0].instanceId |
+      | listenerApp                         | b1                                       |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntent.apps[1].appId | msg.payload.appIntent.apps[1].instanceId |
+      | App2                                | a2                                       |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntent.apps[2].appId | msg.payload.appIntent.apps[2].instanceId |
+      | libraryApp                          | {null}                                   |
+    Then messaging will have outgoing posts
+      | msg.payload.appIntent.apps[3].appId | msg.payload.appIntent.apps[3].instanceId |
+      | listenerApp                         | {null}                                   |
+
   Scenario: Raising An Invalid Intent to the server (no instance)
     When "App1/a1" raises an intent for "borrowBook" with contextType "fdc3.book" on app "listenerApp/z1"
     Then messaging will have outgoing posts


### PR DESCRIPTION
Added support for dynamic intent listeners (ones raised through `addIntentListener` rather than listed in the app directory

### Related Issue
resolves #1610

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?

---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
