### PR TITLE
GHA: Only run GHA comment script if PR origin is from FINOS - v2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -53,7 +53,7 @@ jobs:
 
     # Only post comments if the PR came from FINOS (the only repo with permission to run it)
     - name: PR comment with file
-      if: github.repository == 'finos/FDC3'
+      if: github.event.pull_request.head.repo.full_name == 'finos/FDC3'
       uses: thollander/actions-comment-pull-request@v3
       with:
         file-path: test-summary.md


### PR DESCRIPTION
## Describe your change

Changing the variable used to check the source repo of a PR - `github.repository` will always return `finos/FDC3` for a PR in our repo.

### Related Issue

#1519 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- N/A **CHANGELOG**: Is a *CHANGELOG.md* entry included?
