### PR TITLE
fix to HelloHandler in getAgent to send the correct property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Fixed
+
+* Corrected the property set in WCP1Hello by getAgent that indicates whether an intent resolver is needed. ([#1684](https://github.com/finos/FDC3/issues/1684))
 * Add unit tests to the fdc3-context package for validating context examples are valid schema.
 * Revert schema of `fdc3.timeRange` context type back to use anyOf in place of oneOf for the `startTime` and `endTime` property combinations.  This will allow existence of one of either, or both, and pass schema validation.  When defined with oneOf, validation would fail due to multiple entries being valid and it could not identify which to apply. ([#1592](https://github.com/finos/FDC3/issues/1592))
 * Revert schema of `fdc3.interaction` context type back to use anyOf in place of oneOf for the `interactionType` property.  Since it could be a string enum or a string, validation could not differentiate. ([#1598](https://github.com/finos/FDC3/issues/1598))

--- a/packages/fdc3-get-agent/src/strategies/HelloHandler.ts
+++ b/packages/fdc3-get-agent/src/strategies/HelloHandler.ts
@@ -52,7 +52,7 @@ export class HelloHandler {
       payload: {
         channelSelector: this.options.channelSelector,
         fdc3Version: FDC3_VERSION,
-        resolver: this.options.intentResolver,
+        intentResolver: this.options.intentResolver,
         identityUrl: this.options.identityUrl!,
         actualUrl: globalThis.window.location.href,
       },

--- a/packages/fdc3-schema/generated/api/BrowserTypes.ts
+++ b/packages/fdc3-schema/generated/api/BrowserTypes.ts
@@ -149,7 +149,6 @@ export interface WebConnectionProtocol1HelloPayload {
    * `false` if no intents, or only targeted intents, are raised.
    */
   intentResolver?: boolean;
-  [property: string]: any;
 }
 
 /**
@@ -189,7 +188,6 @@ export interface WebConnectionProtocol2LoadURLPayload {
    * target.
    */
   iframeUrl: string;
-  [property: string]: any;
 }
 
 /**
@@ -4936,7 +4934,7 @@ const typeMap: any = {
       { json: 'identityUrl', js: 'identityUrl', typ: '' },
       { json: 'intentResolver', js: 'intentResolver', typ: u(undefined, true) },
     ],
-    'any'
+    false
   ),
   WebConnectionProtocol2LoadURL: o(
     [
@@ -4946,7 +4944,7 @@ const typeMap: any = {
     ],
     false
   ),
-  WebConnectionProtocol2LoadURLPayload: o([{ json: 'iframeUrl', js: 'iframeUrl', typ: '' }], 'any'),
+  WebConnectionProtocol2LoadURLPayload: o([{ json: 'iframeUrl', js: 'iframeUrl', typ: '' }], false),
   WebConnectionProtocol3Handshake: o(
     [
       { json: 'meta', js: 'meta', typ: r('WebConnectionProtocol1HelloMeta') },

--- a/packages/fdc3-schema/schemas/api/WCP1Hello.schema.json
+++ b/packages/fdc3-schema/schemas/api/WCP1Hello.schema.json
@@ -52,7 +52,8 @@
               "type": "boolean"
             }
           },
-          "required": ["identityUrl","actualUrl","fdc3Version"]
+          "required": ["identityUrl","actualUrl","fdc3Version"],
+          "additionalProperties": false
         },
         "meta": {
           "$ref": "WCPConnectionStep.schema.json#/$defs/ConnectionStepMeta"

--- a/packages/fdc3-schema/schemas/api/WCP2LoadUrl.schema.json
+++ b/packages/fdc3-schema/schemas/api/WCP2LoadUrl.schema.json
@@ -33,7 +33,8 @@
           },
           "required": [
             "iframeUrl"
-          ]
+          ],
+          "additionalProperties": false
         },
         "meta": {
           "$ref": "WCPConnectionStep.schema.json#/$defs/ConnectionStepMeta"


### PR DESCRIPTION
## Describe your change

Corrects the name of a property set in the HelloHandler (part of the getAgent implementation) to match the adopted schema for that message.

### Related Issue

resolves #1683

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [x] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [x] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [x] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [x] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
