### PR TITLE
Fix coverage workflow: don't post comment on PRs from forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,9 +51,9 @@ jobs:
         output: test-summary.md
       if: always()
 
-    # Only post comments if the PR came from FINOS (the only repo with permission to run it)
+    # Only post comments if the PR came from this repo rather than a fork (the only repo with permission to do so)
     - name: PR comment with file
-      if: github.event.pull_request.head.repo.full_name == 'finos/FDC3'
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       uses: thollander/actions-comment-pull-request@v3
       with:
         file-path: test-summary.md


### PR DESCRIPTION
## Describe your change

Fixes the coverage workflow by inhibiting coverage comments on PRs from forks. An ideal solution would fix the posting of comments, but this is not possible without a bot. Hence, we'd need to transition to CodeCov or similar for a full fix. This PR should at least stop the coverage workflow from failing.

After this change the coverage workflow should return to being a required check for merging a PR. A subsequent PR will make it the only workflow that runs tests and linting rules!

### Related Issue

resolves #1519 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- N/A **CHANGELOG**: Is a *CHANGELOG.md* entry included?