### PR TITLE
docs: correct 'Bearer authentication schema' to 'scheme' in App Directory API docs

### DIFF
--- a/website/docs/app-directory/spec.md
+++ b/website/docs/app-directory/spec.md
@@ -37,7 +37,7 @@ An FDC3 Standard compliant App Directory implementation **MUST**:
 
 An FDC3 Standard compliant App Directory implementation **SHOULD**:
 
-- Support authentication (where required) via the HTTP Authorization header and Bearer authentication schema (implemented via JWT tokens)
+- Support authentication (where required) via the HTTP Authorization header and Bearer authentication scheme (implemented via JWT tokens)
 - Select any `categories` field values from the recommended list.
 - Encourage the use of the `lang` and `localizedVersions` fields in appD records to support localization and accessibility.
 


### PR DESCRIPTION
This PR fixes a small terminology issue in the App Directory API documentation.

The phrase "Bearer authentication schema" is updated to the correct "Bearer authentication scheme", which aligns with:

- HTTP authentication standards (RFC 6750)
- Common OpenAPI terminology
- FDC3 documentation consistency

This change improves accuracy in the documentation. No functional or spec logic is modified.
