### PR TITLE
docs: add missing period for consistency in App Directory compliance list

### DIFF
--- a/website/docs/app-directory/spec.md
+++ b/website/docs/app-directory/spec.md
@@ -32,7 +32,7 @@ An FDC3 Standard compliant App Directory implementation **MUST**:
   - `/v2/apps` (GET)
   - `/v2/apps/{appId}` (GET)
 - Ensure that `appId` field values assigned to applications are unique within the directory.
-- Ensure that app directory records served meet the minimum requirements specified in the [app directory OpenAPI specification](pathname:///schemas/next/app-directory.html#tag/Application)
+- Ensure that app directory records served meet the minimum requirements specified in the [app directory OpenAPI specification](pathname:///schemas/next/app-directory.html#tag/Application).
 - Support retrieval of app directory records via either the raw `appId` (e.g. `myAppId`) or fully-qualified appId (e.g. `myAppId@host.domain.com`) as defined in the [app directory overview](overview#shrinking-the-uri).
 
 An FDC3 Standard compliant App Directory implementation **SHOULD**:


### PR DESCRIPTION
This PR adds a missing period at the end of a bullet point in the App Directory Standard Compliance section.

The surrounding bullet points are complete sentences and use proper punctuation.  
Adding this period ensures consistent formatting and improves readability.

No functional or specification content is changed.

