### PR TITLE
Update channelChangedEvent.schema.json for backwards compatibility

### DIFF
--- a/packages/fdc3-schema/schemas/api/channelChangedEvent.schema.json
+++ b/packages/fdc3-schema/schemas/api/channelChangedEvent.schema.json
@@ -30,24 +30,49 @@
 		"ChannelChangedEventPayload": {
 			"title": "channelChanged Event Payload",
 			"type": "object",
-			"properties": {
-				"newChannelId": {
-					"title": "New Channel Id",
-					"description": "The Id of the channel that the app was added to or `null` if it was removed from a channel.",
-					"oneOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "null"
-						}
-					]
-				}
-			},
-			"additionalProperties": false,
-			"required": [
-				"newChannelId"
-			]
+      "anyOf": [
+        {
+          "deprecated": true,
+          "properties": {
+    				"newChannelId": {
+    					"title": "New Channel Id",
+    					"description": "Deprecated - allowed for backwards compatibility.  The Id of the channel that the app was added to or `null` if it was removed from a channel.",
+    					"oneOf": [
+    						{
+    							"type": "string"
+    						},
+    						{
+    							"type": "null"
+    						}
+    					]
+    				}
+    			},
+    			"additionalProperties": false,
+    			"required": [
+    				"newChannelId"
+    			]
+        },{
+          "properties": {
+    				"currentChannelId": {
+    					"title": "Current Channel Id",
+    					"description": "The Id of the channel that the app was added to or `null` if it was removed from a channel.",
+    					"oneOf": [
+    						{
+    							"type": "string"
+    						},
+    						{
+    							"type": "null"
+    						}
+    					]
+    				}
+    			},
+    			"additionalProperties": false,
+    			"required": [
+    				"currentChannelId"
+    			]
+        }  
+      ]
+			
 		}
 	}
 }


### PR DESCRIPTION
## Describe your change

Example schema change to support either the old property or the one standardised to match the FDC3 Standard event (so it doesn't have to be translated).

Types still need to be generated
### Related Issue

#1585

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.