### PR TITLE
Update CI workflow to not report coverage for PRs from Forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,6 +67,7 @@ jobs:
         search_artifacts: true
 
     - name: Report Coverage
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       uses: sidx1024/report-nyc-coverage-github-action@v1.2.7
       with:
         coverage_file: "nyc-coverage-report/coverage-summary.json"


### PR DESCRIPTION
PRs from forks are still failing due to a second step that reports the coverage. Disabling this so that we can merge them.

We'll need to switch to a different solution based on a bot.