### PR TITLE
ocs: fix agent bridging documentation discrepancies for FDC3 2.2

### DIFF
--- a/website/docs/agent-bridging/ref/findIntent.md
+++ b/website/docs/agent-bridging/ref/findIntent.md
@@ -178,7 +178,7 @@ which is sent back over the bridge as a response to the request message as:
     "type":  "findIntentResponse",
     "payload": {
         "appIntent":  {
-            "intent":  { "appId": "StartChat" },
+            "intent":  { "name": "StartChat" },
             "apps": [
                 { "appId": "WebIce"}
             ]

--- a/website/docs/agent-bridging/spec.md
+++ b/website/docs/agent-bridging/spec.md
@@ -258,6 +258,9 @@ The DA must then respond to the `hello` message with a `handshake` request to th
              *  `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
              *  the Desktop Agent.*/
             "UserChannelMembershipAPIs": boolean;
+            /** Used to indicate whether the experimental Desktop Agent Bridging
+             *  feature is implemented by the Desktop Agent.*/
+            "DesktopAgentBridging": boolean;
           }
         },
         /** The requested DA name */

--- a/website/versioned_docs/version-2.2/agent-bridging/ref/findIntent.md
+++ b/website/versioned_docs/version-2.2/agent-bridging/ref/findIntent.md
@@ -178,7 +178,7 @@ which is sent back over the bridge as a response to the request message as:
     "type":  "findIntentResponse",
     "payload": {
         "appIntent":  {
-            "intent":  { "appId": "StartChat" },
+            "intent":  { "name": "StartChat" },
             "apps": [
                 { "appId": "WebIce"}
             ]

--- a/website/versioned_docs/version-2.2/agent-bridging/spec.md
+++ b/website/versioned_docs/version-2.2/agent-bridging/spec.md
@@ -258,6 +258,9 @@ The DA must then respond to the `hello` message with a `handshake` request to th
              *  `fdc3.getCurrentChannel` and `fdc3.leaveCurrentChannel` are implemented by
              *  the Desktop Agent.*/
             "UserChannelMembershipAPIs": boolean;
+            /** Used to indicate whether the experimental Desktop Agent Bridging
+             *  feature is implemented by the Desktop Agent.*/
+            "DesktopAgentBridging": boolean;
           }
         },
         /** The requested DA name */


### PR DESCRIPTION
This PR fixes documentation discrepancies between the API and docs for agent bridging.

- Corrects the Find Intent example payload to use `intent.name`
- Documents the missing `DesktopAgentBridging` boolean property
- Applies fixes to both current and versioned (2.2) documentation

Resolves #1727.