### PR TITLE
Stop fdc3-web-impl delivering broadcast messages back to the sender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Added Conformance tests for FDC3 2.2 ([#1586](https://github.com/finos/FDC3/pull/1586))
 * Fix for channel change listeners not sending addEventListenerRequests ([#1606](https://github.com/finos/FDC3/pull/1606))
 * When adding a listener on the current channel, the payload.channelId should be null ([#1611](https://github.com/finos/FDC3/pull/1611))
+* Changed fdc3-web-impl to not deliver broadcast messages back to the sending application, as recommended (SHOULD) in the Standard. [#1749](https://github.com/finos/FDC3/pull/1749)
 
 ### Deprecated
 

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
@@ -426,8 +426,12 @@ export class BroadcastHandler implements MessageHandler {
     };
 
     const matchingListeners = this.contextListeners
+      // Deliver the message to apps listening to the right channel
       .filter(r => matchesExactChannel(r) || matchesUserChannel(r))
-      .filter(r => r.contextType == null || r.contextType == arg0.payload.context.type);
+      // Deliver the message to apps with matching context type listeners
+      .filter(r => r.contextType == null || r.contextType == arg0.payload.context.type)
+      // Don't deliver messages back to the broadcasting app
+      .filter(r => r.instanceId !== from.instanceId);
 
     const matchingApps: FullAppIdentifier[] = matchingListeners
       .map(r => {


### PR DESCRIPTION
## Describe your change

fdc3-web-impl is delivering messages back to the broadcaster, where it _SHOULD_ not.

The FDC3 Standard recommends that DAs don't deliver broadcast messages back to the sender, as it forces some apps to examine context sharing messages before applying them, just to check if they came from themselves. This used to cause flickering issues in a variety of apps when they changed context (and immediately received a message back and reapplied the same context).

> DesktopAgent implementations SHOULD ensure that context messages broadcast to a channel by an application joined to it are not delivered back to that same application.

See: 
- https://fdc3.finos.org/docs/api/ref/DesktopAgent#broadcast
- https://fdc3.finos.org/docs/api/spec#desktop-agent-api-standard-compliance

A good reference implementation SHOULD implement all of FDC3s recommendations (SHOULD), as well as the requirements (MUST).

Finally, @robmoffat and I have discussed the fact that said recommendation could evolve/be replaced in FDC3 3.0 when metadata (including the sending app details) will be required. At that point it would be trivial to support a parameter to getAgent allowing an app to choose whether they receive their own messages back or not!

### Related Issue

None raised

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
