### PR TITLE
Update coverage.yml to ensure that it doesn't double count tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,9 @@ jobs:
     - name: Create test summary
       uses: test-summary/action@dist
       with:
-        paths: "**/test-results.xml"
+        paths: |
+          packages/*/test-results.xml
+          toolbox/**/test-results.xml
         show: "fail, skip"
         output: test-summary.md
       if: always()


### PR DESCRIPTION
## Describe your change

Corrects the glob used to find all test results so that it doesn't find each file twice - correcting the double counting of test results.

### Related Issue

resolves #1797

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
