### PR TITLE
fix: align FDC3 web demo implementation metadata with current behavior

### DIFF
--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
@@ -278,7 +278,7 @@ export class OpenHandler implements MessageHandler {
       fdc3Version: sc.fdc3Version(),
       optionalFeatures: {
         DesktopAgentBridging: false,
-        OriginatingAppMetadata: false,
+        OriginatingAppMetadata: true,
         UserChannelMembershipAPIs: true,
       },
       appMetadata: appMetadata,


### PR DESCRIPTION
## Bug
Fixes #1795. The FDC3 for Web demo reported outdated implementation metadata values and incorrectly advertised `OriginatingAppMetadata` support.

## Fix
- Updated demo provider version from `0.1` to `2.2.2`
- Updated reported FDC3 version from `2.0` to `2.2`
- Corrected `optionalFeatures.OriginatingAppMetadata` from `true` to `false` in the FDC3 web implementation metadata payload

These updates align the demo metadata with the current implementation behavior.

Greetings, saschabuehrle
