### PR TITLE
1802 fix originating app metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Added support for passing `originatingApp` metadata to context listeners in `fdc3-agent-proxy` and `fdc3-web-impl`, matching the `ContextMetadata` spec for `addContextListener` callbacks. ([#1819](https://github.com/finos/FDC3/pull/1819))
 * Corrected /toolbox/fdc3-for-web/demo to only use MessagePort communication when 'Parent Post-Message' selected in the demo. ([#1695](https://github.com/finos/FDC3/pull/1695))
 * Corrected the property set in WCP1Hello by getAgent that indicates whether an intent resolver is needed. ([#1684](https://github.com/finos/FDC3/issues/1684))
 * Added unit tests to the fdc3-context package for validating context examples are valid schema.

--- a/packages/fdc3-agent-proxy/src/listeners/DefaultContextListener.ts
+++ b/packages/fdc3-agent-proxy/src/listeners/DefaultContextListener.ts
@@ -1,4 +1,4 @@
-import { ContextHandler } from '@finos/fdc3-standard';
+import { AppIdentifier, ContextHandler } from '@finos/fdc3-standard';
 import { Messaging } from '../Messaging.js';
 import { AbstractListener } from './AbstractListener.js';
 import { AddContextListenerRequest, BroadcastEvent } from '@finos/fdc3-schema/dist/generated/api/BrowserTypes.js';
@@ -44,6 +44,8 @@ export class DefaultContextListener
   }
 
   action(m: BroadcastEvent): void {
-    this.handler(m.payload.context);
+    this.handler(m.payload.context, {
+      source: m.payload.originatingApp as AppIdentifier,
+    });
   }
 }

--- a/packages/fdc3-agent-proxy/test/features/app-channels.feature
+++ b/packages/fdc3-agent-proxy/test/features/app-channels.feature
@@ -114,3 +114,16 @@ Feature: Channel Listeners Support
     Then "{contexts}" is an array of objects with the following contents
       | id.ticker | type            | name  |
       | AAPL      | fdc3.instrument | Apple |
+
+  Scenario: App channel context listener receives originating app metadata
+    Given "resultHandler" pipes context and metadata to "contexts" and "metadatas"
+    When I call "{api1}" with "getOrCreateChannel" with parameter "channel-name"
+    And I refer to "{result}" as "channel1"
+    And I call "{channel1}" with "addContextListener" with parameters "fdc3.instrument" and "{resultHandler}"
+    And messaging receives "{instrumentMessageOne}"
+    Then "{contexts}" is an array of objects with the following contents
+      | id.ticker | type            | name  |
+      | AAPL      | fdc3.instrument | Apple |
+    And "{metadatas}" is an array of objects with the following contents
+      | source.appId      | source.instanceId     |
+      | broadcasting-app   | broadcasting-instance |

--- a/packages/fdc3-agent-proxy/test/features/broadcast.feature
+++ b/packages/fdc3-agent-proxy/test/features/broadcast.feature
@@ -30,3 +30,16 @@ Feature: Broadcasting
       | {null}            | {null}               | {null}               | getUserChannelsRequest   |
       | {null}            | {null}               | {null}               | getCurrentChannelRequest |
       | one               | fdc3.instrument      | Apple                | broadcastRequest         |
+
+  Scenario: Context listener receives originating app metadata
+    Given "resultHandler" pipes context and metadata to "contexts" and "metadatas"
+    When I call "{api}" with "getOrCreateChannel" with parameter "channel-name"
+    And I refer to "{result}" as "channel1"
+    And I call "{channel1}" with "addContextListener" with parameters "fdc3.instrument" and "{resultHandler}"
+    And messaging receives "{instrumentMessageOne}"
+    Then "{contexts}" is an array of objects with the following contents
+      | id.ticker | type            | name  |
+      | AAPL      | fdc3.instrument | Apple |
+    And "{metadatas}" is an array of objects with the following contents
+      | source.appId      | source.instanceId     |
+      | broadcasting-app   | broadcasting-instance |

--- a/packages/fdc3-agent-proxy/test/features/private-channels.feature
+++ b/packages/fdc3-agent-proxy/test/features/private-channels.feature
@@ -26,6 +26,17 @@ Feature: Basic Private Channels Support
       | id.ticker | type            | name  |
       | AAPL      | fdc3.instrument | Apple |
 
+  Scenario: Private channel context listener receives originating app metadata
+    Given "resultHandler" pipes context and metadata to "contexts" and "metadatas"
+    When I call "{privateChannel}" with "addContextListener" with parameters "fdc3.instrument" and "{resultHandler}"
+    And messaging receives "{instrumentMessageOne}"
+    Then "{contexts}" is an array of objects with the following contents
+      | id.ticker | type            | name  |
+      | AAPL      | fdc3.instrument | Apple |
+    And "{metadatas}" is an array of objects with the following contents
+      | source.appId      | source.instanceId     |
+      | broadcasting-app   | broadcasting-instance |
+
   Scenario: Adding and then unsubscribing an "onAddContextListener" listener will send a notification of each event to the agent
     Given "typesHandler" pipes events to "types"
     When I call "{privateChannel}" with "addEventListener" with parameters "addContextListener" and "{typesHandler}"

--- a/packages/fdc3-agent-proxy/test/features/user-channels.feature
+++ b/packages/fdc3-agent-proxy/test/features/user-channels.feature
@@ -339,3 +339,15 @@ Feature: Basic User Channels Support
     And messaging will have posts
       | payload.channelId | payload.contextType | matches_type              |
       | {null}            | fdc3.instrument     | addContextListenerRequest |
+
+  Scenario: User channel context listener receives originating app metadata
+    Given "resultHandler" pipes context and metadata to "contexts" and "metadatas"
+    When I call "{api}" with "joinUserChannel" with parameter "one"
+    And I call "{api}" with "addContextListener" with parameters "fdc3.instrument" and "{resultHandler}"
+    And messaging receives "{instrumentMessageOne}"
+    Then "{contexts}" is an array of objects with the following contents
+      | id.ticker | type            | name  |
+      | AAPL      | fdc3.instrument | Apple |
+    And "{metadatas}" is an array of objects with the following contents
+      | source.appId      | source.instanceId     |
+      | broadcasting-app   | broadcasting-instance |

--- a/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
+++ b/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
@@ -4,7 +4,7 @@ import { Context } from '@finos/fdc3-context';
 import { handleResolve, matchData } from '@finos/testing';
 import { CustomWorld } from '../world/index.js';
 import { CHANNEL_STATE } from '@finos/testing';
-import { ApiEvent } from '@finos/fdc3-standard';
+import { ApiEvent, ContextMetadata } from '@finos/fdc3-standard';
 import {
   BroadcastEvent,
   ChannelChangedEvent,
@@ -52,6 +52,10 @@ Given(
       payload: {
         channelId: handleResolve(channel, world),
         context: contextMap[context],
+        originatingApp: {
+          appId: 'broadcasting-app',
+          instanceId: 'broadcasting-instance',
+        },
       },
       type: 'broadcastEvent',
     } as BroadcastEvent;
@@ -176,6 +180,18 @@ Given('{string} pipes context to {string}', (world: CustomWorld, contextHandlerN
     world.props[field].push(context);
   };
 });
+
+Given(
+  '{string} pipes context and metadata to {string} and {string}',
+  (world: CustomWorld, contextHandlerName: string, contextField: string, metadataField: string) => {
+    world.props[contextField] = [];
+    world.props[metadataField] = [];
+    world.props[contextHandlerName] = (context: Context, metadata?: ContextMetadata) => {
+      world.props[contextField].push(context);
+      world.props[metadataField].push(metadata);
+    };
+  }
+);
 
 When('messaging receives {string}', (world: CustomWorld, field: string) => {
   const message = handleResolve(field, world);

--- a/toolbox/fdc3-for-web/demo/src/client/da/DemoServerContext.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/da/DemoServerContext.ts
@@ -212,7 +212,8 @@ export class DemoServerContext implements ServerContext<DemoAppRegistration> {
     }
   }
 
-  async open(appId: string): Promise<InstanceID> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async open(appId: string, _source?: AppIdentifier): Promise<InstanceID> {
     const details: DirectoryApp[] = this.directory.retrieveAppsById(appId) as DirectoryApp[];
     if (details.length > 0) {
       const launchDetails = details[0].details;

--- a/toolbox/fdc3-for-web/demo/src/client/da/FDC3_2_1_JSONDirectory.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/da/FDC3_2_1_JSONDirectory.ts
@@ -1,5 +1,4 @@
-import { BasicDirectory } from '@finos/fdc3-web-impl/src/directory/BasicDirectory';
-import { DirectoryApp } from '@finos/fdc3-web-impl/src/directory/DirectoryInterface';
+import { BasicDirectory, DirectoryApp } from '@finos/fdc3-web-impl';
 
 async function loadRemotely(u: string) {
   const response = await fetch(u);

--- a/toolbox/fdc3-for-web/demo/src/client/da/dummy-desktop-agent.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/da/dummy-desktop-agent.ts
@@ -3,8 +3,14 @@ import { v4 as uuid } from 'uuid';
 import { APP_GOODBYE, DA_HELLO, FDC3_APP_EVENT } from '../../message-types.js';
 import { DemoServerContext } from './DemoServerContext.js';
 import { FDC3_2_1_JSONDirectory } from './FDC3_2_1_JSONDirectory.js';
-import { AppRegistration, DefaultFDC3Server, DirectoryApp, ServerContext } from '@finos/fdc3-web-impl';
-import { ChannelState, ChannelType } from '@finos/fdc3-web-impl/src/handlers/BroadcastHandler.js';
+import {
+  AppRegistration,
+  ChannelState,
+  ChannelType,
+  DefaultFDC3Server,
+  DirectoryApp,
+  ServerContext,
+} from '@finos/fdc3-web-impl';
 import { UI, UI_URLS } from './util.js';
 import { BrowserTypes } from '@finos/fdc3-schema';
 import { WebConnectionProtocol3Handshake } from '@finos/fdc3-schema/dist/generated/api/BrowserTypes.js';
@@ -153,7 +159,7 @@ window.addEventListener('load', () => {
 
     // let's create buttons for some apps
     const appList = document.getElementById('app-list') as HTMLOListElement;
-    directory.retrieveAllApps().forEach(app => {
+    directory.retrieveAllApps().forEach((app: DirectoryApp) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mani = app?.hostManifests?.demo as any;
       const show = mani?.visible ?? true;

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/ServerContext.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/ServerContext.ts
@@ -40,8 +40,10 @@ export interface ServerContext<X extends AppRegistration> {
   /**
    * Opens a new instance of an application.
    * Promise completes once the application window is opened
+   * @param appId - the appId of the application to open
+   * @param source - the AppIdentifier of the app that requested the open, if available
    */
-  open(appId: string): Promise<InstanceID>;
+  open(appId: string, source?: AppIdentifier): Promise<InstanceID>;
 
   /** Set the FDC3Server instance associated with this context. This reference is
    *  used to notify the server to cleanup state for apps that have been terminated.

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
@@ -7,6 +7,7 @@ import {
   AddEventListenerRequest,
   AgentResponseMessage,
   AppRequestMessage,
+  BroadcastEvent,
   BroadcastRequest,
   ChannelChangedEvent,
   ContextListenerUnsubscribeRequest,
@@ -439,21 +440,24 @@ export class BroadcastHandler implements MessageHandler {
       })
       .filter(onlyUniqueAppIds);
 
-    matchingApps.forEach(app => {
-      sc.post(
-        {
-          meta: {
-            eventUuid: sc.createUUID(),
-            timestamp: new Date(),
-          },
-          type: 'broadcastEvent',
-          payload: {
-            channelId: arg0.payload.channelId,
-            context: arg0.payload.context,
-          },
+    const msg: BroadcastEvent = {
+      meta: {
+        eventUuid: sc.createUUID(),
+        timestamp: new Date(),
+      },
+      type: 'broadcastEvent',
+      payload: {
+        channelId: arg0.payload.channelId,
+        context: arg0.payload.context,
+        originatingApp: {
+          appId: from.appId,
+          instanceId: from.instanceId,
         },
-        app.instanceId
-      );
+      },
+    };
+
+    matchingApps.forEach(app => {
+      sc.post(msg, app.instanceId);
     });
 
     this.updateChannelState(arg0.payload.channelId, arg0.payload.context);

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/IntentHandler.ts
@@ -283,7 +283,7 @@ export class IntentHandler implements MessageHandler {
     // app exists but needs starting
     const pi = new PendingIntent(arg0, sc, this, target);
     this.pendingIntents.add(pi);
-    sc.open(target.appId).then(() => {
+    sc.open(target.appId, arg0.from).then(() => {
       return undefined;
     });
   }

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
@@ -247,7 +247,7 @@ export class OpenHandler implements MessageHandler {
     const context = arg0.payload.context;
 
     try {
-      const uuid = await sc.open(toOpen.appId);
+      const uuid = await sc.open(toOpen.appId, from);
       this.pending.set(uuid, new PendingApp(sc, arg0, context, from, this.timeoutMs));
     } catch (e) {
       errorResponse(sc, arg0, from, (e as Error).message ?? e, 'openResponse');

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/apps.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/apps.feature
@@ -54,11 +54,11 @@ Feature: Opening and Requesting App Details
     And we wait for a period of "100" ms
     And "storageApp/uuid-0" adds a context listener on "{null}" with type "fdc3.instrument"
     Then messaging will have outgoing posts
-      | msg.matches_type                | msg.payload.channelId | msg.payload.context.type | to.instanceId | to.appId   |
-      | WCP5ValidateAppIdentityResponse | {null}                | {null}                   | uuid-0        | storageApp |
-      | addContextListenerResponse      | {empty}               | {empty}                  | uuid-0        | storageApp |
-      | openResponse                    | {empty}               | {empty}                  | a1            | libraryApp |
-      | broadcastEvent                  | {null}                | fdc3.instrument          | uuid-0        | storageApp |
+      | msg.matches_type                | msg.payload.channelId | msg.payload.context.type | to.instanceId | to.appId   | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | WCP5ValidateAppIdentityResponse | {null}                | {null}                   | uuid-0        | storageApp | {null}                           | {null}                                |
+      | addContextListenerResponse      | {empty}               | {empty}                  | uuid-0        | storageApp | {null}                           | {null}                                |
+      | openResponse                    | {empty}               | {empty}                  | a1            | libraryApp | {null}                           | {null}                                |
+      | broadcastEvent                  | {null}                | fdc3.instrument          | uuid-0        | storageApp | libraryApp                       | a1                                    |
 
   Scenario: Opening An App With Context, But No Listener Added
     When "libraryApp/a1" opens app "storageApp" with context data "fdc3.instrument"

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/broadcast.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/broadcast.feature
@@ -18,10 +18,10 @@ Feature: Relaying Broadcast messages
     And we wait for a period of "100" ms
     And "App1/a1" broadcasts "fdc3.instrument" on "one"
     Then messaging will have outgoing posts
-      | msg.matches_type           | to.appId | to.instanceId | msg.payload.channelId | msg.payload.context.type | msg.payload.context.id.ticker |
-      | addContextListenerResponse | App2     | a2            | {null}                | {null}                   | {null}                        |
-      | broadcastEvent             | App2     | a2            | one                   | fdc3.instrument          | AAPL                          |
-      | broadcastResponse          | App1     | a1            | {null}                | {null}                   | {null}                        |
+      | msg.matches_type           | to.appId | to.instanceId | msg.payload.channelId | msg.payload.context.type | msg.payload.context.id.ticker | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | addContextListenerResponse | App2     | a2            | {null}                | {null}                   | {null}                        | {null}                           | {null}                                |
+      | broadcastEvent             | App2     | a2            | one                   | fdc3.instrument          | AAPL                          | App1                             | a1                                    |
+      | broadcastResponse          | App1     | a1            | {null}                | {null}                   | {null}                        | {null}                           | {null}                                |
 
   Scenario: Broadcast message sent but listener has unsubscribed
     When "App2/a2" adds a context listener on "one" with type "fdc3.instrument"

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/private-channel.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/private-channel.feature
@@ -25,10 +25,10 @@ Feature: Relaying Private Channel Broadcast messages
     When "App2/a2" adds a context listener on "{channel1Id}" with type "fdc3.instrument"
     And "App1/a1" broadcasts "fdc3.instrument" on "{channel1Id}"
     Then messaging will have outgoing posts
-      | msg.matches_type           | msg.payload.channelId | msg.payload.context.id.ticker | msg.payload.context.type | to.appId | to.instanceId |
-      | addContextListenerResponse | {null}                | {null}                        | {null}                   | App2     | a2            |
-      | broadcastEvent             | {channel1Id}          | AAPL                          | fdc3.instrument          | App2     | a2            |
-      | broadcastResponse          | {null}                | {null}                        | {null}                   | App1     | a1            |
+      | msg.matches_type           | msg.payload.channelId | msg.payload.context.id.ticker | msg.payload.context.type | to.appId | to.instanceId | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | addContextListenerResponse | {null}                | {null}                        | {null}                   | App2     | a2            | {null}                           | {null}                                |
+      | broadcastEvent             | {channel1Id}          | AAPL                          | fdc3.instrument          | App2     | a2            | App1                             | a1                                    |
+      | broadcastResponse          | {null}                | {null}                        | {null}                   | App1     | a1            | {null}                           | {null}                                |
 
   Scenario: Event Listener created for addContextListener and unsubscribe
     When "App2/a2" adds an "addContextListener" event listener on "{channel1Id}"

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/user-channels.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/user-channels.feature
@@ -38,18 +38,18 @@ Feature: Relaying Private Channel Broadcast messages
     And "App/a1" adds a user-channel context listener with type "fdc3.instrument"
     And "App2/a2" broadcasts "fdc3.instrument" on "one"
     Then messaging will have outgoing posts
-      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  | to.instanceId |
-      | one                   | fdc3.instrument          | broadcastEvent    | a1            |
-      | {null}                | {null}                   | broadcastResponse | a2            |
+      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  | to.instanceId | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | one                   | fdc3.instrument          | broadcastEvent    | a1            | App2                             | a2                                    |
+      | {null}                | {null}                   | broadcastResponse | a2            | {null}                           | {null}                                |
 
   Scenario: Adding an Un-Typed Listener on a given User Channel
     When "App/a1" joins user channel "one"
     And "App/a1" adds a user-channel context listener with type "{null}"
     And "App2/a2" broadcasts "fdc3.instrument" on "one"
     Then messaging will have outgoing posts
-      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  | to.instanceId |
-      | one                   | fdc3.instrument          | broadcastEvent    | a1            |
-      | {null}                | {null}                   | broadcastResponse | a2            |
+      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  | to.instanceId | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | one                   | fdc3.instrument          | broadcastEvent    | a1            | App2                             | a2                                    |
+      | {null}                | {null}                   | broadcastResponse | a2            | {null}                           | {null}                                |
 
   Scenario: If you haven't joined a channel, your listener receives nothing
     When "App/a1" joins user channel "one"
@@ -125,10 +125,10 @@ Feature: Relaying Private Channel Broadcast messages
     And "App2/a2" broadcasts "fdc3.instrument" on "two"
     And "App2/a2" broadcasts "fdc3.country" on "one"
     Then messaging will have outgoing posts
-      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  |
-      | two                   | fdc3.instrument          | broadcastEvent    |
-      | {null}                | {null}                   | broadcastResponse |
-      | {null}                | {null}                   | broadcastResponse |
+      | msg.payload.channelId | msg.payload.context.type | msg.matches_type  | msg.payload.originatingApp.appId | msg.payload.originatingApp.instanceId |
+      | two                   | fdc3.instrument          | broadcastEvent    | App2                             | a2                                    |
+      | {null}                | {null}                   | broadcastResponse | {null}                           | {null}                                |
+      | {null}                | {null}                   | broadcastResponse | {null}                           | {null}                                |
 
   Scenario: You can get the details of the last context type when none is set
     When "App/a1" joins user channel "one"


### PR DESCRIPTION
## Describe your change

Adds support for passing originatingAppmetadata to fdc3-agent-proxy and fdc3-web-impl to match the implementation metadata and specs for agent-proxy. Tests are are included confirming the support.

### Related Issue
resolves #1802

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
