### PR TITLE
Don't publish private packages in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,14 @@ jobs:
             echo "This is a stable release. Will use tag 'latest'."
           fi
 
-      # Create tarballs for each workspace so we can publish the exact same artifacts twice
-      - name: Pack workspaces
+      # Create tarballs for each public workspace so we can publish the exact same artifacts twice
+      - name: Pack workspaces (skip private)
         run: |
           set -euo pipefail
-          npm pack --workspaces
+          for ws in $(npm query ':not(.private)' --workspaces | jq -r '.[].location'); do
+            echo "Packing $ws ..."
+            npm pack --workspace "$ws"
+          done
           echo "Packed tarballs:"
           ls -1 *.tgz
 

--- a/toolbox/fdc3-conformance/package.json
+++ b/toolbox/fdc3-conformance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdc3-conformance",
-  "version": "2.2.0",
+  "version": "2.2.2-beta.1",
   "homepage": "https://fdc3.finos.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Describe your change

The release workflow is failing as it tries to publish a private package (fdc3-conformance), see: https://github.com/finos/FDC3/actions/runs/24356768029

This PR adjusts teh release workflow to filter down to packing and publishing non-private packages only.

### Related Issue

resolves #1844

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?