### PR TITLE
Handle app disconnection in fdc3 reference implementation when working with a websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fixed lint in the fdc3-workbench implementation. ([#1823](https://github.com/finos/FDC3/pull/1823))
 * Stopped fdc3-workbench flagging FDC3 version 2.2 as unsupported. ([#1841](https://github.com/finos/FDC3/pull/1841))
 * Resolved vulnerable dependencies (esbuild, serialize-javascript, elliptic) and consolidated shared devDependencies to simplify future maintenance. ([#1841](https://github.com/finos/FDC3/pull/1841))
+* Fixed the lack of handling of WCP6Disconnect messages in MessagePort example in the FDC3 Web reference implementation. ([#1854](https://github.com/finos/FDC3/pull/1854))
 
 ## [FDC3 Standard 2.2](https://github.com/finos/FDC3/compare/v2.1..v2.2) - 2025-03-12
 

--- a/toolbox/fdc3-for-web/demo/src/client/da/dummy-desktop-agent.ts
+++ b/toolbox/fdc3-for-web/demo/src/client/da/dummy-desktop-agent.ts
@@ -213,7 +213,14 @@ window.addEventListener('load', () => {
                 | BrowserTypes.AppRequestMessage
                 | BrowserTypes.WebConnectionProtocol4ValidateAppIdentity
                 | BrowserTypes.WebConnectionProtocol6Goodbye;
-              fdc3Server.receive(msg, instance.instanceId);
+
+              if (msg.type == 'WCP6Goodbye') {
+                // handle disconnect messages
+                fdc3Server.cleanup(instance.instanceId);
+              } else {
+                // handle DACP messages and WCP4ValidateAppIdentity
+                fdc3Server.receive(msg, instance.instanceId);
+              }
             };
 
             //update the server Context with the MessagePort


### PR DESCRIPTION
## Describe your change

Adds handling of the WCP6Disconnect message in the FDC3 for Web reference implementation (demo package) when working with a MessagePort only. In earlier versions all comms was sent over a websocket, where this was handled. Once the WebSocket was made optional additional handling was needed but ommitted. 

### Related Issue

resolves #1853 

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
