### PR TITLE
[Bugfix] channel changed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Fixed `addEventListener` callback receiving the raw `channelChangedEvent` wire message instead of a properly structured `FDC3ChannelChangedEvent` when a user leaves a channel or when the `currentChannelId` field is used in place of the deprecated `newChannelId` field. ([#1870](https://github.com/finos/FDC3/pull/1870))
+
 ## [npm v2.2.2] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/fdc3",
-  "version": "2.2.2-beta.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/fdc3",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/fdc3-schema",
@@ -17664,25 +17664,25 @@
     },
     "packages/fdc3": {
       "name": "@finos/fdc3",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-context": "2.2.2-beta.1",
-        "@finos/fdc3-get-agent": "2.2.2-beta.1",
-        "@finos/fdc3-schema": "2.2.2-beta.1",
-        "@finos/fdc3-standard": "2.2.2-beta.1"
+        "@finos/fdc3-context": "2.2.2",
+        "@finos/fdc3-get-agent": "2.2.2",
+        "@finos/fdc3-schema": "2.2.2",
+        "@finos/fdc3-standard": "2.2.2"
       }
     },
     "packages/fdc3-agent-proxy": {
       "name": "@finos/fdc3-agent-proxy",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-standard": "2.2.2-beta.1"
+        "@finos/fdc3-standard": "2.2.2"
       },
       "devDependencies": {
         "@cucumber/cucumber": "10.3.1",
-        "@finos/testing": "2.2.2-beta.1",
+        "@finos/testing": "2.2.2",
         "@types/uuid": "^10.0.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "3.3.1",
@@ -17706,10 +17706,10 @@
     },
     "packages/fdc3-commonjs": {
       "name": "@finos/fdc3-commonjs",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3": "2.2.2-beta.1"
+        "@finos/fdc3": "2.2.2"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.1",
@@ -17722,7 +17722,7 @@
     },
     "packages/fdc3-context": {
       "name": "@finos/fdc3-context",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "ajv": "^8.18.0",
@@ -17768,20 +17768,20 @@
     },
     "packages/fdc3-get-agent": {
       "name": "@finos/fdc3-get-agent",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-agent-proxy": "2.2.2-beta.1",
-        "@finos/fdc3-context": "2.2.2-beta.1",
-        "@finos/fdc3-schema": "2.2.2-beta.1",
-        "@finos/fdc3-standard": "2.2.2-beta.1",
+        "@finos/fdc3-agent-proxy": "2.2.2",
+        "@finos/fdc3-context": "2.2.2",
+        "@finos/fdc3-schema": "2.2.2",
+        "@finos/fdc3-standard": "2.2.2",
         "@types/uuid": "^10.0.0",
         "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@cucumber/cucumber": "10.3.1",
-        "@finos/fdc3-web-impl": "2.2.2-beta.1",
-        "@finos/testing": "2.2.2-beta.1",
+        "@finos/fdc3-web-impl": "2.2.2",
+        "@finos/testing": "2.2.2",
         "@types/wtfnode": "^0.7.3",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
@@ -17823,7 +17823,7 @@
     },
     "packages/fdc3-schema": {
       "name": "@finos/fdc3-schema",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "message-await": "^1.1.0",
@@ -17849,11 +17849,11 @@
     },
     "packages/fdc3-standard": {
       "name": "@finos/fdc3-standard",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-context": "2.2.2-beta.1",
-        "@finos/fdc3-schema": "2.2.2-beta.1"
+        "@finos/fdc3-context": "2.2.2",
+        "@finos/fdc3-schema": "2.2.2"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
@@ -17866,13 +17866,13 @@
     },
     "packages/testing": {
       "name": "@finos/testing",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@cucumber/cucumber": "10.3.1",
         "@cucumber/html-formatter": "11.0.4",
         "@cucumber/pretty-formatter": "1.0.1",
-        "@finos/fdc3-standard": "2.2.2-beta.1",
+        "@finos/fdc3-standard": "2.2.2",
         "@types/expect": "24.3.0",
         "@types/lodash": "4.14.167",
         "@types/uuid": "^10.0.0",
@@ -17920,10 +17920,10 @@
       }
     },
     "toolbox/fdc3-conformance": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3": "2.2.2-beta.1",
+        "@finos/fdc3": "2.2.2",
         "buffer": "^6.0.3",
         "chai": "^4.3.6",
         "get-func-name": "^2.0.2",
@@ -18014,10 +18014,10 @@
     },
     "toolbox/fdc3-for-web/demo": {
       "name": "@finos/demo",
-      "version": "2.2.0",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3": "2.2.2-beta.1",
+        "@finos/fdc3": "2.2.2",
         "@types/uuid": "^10.0.0",
         "@types/ws": "^8.5.12",
         "express": "^4.21.1",
@@ -18628,10 +18628,10 @@
     },
     "toolbox/fdc3-for-web/fdc3-web-impl": {
       "name": "@finos/fdc3-web-impl",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-standard": "2.2.2-beta.1",
+        "@finos/fdc3-standard": "2.2.2",
         "@types/uuid": "^10.0.0",
         "uuid": "^9.0.1"
       },
@@ -18640,7 +18640,7 @@
         "@cucumber/html-formatter": "11.0.4",
         "@cucumber/messages": "^28.1.0",
         "@cucumber/pretty-formatter": "1.0.1",
-        "@finos/testing": "2.2.2-beta.1",
+        "@finos/testing": "2.2.2",
         "@types/expect": "24.3.0",
         "@types/lodash": "4.14.167",
         "@types/uuid": "^10.0.0",
@@ -18692,10 +18692,10 @@
     },
     "toolbox/fdc3-for-web/reference-ui": {
       "name": "fdc3-for-web-reference-ui",
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3": "2.2.2-beta.1"
+        "@finos/fdc3": "2.2.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -19282,7 +19282,7 @@
       }
     },
     "toolbox/fdc3-workbench": {
-      "version": "2.2.2-beta.1",
+      "version": "2.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@apidevtools/json-schema-ref-parser": "11.7.2",
@@ -19290,7 +19290,7 @@
         "@emotion/styled": "^11.11.5",
         "@eslint/compat": "^1.2.5",
         "@eslint/js": "^9.19.0",
-        "@finos/fdc3": "2.2.2-beta.1",
+        "@finos/fdc3": "2.2.2",
         "@fontsource/roboto": "5.1.0",
         "@fontsource/source-code-pro": "5.1.0",
         "@mui/icons-material": "^5.15.20",

--- a/packages/fdc3-agent-proxy/src/listeners/DesktopAgentEventListener.ts
+++ b/packages/fdc3-agent-proxy/src/listeners/DesktopAgentEventListener.ts
@@ -8,22 +8,30 @@ import {
 import { Messaging } from '../Messaging.js';
 import { AbstractListener } from './AbstractListener.js';
 
+const handleChannelChangedEvent = (handler: EventHandler, m: ChannelChangedEvent) => {
+  const currentChannelId = m.payload.currentChannelId ?? m.payload.newChannelId ?? null;
+
+  const channelChangedEvent: FDC3ChannelChangedEvent = {
+    type: 'userChannelChanged',
+    details: {
+      currentChannelId,
+    },
+  };
+
+  handler(channelChangedEvent);
+};
+
 function wrapHandler(handler: EventHandler): (msg: AgentEventMessage) => void {
   return (m: AgentEventMessage) => {
-    if (m.type !== 'channelChangedEvent') {
-      return;
+    if (m.type === 'channelChangedEvent') {
+      return handleChannelChangedEvent(handler, m);
     }
 
-    const currentChannelId = m.payload.currentChannelId ?? m.payload.newChannelId ?? null;
-
-    const channelChangedEvent: FDC3ChannelChangedEvent = {
-      type: 'userChannelChanged',
-      details: {
-        currentChannelId,
-      },
-    };
-
-    handler(channelChangedEvent);
+    //forward other events
+    handler({
+      type: m.type,
+      details: m.payload,
+    });
   };
 }
 

--- a/packages/fdc3-agent-proxy/src/listeners/DesktopAgentEventListener.ts
+++ b/packages/fdc3-agent-proxy/src/listeners/DesktopAgentEventListener.ts
@@ -10,23 +10,20 @@ import { AbstractListener } from './AbstractListener.js';
 
 function wrapHandler(handler: EventHandler): (msg: AgentEventMessage) => void {
   return (m: AgentEventMessage) => {
-    //backwards compatibility, see issue #1585
-    if (m.type === 'channelChangedEvent' && m.payload.newChannelId) {
-      const restructured: FDC3ChannelChangedEvent = {
-        type: 'userChannelChanged',
-        details: {
-          currentChannelId: m.payload.newChannelId,
-        },
-      };
-
-      handler(restructured);
-    } else {
-      // currently unused but meeting issue #1585
-      handler({
-        type: m.type,
-        details: m.payload,
-      });
+    if (m.type !== 'channelChangedEvent') {
+      return;
     }
+
+    const currentChannelId = m.payload.currentChannelId ?? m.payload.newChannelId ?? null;
+
+    const channelChangedEvent: FDC3ChannelChangedEvent = {
+      type: 'userChannelChanged',
+      details: {
+        currentChannelId,
+      },
+    };
+
+    handler(channelChangedEvent);
   };
 }
 

--- a/packages/fdc3-agent-proxy/test/features/user-channels.feature
+++ b/packages/fdc3-agent-proxy/test/features/user-channels.feature
@@ -267,6 +267,52 @@ Feature: Basic User Channels Support
     When I call "{api}" with "addEventListener" with parameters "unknownEventType" and "{typesHandler}"
     Then "{result}" is an error with message "UnknownEventType"
 
+  Scenario: User Channel Changed Event fires when currentChannelId field is used
+    Given "typesHandler" pipes events to "types"
+    And "modernMessage" is a channelChangedEvent message with currentChannelId "channelX"
+    When I call "{api}" with "addEventListener" with parameters "userChannelChanged" and "{typesHandler}"
+    And I refer to "{result}" as "theListener"
+    And messaging receives "{modernMessage}"
+    Then "{types}" is an array of objects with the following contents
+      | currentChannelId |
+      | channelX         |
+
+  Scenario: User Channel Changed Event fires when user leaves a channel via currentChannelId null
+    Given "typesHandler" pipes events to "types"
+    And "leaveMessage" is a channelChangedEvent message with currentChannelId "{null}"
+    When I call "{api}" with "addEventListener" with parameters "userChannelChanged" and "{typesHandler}"
+    And I refer to "{result}" as "theListener"
+    And messaging receives "{leaveMessage}"
+    Then "{types}" is an array of objects with the following contents
+      | currentChannelId |
+      | {null}           |
+
+  Scenario: User Channel Changed Event fires when user leaves a channel via deprecated newChannelId null
+    Given "typesHandler" pipes events to "types"
+    And "leaveMessageDeprecated" is a channelChangedEvent message on channel "{null}"
+    When I call "{api}" with "addEventListener" with parameters "userChannelChanged" and "{typesHandler}"
+    And I refer to "{result}" as "theListener"
+    And messaging receives "{leaveMessageDeprecated}"
+    Then "{types}" is an array of objects with the following contents
+      | currentChannelId |
+      | {null}           |
+
+  Scenario: currentChannelId takes precedence over deprecated newChannelId in channel changed events
+    Given "typesHandler" pipes events to "types"
+    And "bothFieldsMessage" is a channelChangedEvent message with currentChannelId "modern" and newChannelId "deprecated"
+    When I call "{api}" with "addEventListener" with parameters "userChannelChanged" and "{typesHandler}"
+    And I refer to "{result}" as "theListener"
+    And messaging receives "{bothFieldsMessage}"
+    Then "{types}" is an array of objects with the following contents
+      | currentChannelId |
+      | modern           |
+
+  Scenario: Wildcard event listener does not fire for non-channelChangedEvent messages
+    Given "typesHandler" pipes events to "types"
+    When I call "{api}" with "addEventListener" with parameters "{null}" and "{typesHandler}"
+    And messaging receives "{instrumentMessageOne}"
+    Then "{types}" is empty
+
   Scenario: Destructured getUserChannels returns user channels
     When I destructure method "getUserChannels" from "{api}"
     And I call destructured "getUserChannels"

--- a/packages/fdc3-agent-proxy/test/features/user-channels.feature
+++ b/packages/fdc3-agent-proxy/test/features/user-channels.feature
@@ -307,11 +307,13 @@ Feature: Basic User Channels Support
       | currentChannelId |
       | modern           |
 
-  Scenario: Wildcard event listener does not fire for non-channelChangedEvent messages
+  Scenario: Wildcard event listener fires and forwards non-channelChangedEvent messages
     Given "typesHandler" pipes events to "types"
     When I call "{api}" with "addEventListener" with parameters "{null}" and "{typesHandler}"
     And messaging receives "{instrumentMessageOne}"
-    Then "{types}" is empty
+    Then "{types}" is an array of objects with the following contents
+      | channelId | context.type    |
+      | one       | fdc3.instrument |
 
   Scenario: Destructured getUserChannels returns user channels
     When I destructure method "getUserChannels" from "{api}"

--- a/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
+++ b/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
@@ -114,6 +114,43 @@ Given(
 );
 
 Given(
+  '{string} is a channelChangedEvent message with currentChannelId {string}',
+  (world: CustomWorld, field: string, channelId: string) => {
+    const message: ChannelChangedEvent = {
+      meta: {
+        eventUuid: world.messaging!.createUUID(),
+        timestamp: new Date(),
+      },
+      payload: {
+        currentChannelId: handleResolve(channelId, world),
+      },
+      type: 'channelChangedEvent',
+    };
+
+    world.props[field] = message;
+  }
+);
+
+Given(
+  '{string} is a channelChangedEvent message with currentChannelId {string} and newChannelId {string}',
+  (world: CustomWorld, field: string, currentChannelId: string, newChannelId: string) => {
+    const message: ChannelChangedEvent = {
+      meta: {
+        eventUuid: world.messaging!.createUUID(),
+        timestamp: new Date(),
+      },
+      payload: {
+        currentChannelId: handleResolve(currentChannelId, world),
+        newChannelId: handleResolve(newChannelId, world),
+      },
+      type: 'channelChangedEvent',
+    };
+
+    world.props[field] = message;
+  }
+);
+
+Given(
   '{string} is a PrivateChannelOnUnsubscribeEvent message on channel {string} with contextType as {string}',
   (world: CustomWorld, field: string, channel: string, contextType: string) => {
     const message = {


### PR DESCRIPTION
## Describe your change

The `addEventListener` callback was invoked with the wrong event object when a user left a channel. Also, the `currentChannelId` payload field was not used properly, since `newChannelId` is deprecated.

### Related Issue

Resolves #1869 

## Review Checklist

<!--- 
If you've changed docs or schemas make sure you run code and documentation tasks before raising your PR.
To do so, run: 
    - Code generation and build: `npm run build`
    - Docs generation and preview `cd website; npm run start`
Once run, any modified files can be committed and added to your PR for review.
--->
<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?