### PR TITLE
Added FDC3 API Metadata support to the Go language binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Added Go language binding. ([#1483](https://github.com/finos/FDC3/pull/1483))
-* Added FDC3 API Metadata support to the Go language binding. ([]())
+* Added FDC3 API Metadata support to the Go language binding. ([#1905](https://github.com/finos/FDC3/pull/1905))
 * Added details of and procedures for resolving fully-qualified appIds and unqualified appIds in the API and Bridging Parts of the Standard. ([#1523](https://github.com/finos/FDC3/pull/1523))
 * Added clarification regarding expected behavior upon repeated calls to `addContextListener` on same or overlapping types (allowed) and `addIntentListener` on same intent (rejected; new error type added). ([#1394](https://github.com/finos/FDC3/pull/1394))
 * Added `clearContext` function and associated `contextClearedEvent` to the `Channel` API, to be able to clear specific or all context types from the channel. ([#1379](https://github.com/finos/FDC3/pull/1379))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 * Added Go language binding. ([#1483](https://github.com/finos/FDC3/pull/1483))
+* Added FDC3 API Metadata support to the Go language binding. ([]())
 * Added details of and procedures for resolving fully-qualified appIds and unqualified appIds in the API and Bridging Parts of the Standard. ([#1523](https://github.com/finos/FDC3/pull/1523))
 * Added clarification regarding expected behavior upon repeated calls to `addContextListener` on same or overlapping types (allowed) and `addIntentListener` on same intent (rejected; new error type added). ([#1394](https://github.com/finos/FDC3/pull/1394))
 * Added `clearContext` function and associated `contextClearedEvent` to the `Channel` API, to be able to clear specific or all context types from the channel. ([#1379](https://github.com/finos/FDC3/pull/1379))

--- a/website/docs/api/ref/Channel.md
+++ b/website/docs/api/ref/Channel.md
@@ -71,8 +71,9 @@ interface IChannel: IIntentResult
 ```go
 @experimental
 type IChannel interface {
-    Broadcast(context Context) <-chan Result[any]
+    Broadcast(context Context, metadata *AppProvidableContextMetadata) <-chan Result[any]
     GetCurrentContext(contextType string) <-chan Result[IContext]
+    GetCurrentContextWithMetadata(contextType string) <-chan Result[ContextWithMetadata]
     AddContextListener(contextType string, handler ContextHandler) <-chan Result[Listener]
 }
 
@@ -445,7 +446,7 @@ Task Broadcast(IContext context);
 <TabItem value="golang" label="Go">
 
 ```go
-func (channel *Channel) Broadcast(context IContext) <-chan Result[any]  { 
+func (channel *Channel) Broadcast(context IContext, metadata *AppProvidableContextMetadata) <-chan Result[any]  { 
   // Implementation here
 }
 ```
@@ -666,6 +667,15 @@ Task<IContextWithMetadata?> GetCurrentContextWithMetadata(string? contextType);
 ```
 
 </TabItem>
+<TabItem value="golang" label="Go">
+
+```go
+func (channel *Channel) GetCurrentContextWithMetadata(contextType string) <-chan Result[ContextWithMetadata]  { 
+  // Implementation here
+}
+```
+
+</TabItem>
 </Tabs>
 
 Returns the most recent context that was broadcast on the channel along with its associated [`ContextMetadata`](Metadata#contextmetadata), or `null` if no matching context is found.
@@ -708,6 +718,19 @@ try
 catch (Exception ex)
 {
     // handle error
+}
+```
+
+</TabItem>
+<TabItem value="golang" label="Go">
+
+```go
+result := <-myChannel.GetCurrentContextWithMetadata("fdc3.contact")
+if result.Err != nil {
+    // handle error 
+}
+if result.Value != nil {
+    fmt.Printf("Context from %s\n", result.Value.Metadata.Source.AppId)
 }
 ```
 

--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -118,19 +118,19 @@ type DesktopAgent struct {}
 @experimental
 type IDesktopAgent interface {
     // Apps
-    Open(appIdentifier AppIdentifier, context *IContext) <-chan Result[AppIdentifier]
+    Open(appIdentifier AppIdentifier, context *IContext, metadata *AppProvidableContextMetadata) <-chan Result[AppIdentifier]
     FindInstances(appIdentifier AppIdentifier) <-chan Result[[]AppIdentifier]
     GetAppMetadata(appIdentifier AppIdentifier) <-chan Result[AppIdentifier]
 
     // Context
-    Broadcast(context IContext) <-chan Result[any]
+    Broadcast(context IContext, metadata *AppProvidableContextMetadata) <-chan Result[any]
     AddContextListener(contextType string, handler ContextHandler) <-chan Result[Listener]
 
     // Intents
     FindIntent(intent string, context *IContext, resultType *string) <-chan Result[AppIntent]
     FindIntentsByContext(context IContext, resultType *string) <-chan Result[[]AppIntent]
-    RaiseIntent(intent string, context IContext, appIdentifier *AppIdentifier) <-chan Result[IntentResolution]
-    RaiseIntentForContext(context IContext, appIdentifier *AppIdentifier) <-chan Result[IntentResolution]
+    RaiseIntent(intent string, context IContext, appIdentifier *AppIdentifier, metadata *AppProvidableContextMetadata) <-chan Result[IntentResolution]
+    RaiseIntentForContext(context IContext, appIdentifier *AppIdentifier, metadata *AppProvidableContextMetadata) <-chan Result[IntentResolution]
     AddIntentListener(intent string, handler IntentHandler) <-chan Result[Listener]
 
     // Channels
@@ -496,7 +496,7 @@ Task Broadcast(IContext context);
 <TabItem value="golang" label="Go">
 
 ```go
-func (desktopAgent *DesktopAgent) Broadcast(context IContext) <-chan Result[any]  { 
+func (desktopAgent *DesktopAgent) Broadcast(context IContext, metadata *AppProvidableContextMetadata) <-chan Result[any]  { 
   // Implmentation here
 }
 ```
@@ -1699,7 +1699,7 @@ Task<IAppIdentifier> Open(IAppIdentifier app, IContext? context = null);
 <TabItem value="golang" label="Go">
 
 ```go
-func (desktopAgent *DesktopAgent) Open(appIdentifier AppIdentifier, context *IContext) <-chan Result[AppIdentifier] {
+func (desktopAgent *DesktopAgent) Open(appIdentifier AppIdentifier, context *IContext, metadata *AppProvidableContextMetadata) <-chan Result[AppIdentifier] {
   // Implementation here
 }
 ```
@@ -1792,7 +1792,7 @@ Task<IIntentResolution> RaiseIntent(string intent, IContext context, IAppIdentif
 <TabItem value="golang" label="Go">
 
 ```go
-func (desktopAgent *DesktopAgent) RaiseIntent(intent string, context IContext, appIdentifier *AppIdentifier) <-chan Result[IntentResolution] {
+func (desktopAgent *DesktopAgent) RaiseIntent(intent string, context IContext, appIdentifier *AppIdentifier, metadata *AppProvidableContextMetadata) <-chan Result[IntentResolution] {
   // Implementation here
 }
 ```
@@ -1935,7 +1935,7 @@ Task<IIntentResolution> RaiseIntentForContext(IContext context, IAppIdentifier? 
 <TabItem value="golang" label="Go">
 
 ```go
-func (desktopAgent *DesktopAgent) RaiseIntentForContext(context IContext, appIdentifier *AppIdentifier) <-chan Result[IntentResolution] {
+func (desktopAgent *DesktopAgent) RaiseIntentForContext(context IContext, appIdentifier *AppIdentifier, metadata *AppProvidableContextMetadata) <-chan Result[IntentResolution] {
   // Implementation here
 }
 ```

--- a/website/docs/api/ref/Metadata.md
+++ b/website/docs/api/ref/Metadata.md
@@ -938,6 +938,11 @@ type IntentResult any
 func (ir *IntentResolution) GetResult() <-chan Result[IntentResult] {
   // implementation here
 }
+
+// getResultMetadata retrieves the ContextMetadata for the intent result.
+func (resolution *IntentResolution) GetResultMetadata() <-chan Result[ContextMetadata] {
+  // Implementation here
+}
 ```
 
 </TabItem>
@@ -1061,6 +1066,13 @@ If an error occurs (i.e. an error is thrown by the handler function, the promise
 
 ```ts
 getResultMetadata(): Promise<ContextMetadata>;
+```
+
+</TabItem>
+<TabItem value="golang" label="Go">
+
+```go
+func (resolution *IntentResolution) GetResultMetadata() <-chan Result[ContextMetadata]
 ```
 
 </TabItem>


### PR DESCRIPTION
## Describe your change
Added FDC3 API Metadata support to the Go language binding

### Related Issue
resolves #1893  

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- 
If you've changed docs or schemas make sure you run code and documentation tasks before raising your PR.
To do so, run: 
    - Code generation and build: `npm run build`
    - Docs generation and preview `cd website; npm run start`
Once run, any modified files can be committed and added to your PR for review.
--->
<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
