### PR TITLE
Add labels and tooltips to the fdc3-for-web ref implementation demo 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   * `fdc3-example-apps` toolbox with runnable security demos (identity provider apps, Login POC, signed broadcast, encrypted channels).
   * READMEs, Glossary entries and an API spec introduction for securing inter-app communication.
 * Added engines restriction to all package.json files requiring at least node 22 for all packages. ([#1926](https://github.com/finos/FDC3/pull/1926))
+* Added labels and tooltips to dropdowns in the FDC3 for Web reference implementation demo. ([#193](https://github.com/finos/FDC3/pull/1932))
 
 ### Changed
 

--- a/toolbox/fdc3-for-web/demo/static/da/index.html
+++ b/toolbox/fdc3-for-web/demo/static/da/index.html
@@ -14,21 +14,38 @@
         </h1>
     </header>
 
-    <select name="opener" id="opener">
-        <option value="Frame" default>Frame</option>
-        <option value="Tab">New Tab</option>
-    </select>
+    <div style="display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; font-family: sans-serif;">
+        <div>
+            <label for="opener" style="display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; color: #555;">App Opener</label>
+            <select name="opener" id="opener"
+                    title="Controls whether new applications are opened in iframes in the current page or as new tabs in a separate browser window"
+                    aria-label="App opener: choose whether apps open in iframes or new tabs">
+                <option value="Frame" default>Frame</option>
+                <option value="Tab">New Tab</option>
+            </select>
+        </div>
 
-    <select name="approach" id="approach">
-        <option value="IFRAME">Create Iframe</option>
-        <option value="PARENT_POST_MESSAGE" default>Parent Post-Message</option>
-    </select>
+        <div>
+            <label for="approach" style="display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; color: #555;">Communication Approach</label>
+            <select name="approach" id="approach"
+                    title="Controls the approach the Desktop Agent uses to communicate with FDC3 apps: direct communication over the app's window/frame, or injection of a hidden iframe by getAgent for comms"
+                    aria-label="Communication approach: direct post-message or injected iframe for Desktop Agent comms">
+                <option value="IFRAME">Create Iframe</option>
+                <option value="PARENT_POST_MESSAGE" default>Parent Post-Message</option>
+            </select>
+        </div>
 
-    <select name="ui" id="ui">
-        <option value="DEMO" default>Demo's Own Implementation</option>
-        <option value="DEFAULT">Default Web FDC3 (Running on fdc3.finos.org)</option>
-        <option value="LOCAL">Default Web FDC3 (Running on Localhost)</option>
-    </select>
+        <div>
+            <label for="ui" style="display: block; font-size: 12px; font-weight: 600; margin-bottom: 4px; color: #555;">App Selector UI</label>
+            <select name="ui" id="ui"
+                    title="Controls which App Selector UI is injected into applications by the Desktop Agent, demonstrating that UI selection is driven by the Desktop Agent"
+                    aria-label="App selector UI: choose which intent resolver UI the Desktop Agent injects into apps">
+                <option value="DEMO" default>Demo's Own Implementation</option>
+                <option value="DEFAULT">Default Web FDC3 (Running on fdc3.finos.org)</option>
+                <option value="LOCAL">Default Web FDC3 (Running on Localhost)</option>
+            </select>
+        </div>
+    </div>
 
     <div id="app-list"></div>
     <div id="app-frames"></div>


### PR DESCRIPTION
## Describe your change

The drop downs in the  FDC3 for Web reference demo don't have labels and are confusing - as one of them doesn't produce any visible difference (changes under-the-hood-communications). This small PR adds labels and tooltips:

<img width="912" height="387" alt="image" src="https://github.com/user-attachments/assets/7e96fc9e-2fd2-48ae-88c9-acea736fafb8" />

### Related Issue

N/A

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?