### PR TITLE
Remove deprecated `name` and `customConfig` from AppD specification (#1937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 * Removed deprecated functions from the Desktop Agent, Channel and PrivateChannel APIs for deprecations applied in FDC3 2.0-2.2 ([#1928](https://github.com/finos/FDC3/pull/1928))
+* Removed the deprecated `name` and `customConfig` properties from the App Directory `Application` record (`BaseApplication`) in the AppD specification, deprecated since FDC3 2.0. ([#1937](https://github.com/finos/FDC3/issues/1937))
 
 ### Deprecated
 

--- a/packages/fdc3-standard/src/app-directory/specification/appd.schema.json
+++ b/packages/fdc3-standard/src/app-directory/specification/appd.schema.json
@@ -467,11 +467,6 @@
 			"details": {
 			  "$ref": "#/components/schemas/LaunchDetails"
 			},
-			"name": {
-			  "type": "string",
-			  "description": "Deprecated in favour of using `appId` to identify apps and `title` for their display names. The name of the application. The name should be unique within an FDC3 App Directory instance. The exception to the uniqueness constraint is that an App Directory can hold definitions for multiple versions of the same app. The same appName could occur in other directories. We are not currently specifying app name conventions in the document.",
-			  "deprecated": true
-			},
 			"version": {
 			  "type": "string",
 			  "description": "Version of the application. This allows multiple app versions to be defined using the same app name. This can be a triplet but can also include things like 1.2.5 (BETA)"
@@ -528,14 +523,6 @@
 			"publisher": {
 			  "type": "string",
 			  "description": "The name of the company that owns the application. The publisher has control over their namespace/app/signature."
-			},
-			"customConfig": {
-			  "deprecated": true,
-			  "type": "array",
-			  "description": "An optional set of name value pairs that can be used to deliver custom data from an App Directory to a launcher. Deprecated due to a lack of a standard means of retrieval via the Desktop Agent API. To be replaced in a future version with an `applicationConfig` element and standard API to retrieve it. See issue  [#1006](https://github.com/finos/FDC3/issues/1006) for details.",
-			  "items": {
-				"$ref": "#/components/schemas/NameValuePair"
-			  }
 			},
 			"hostManifests": {
 			  "$ref": "#/components/schemas/HostManifests"

--- a/packages/fdc3-standard/src/app-directory/specification/examples/application/fdc3-workbench.json
+++ b/packages/fdc3-standard/src/app-directory/specification/examples/application/fdc3-workbench.json
@@ -1,6 +1,5 @@
 {
   "appId": "fdc3-workbench",
-  "name": "fdc3-workbench",
   "title": "FDC3 Workbench",
   "description": "Development and test tool for FDC3 desktop agents and apps",
   "categories": [

--- a/packages/fdc3-standard/src/app-directory/specification/examples/application/myApplication.json
+++ b/packages/fdc3-standard/src/app-directory/specification/examples/application/myApplication.json
@@ -1,6 +1,5 @@
 {
 	"appId": "my-application",
-	"name": "my-application",
 	"title": "My Application",
 	"description": "An example application that uses FDC3 and fully describes itself in an AppD record.",
 	"categories": [

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/OpenHandler.ts
@@ -212,7 +212,6 @@ export class OpenHandler implements MessageHandler {
   filterPublicDetails(appD: DirectoryApp, appID: AppIdentifier): AppMetadata {
     return {
       appId: appD.appId,
-      name: appD.name,
       version: appD.version,
       title: appD.title,
       tooltip: appD.tooltip,

--- a/website/static/schemas/next/appd.schema.json
+++ b/website/static/schemas/next/appd.schema.json
@@ -467,11 +467,6 @@
 			"details": {
 			  "$ref": "#/components/schemas/LaunchDetails"
 			},
-			"name": {
-			  "type": "string",
-			  "description": "Deprecated in favour of using `appId` to identify apps and `title` for their display names. The name of the application. The name should be unique within an FDC3 App Directory instance. The exception to the uniqueness constraint is that an App Directory can hold definitions for multiple versions of the same app. The same appName could occur in other directories. We are not currently specifying app name conventions in the document.",
-			  "deprecated": true
-			},
 			"version": {
 			  "type": "string",
 			  "description": "Version of the application. This allows multiple app versions to be defined using the same app name. This can be a triplet but can also include things like 1.2.5 (BETA)"
@@ -528,14 +523,6 @@
 			"publisher": {
 			  "type": "string",
 			  "description": "The name of the company that owns the application. The publisher has control over their namespace/app/signature."
-			},
-			"customConfig": {
-			  "deprecated": true,
-			  "type": "array",
-			  "description": "An optional set of name value pairs that can be used to deliver custom data from an App Directory to a launcher. Deprecated due to a lack of a standard means of retrieval via the Desktop Agent API. To be replaced in a future version with an `applicationConfig` element and standard API to retrieve it. See issue  [#1006](https://github.com/finos/FDC3/issues/1006) for details.",
-			  "items": {
-				"$ref": "#/components/schemas/NameValuePair"
-			  }
 			},
 			"hostManifests": {
 			  "$ref": "#/components/schemas/HostManifests"


### PR DESCRIPTION
## Describe your change

Removes the `name` and `customConfig` properties from the App Directory `Application` record. Both were deprecated back in FDC3 2.0, so they should no longer appear in the FDC3 3.0 AppD specification.

Changes:
- Removed `name` and `customConfig` from the `BaseApplication` schema in `packages/fdc3-standard/src/app-directory/specification/appd.schema.json`.
- Removed the now-unused `name` property from the AppD example payloads (`myApplication.json`, `fdc3-workbench.json`).
- Regenerated the website's `static/schemas/next/appd.schema.json` via `npm run copy-appd`.
- Added a `### Removed` entry to `CHANGELOG.md`.

Scope notes (intentionally left untouched to keep this scoped to the issue):
- The legacy `ApplicationV1` / `IntentV1` schemas.
- `Intent.customConfig`, which is a separate, differently-motivated deprecation.
- The `NameValuePair` schema, which is still referenced by the above.

Happy to expand scope in a follow-up if maintainers prefer.

### Related Issue

Resolves #1937.

Complements #1928 (which removed deprecated Desktop Agent / Channel API functions); this PR handles the AppD spec side. Kept independent of the ongoing AppD work in #1926 so it can merge on its own.

### Contributor License Agreement (CLA)

A CLA is required to contribute to this project - please refer to the CONTRIBUTING.md file for details. By raising this Pull Request I confirm I am covered by an applicable CLA.
