### PR TITLE
fix(workbench): update FDC3 context examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+* Added standalone Workbench examples for the FDC3 2.2 `fdc3.action`, `fdc3.fileAttachment`, `fdc3.message`, `fdc3.orderList`, `fdc3.tradeList`, and `fdc3.timeRange` context types. ([#1949](https://github.com/finos/FDC3/pull/1949))
 * Added advanced conformance tests (`fdc3.intentListenerConflict`) covering intent listener conflicts, verifying that `addIntentListener`/`addIntentListenerWithContext` reject with `ResolveError.IntentListenerConflict` for conflicting listeners (unfiltered, or overlapping context types) and allow non-overlapping filtered listeners, listeners for different intents, and re-adding after `unsubscribe()`. Added the corresponding test definitions to the "Avoiding Adding Multiple Intent Listeners" section of the Intents conformance docs.
 * Added a classification field to Instrument context type ([#1665](https://github.com/finos/FDC3/pull/1665))
 * Added Go language binding. ([#1483](https://github.com/finos/FDC3/pull/1483))

--- a/toolbox/fdc3-workbench/src/fixtures/contexts.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/contexts.ts
@@ -11,9 +11,9 @@ export const contexts: ContextItem[] = [
     id: 'Action example',
     template: {
       type: 'fdc3.action',
-      action: 'raiseIntent',
+      action: 'broadcast',
+      channelId: 'Channel 1',
       title: 'Click to view Chart',
-      intent: 'ViewChart',
       context: {
         type: 'fdc3.chart',
         instruments: [
@@ -30,10 +30,6 @@ export const contexts: ContextItem[] = [
           endTime: '2020-10-31T08:00:00.000Z',
         },
         style: 'candle',
-      },
-      app: {
-        appId: 'MyChartViewingApp',
-        instanceId: 'instance1',
       },
     },
     schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/action.schema.json'),
@@ -555,61 +551,6 @@ export const contexts: ContextItem[] = [
       },
     },
     schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/product.schema.json'),
-  },
-  {
-    uuid: uuidv4(),
-    id: 'Security encrypted context example',
-    template: {
-      type: 'fdc3.security.encryptedContext',
-      originalType: 'fdc3.instrument',
-      id: {
-        kid: 'channel-key-abc123',
-      },
-      encryptedPayload: 'eyJuYW1lIjoiQXBwbGUiLCJpZCI6eyJ0aWNrZXIiOiJBQVBMIn19...',
-    },
-    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/encrypted.schema.json'),
-  },
-  {
-    uuid: uuidv4(),
-    id: 'Security symmetric key request example',
-    template: {
-      type: 'fdc3.security.symmetricKeyRequest',
-      id: {
-        kid: 'channel-key-abc123',
-      },
-    },
-    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/symmetricKeyRequest.schema.json'),
-  },
-  {
-    uuid: uuidv4(),
-    id: 'Security symmetric key response example',
-    template: {
-      type: 'fdc3.security.symmetricKeyResponse',
-      id: {
-        kid: 'key-id-123',
-        pki: 'https://examples.com/myJWKSendpoint',
-      },
-      wrappedKey: 'u4jvA7Gx8LdH...==',
-    },
-    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/symmetricKeyResponse.schema.json'),
-  },
-  {
-    uuid: uuidv4(),
-    id: 'Security user example',
-    template: {
-      type: 'fdc3.security.user',
-      wrappedJwt: '--example-jwt-token--but-wrapped-in-the-public-key-of-the-requester--',
-    },
-    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/user.schema.json'),
-  },
-  {
-    uuid: uuidv4(),
-    id: 'Security user request example',
-    template: {
-      type: 'fdc3.security.userRequest',
-      aud: 'https://my-app-url.com',
-    },
-    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/userRequest.schema.json'),
   },
   {
     uuid: uuidv4(),

--- a/toolbox/fdc3-workbench/src/fixtures/contexts.ts
+++ b/toolbox/fdc3-workbench/src/fixtures/contexts.ts
@@ -8,6 +8,38 @@ import { v4 as uuidv4 } from 'uuid';
 export const contexts: ContextItem[] = [
   {
     uuid: uuidv4(),
+    id: 'Action example',
+    template: {
+      type: 'fdc3.action',
+      action: 'raiseIntent',
+      title: 'Click to view Chart',
+      intent: 'ViewChart',
+      context: {
+        type: 'fdc3.chart',
+        instruments: [
+          {
+            type: 'fdc3.instrument',
+            id: {
+              ticker: 'EURUSD',
+            },
+          },
+        ],
+        range: {
+          type: 'fdc3.timeRange',
+          startTime: '2020-09-01T08:00:00.000Z',
+          endTime: '2020-10-31T08:00:00.000Z',
+        },
+        style: 'candle',
+      },
+      app: {
+        appId: 'MyChartViewingApp',
+        instanceId: 'instance1',
+      },
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/action.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
     id: 'Chart example',
     template: {
       type: 'fdc3.chart',
@@ -151,6 +183,9 @@ export const contexts: ContextItem[] = [
         {
           type: 'fdc3.organization',
           name: 'Symphony',
+          id: {
+            FDS_ID: 'SYMPHONY',
+          },
         },
         '#OrderID45788422',
       ],
@@ -233,6 +268,19 @@ export const contexts: ContextItem[] = [
       textBody: 'Blah, blah, blah ...',
     },
     schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/email.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'File attachment example',
+    template: {
+      type: 'fdc3.fileAttachment',
+      data: {
+        name: 'myImage.png',
+        dataUri:
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
+      },
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/fileAttachment.schema.json'),
   },
   {
     uuid: uuidv4(),
@@ -326,6 +374,49 @@ export const contexts: ContextItem[] = [
   },
   {
     uuid: uuidv4(),
+    id: 'Message example',
+    template: {
+      type: 'fdc3.message',
+      text: {
+        'text/plain': 'Hey all, can we discuss the issue together? I attached a screenshot and a chart link.',
+      },
+      entities: {
+        picture1: {
+          type: 'fdc3.fileAttachment',
+          data: {
+            name: 'myImage.png',
+            dataUri:
+              'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII',
+          },
+        },
+        viewChart: {
+          type: 'fdc3.action',
+          title: 'Click to view Chart',
+          intent: 'ViewChart',
+          context: {
+            type: 'fdc3.chart',
+            instruments: [
+              {
+                type: 'fdc3.instrument',
+                id: {
+                  ticker: 'EURUSD',
+                },
+              },
+            ],
+            range: {
+              type: 'fdc3.timeRange',
+              startTime: '2020-09-01T08:00:00.000Z',
+              endTime: '2020-10-31T08:00:00.000Z',
+            },
+            style: 'candle',
+          },
+        },
+      },
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/message.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
     id: 'Nothing example',
     template: {
       type: 'fdc3.nothing',
@@ -357,6 +448,28 @@ export const contexts: ContextItem[] = [
       },
     },
     schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/order.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'OrderList example',
+    template: {
+      type: 'fdc3.orderList',
+      orders: [
+        {
+          type: 'fdc3.order',
+          id: {
+            myOMS: 'ABC123',
+          },
+        },
+        {
+          type: 'fdc3.order',
+          id: {
+            myOMS: 'DEF456',
+          },
+        },
+      ],
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/orderList.schema.json'),
   },
   {
     uuid: uuidv4(),
@@ -445,6 +558,71 @@ export const contexts: ContextItem[] = [
   },
   {
     uuid: uuidv4(),
+    id: 'Security encrypted context example',
+    template: {
+      type: 'fdc3.security.encryptedContext',
+      originalType: 'fdc3.instrument',
+      id: {
+        kid: 'channel-key-abc123',
+      },
+      encryptedPayload: 'eyJuYW1lIjoiQXBwbGUiLCJpZCI6eyJ0aWNrZXIiOiJBQVBMIn19...',
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/encrypted.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'Security symmetric key request example',
+    template: {
+      type: 'fdc3.security.symmetricKeyRequest',
+      id: {
+        kid: 'channel-key-abc123',
+      },
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/symmetricKeyRequest.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'Security symmetric key response example',
+    template: {
+      type: 'fdc3.security.symmetricKeyResponse',
+      id: {
+        kid: 'key-id-123',
+        pki: 'https://examples.com/myJWKSendpoint',
+      },
+      wrappedKey: 'u4jvA7Gx8LdH...==',
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/symmetricKeyResponse.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'Security user example',
+    template: {
+      type: 'fdc3.security.user',
+      wrappedJwt: '--example-jwt-token--but-wrapped-in-the-public-key-of-the-requester--',
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/user.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'Security user request example',
+    template: {
+      type: 'fdc3.security.userRequest',
+      aud: 'https://my-app-url.com',
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/userRequest.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'TimeRange example',
+    template: {
+      type: 'fdc3.timeRange',
+      startTime: '2022-03-30T15:44:44Z',
+      endTime: '2022-04-30T23:59:59Z',
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/timeRange.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
     id: 'Trade example',
     template: {
       type: 'fdc3.trade',
@@ -466,6 +644,53 @@ export const contexts: ContextItem[] = [
       },
     },
     schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/trade.schema.json'),
+  },
+  {
+    uuid: uuidv4(),
+    id: 'TradeList example',
+    template: {
+      type: 'fdc3.tradeList',
+      trades: [
+        {
+          type: 'fdc3.trade',
+          name: '...',
+          id: {
+            myEMS: '12345',
+          },
+          product: {
+            type: 'fdc3.product',
+            id: {
+              productId: 'ABC123',
+            },
+            instrument: {
+              type: 'fdc3.instrument',
+              id: {
+                ticker: 'MSFT',
+              },
+            },
+          },
+        },
+        {
+          type: 'fdc3.trade',
+          id: {
+            myEMS: '67890',
+          },
+          product: {
+            type: 'fdc3.product',
+            id: {
+              productId: 'DEF456',
+            },
+            instrument: {
+              type: 'fdc3.instrument',
+              id: {
+                ticker: 'TSLA',
+              },
+            },
+          },
+        },
+      ],
+    },
+    schemaUrl: new URL('https://fdc3.finos.org/schemas/next/context/tradeList.schema.json'),
   },
   {
     uuid: uuidv4(),


### PR DESCRIPTION
Fixes #1673.

## Summary
- Adds standalone Workbench context examples for schema-backed FDC3 2.2 context types: `fdc3.action`, `fdc3.fileAttachment`, `fdc3.message`, `fdc3.orderList`, `fdc3.tradeList`, and `fdc3.timeRange`.
- Uses the `broadcast` action and `channelId` in the standalone `fdc3.action` fixture to demonstrate the action variant added in FDC3 2.2.
- Updates the existing chat search example so its `fdc3.organization` entry includes an `id`, matching the current organization schema requirement.
- Uses the current `next` schema URLs for the added examples.

## Validation
- Prettier check on `toolbox/fdc3-workbench/src/fixtures/contexts.ts`
- `npm run -w toolbox/fdc3-workbench lint` (0 errors; existing warnings remain outside this fixture)
- `npm exec --workspace toolbox/fdc3-workbench -- tsc`
- Local AJV validation of all 29 Workbench context fixtures against the current context schemas
- HTTP 200 verification for all 28 unique schema URLs referenced by the fixtures
- `git diff --check origin/main...HEAD`