### PR TITLE
test(conformance): check FDC3 version from getInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Fixed the basic conformance version check to use the exported FDC3 version and accept newer compatible Desktop Agents. ([#1966](https://github.com/finos/FDC3/pull/1966))
 * Fixed an issue in conformance test AOpensBWithWrongContext, which was not correctly waiting for the timeout and was sending close messages outside of the execution of the test. Also added logging of test starts and finishes to aid debugging. ([#1933](https://github.com/finos/FDC3/pull/1933))
 
 ## [npm v2.2.3] - 2026-04-15

--- a/toolbox/fdc3-conformance/src/test/basic/fdc3.basic.ts
+++ b/toolbox/fdc3-conformance/src/test/basic/fdc3.basic.ts
@@ -1,4 +1,4 @@
-import { Context, DesktopAgent } from '@finos/fdc3';
+import { Context, DesktopAgent, FDC3_VERSION, versionIsAtLeast } from '@finos/fdc3';
 
 import { APIDocumentation } from '../support/apiDocuments';
 import { ContextType, Intent } from '../support/intent-support';
@@ -8,9 +8,12 @@ import { assert, expect } from 'chai';
 import { handleFail } from '../../utils';
 
 const getAgent2_2 = (fdc3: DesktopAgent, documentation: string) => {
-  it('(GetAgentAPI) Method is callable', async () => {
+  it('(GetInfoFDC3Version) getInfo returns an FDC3 version at least the conformance test version', async () => {
     const info = await fdc3.getInfo();
-    assert.isTrue(info.fdc3Version.startsWith('2.'), documentation);
+    assert.isTrue(
+      versionIsAtLeast(info, FDC3_VERSION),
+      `${documentation} Expected getInfo().fdc3Version ${info.fdc3Version} to be at least ${FDC3_VERSION}`
+    );
     const userChannels = await fdc3.getUserChannels();
     assert.isTrue(userChannels.length > 0, documentation);
   });

--- a/website/docs/api/conformance/Basic-Tests.md
+++ b/website/docs/api/conformance/Basic-Tests.md
@@ -12,15 +12,14 @@ _These are some basic sanity tests implemented in the FDC3 Conformance Framework
 
 ## Connection
 
-![2.2+](https://img.shields.io/badge/FDC3-2.2+-purple) In FDC3 2.2, a new interface was introduced to support Browser-based FDC3 Desktop Agents, known as a 'Desktop Agent Proxy', and a new [`getAgent`](../ref/GetAgent) API call was introduced to all apps to retrieve the Desktop Agent API via that interface or the existing 'Desktop Agent Preload' interface. This test pack checks that the a connection is made correctly via `getAgent`.
+![2.2+](https://img.shields.io/badge/FDC3-2.2+-purple) In FDC3 2.2, a new interface was introduced to support Browser-based FDC3 Desktop Agents, known as a 'Desktop Agent Proxy', and a new [`getAgent`](../ref/GetAgent) API call was introduced to all apps to retrieve the Desktop Agent API via that interface or the existing 'Desktop Agent Preload' interface. This test checks that the connected Desktop Agent reports a compatible FDC3 version and provides User channels.
 
 | App | Step            | Description                                              |
 |-----|-----------------|----------------------------------------------------------|
-| A   | `getAgent`      | App A calls `getAgent` and waits for the promise to resolve to a `DesktopAgent` instance. |
-| A   | `getInfo`       | App A can call the `getInfo()` method on the `DesktopAgent` instance to get the `ImplementationMetadata` object. <br /> Check that fdc3Version is set to 2.x.  <br />Check that provider and providerVersion are populated. |
-| A   | `getUserChannels`| App A can call the `getUserChannels()` method on the `DesktopAgent` instance to get the `Channel` objects representing the system channels.<br />Check **user** channels are returned.|
+| A   | `getInfo`       | App A calls `getInfo()` on the connected `DesktopAgent` and checks that `fdc3Version` is at least the FDC3 version used by the conformance framework. |
+| A   | `getUserChannels`| App A calls `getUserChannels()` and checks that at least one User channel is returned. |
 
-- `GetAgentAPI`: ![2.2+](https://img.shields.io/badge/FDC3-2.2+-purple) Perform the above test.
+- `GetInfoFDC3Version`: ![2.2+](https://img.shields.io/badge/FDC3-2.2+-purple) Perform the above steps as a single test.
 
 ## Basic API Usage
 


### PR DESCRIPTION
## Summary
- update the basic conformance getInfo check to compare against the exported FDC3_VERSION constant
- use versionIsAtLeast so newer compatible desktop agents pass the conformance version gate
- rename the test description to call out getInfo and the FDC3 version check

Fixes #1750

## Testing
- npm run build
- npm run build --workspace fdc3-conformance
- npx tsc -p toolbox/fdc3-conformance/tsconfig.json --noEmit
- npx eslint src/test/basic/fdc3.basic.ts --config eslint.config.mjs (from toolbox/fdc3-conformance)