### PR TITLE
Request for Chris Watson to become an FDC3 maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@ This file lists the maintainers of this repository.
 | @kriswest | Kris West | NatWest Group | kristopher.west@natwest.com |
 | @mistryvinay | Vinay Mistry | Symphony | mrvinaymistry@gmail.com |
 | @openfin-johans | Johan Sandersson | HERE (formerly OpenFin) | johan.sandersson@here.io |
+| @SeeWhatsOn | Chris Watson | AlphaFMC | christopher.watson@alphafmc.com |
 
 For information about maintainer responsibilities and resources, see the [FINOS Maintainers Cheatsheet](https://community.finos.org/docs/finos-maintainers-cheatsheet).
 


### PR DESCRIPTION
Requesting to join FDC3 as a maintainer.

## Describe your change

I've been around FDC3 since close to the start, back when it was something simple enough for a team to bolt onto their desktop and get two apps talking. Seven years on it's a hardened standard that holds up in a global bank as well as it does in a five person fintech.

I've stayed just outside formal maintainership most of that time: useful to float between implementers and users, and if I'm honest, a bit wary of taking on more governance.

That's changed. I already do most of the job as lead maintainer on FDC3 Sail, reviewing contributions and making the calls on scope. Makes sense to have that reflected properly rather than operating next to it.

I've always sat on the client facing side of this, working directly with banks and vendors implementing FDC3. That's where most of my opinions on the standard come from.

Happy to go into more detail if useful, but you lot know me well enough by now that I didn't want to overwrite this.

### Related Issue

Not applicable, this is a maintainer nomination rather than a change linked to an existing issue.

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.