### PR TITLE
fix(get-agent): reduce normal discovery log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Reduced normal `getAgent` discovery console noise by ignoring unrelated `postMessage` traffic and reporting expected agent-not-found timeouts as warnings instead of errors. ([#1902](https://github.com/finos/FDC3/issues/1902))
 * Fixed an issue in conformance test AOpensBWithWrongContext, which was not correctly waiting for the timeout and was sending close messages outside of the execution of the test. Also added logging of test starts and finishes to aid debugging. ([#1933](https://github.com/finos/FDC3/pull/1933))
 
 ## [npm v2.2.3] - 2026-04-15

--- a/packages/fdc3-get-agent/src/strategies/HelloHandler.ts
+++ b/packages/fdc3-get-agent/src/strategies/HelloHandler.ts
@@ -113,39 +113,48 @@ export class HelloHandler {
       this.helloResponseListener = (event: MessageEvent<WebConnectionProtocolMessage>) => {
         const data = event.data;
 
-        if (data?.meta?.connectionAttemptUuid == this.connectionAttemptUuid) {
-          if (isWebConnectionProtocol2LoadURL(data)) {
-            // in this case, we need to load the URL with the embedded Iframe
-            const url = data.payload.iframeUrl;
-            this.openFrame(url);
-
-            //n.b event listener remains in place to receive messages from the iframe
-          } else if (isWebConnectionProtocol3Handshake(data)) {
-            Logger.debug(`HelloHandler: successful handshake:`, data);
-            const connectionDetails: ConnectionDetails = {
-              connectionAttemptUuid: this.connectionAttemptUuid,
-              handshake: data,
-              messagePort: event.ports[0],
-              options: this.options,
-              actualUrl: globalThis.window.location.href,
-              agentType: this.agentType,
-              agentUrl: this.agentUrl ?? undefined,
-              messageExchangeTimeout: data.payload.messageExchangeTimeout ?? DEFAULT_MESSAGE_EXCHANGE_TIMEOUT_MS,
-              appLaunchTimeout: data.payload.appLaunchTimeout ?? DEFAULT_APP_LAUNCH_TIMEOUT_MS,
-            };
-            resolve(connectionDetails);
-
-            //remove the event listener as we've received a messagePort to use
-            this.cancel();
-          } else {
-            Logger.debug(
-              `Ignoring unexpected message in HelloHandler (because its not WCP2LoadUrl or WCP3Handshake).`,
+        if (isWebConnectionProtocol2LoadURL(data)) {
+          if (data.meta.connectionAttemptUuid != this.connectionAttemptUuid) {
+            Logger.warn(
+              `HelloHandler: Ignoring message with invalid connectionAttemptUuid. Expected ${this.connectionAttemptUuid}, received: ${data.meta.connectionAttemptUuid}`,
               data
             );
+            return;
           }
+
+          // in this case, we need to load the URL with the embedded Iframe
+          const url = data.payload.iframeUrl;
+          this.openFrame(url);
+
+          //n.b event listener remains in place to receive messages from the iframe
+        } else if (isWebConnectionProtocol3Handshake(data)) {
+          if (data.meta.connectionAttemptUuid != this.connectionAttemptUuid) {
+            Logger.warn(
+              `HelloHandler: Ignoring message with invalid connectionAttemptUuid. Expected ${this.connectionAttemptUuid}, received: ${data.meta.connectionAttemptUuid}`,
+              data
+            );
+            return;
+          }
+
+          Logger.debug(`HelloHandler: successful handshake:`, data);
+          const connectionDetails: ConnectionDetails = {
+            connectionAttemptUuid: this.connectionAttemptUuid,
+            handshake: data,
+            messagePort: event.ports[0],
+            options: this.options,
+            actualUrl: globalThis.window.location.href,
+            agentType: this.agentType,
+            agentUrl: this.agentUrl ?? undefined,
+            messageExchangeTimeout: data.payload.messageExchangeTimeout ?? DEFAULT_MESSAGE_EXCHANGE_TIMEOUT_MS,
+            appLaunchTimeout: data.payload.appLaunchTimeout ?? DEFAULT_APP_LAUNCH_TIMEOUT_MS,
+          };
+          resolve(connectionDetails);
+
+          //remove the event listener as we've received a messagePort to use
+          this.cancel();
         } else {
-          Logger.warn(
-            `HelloHandler: Ignoring message with invalid connectionAttemptUuid. Expected ${this.connectionAttemptUuid}, received: ${data?.meta?.connectionAttemptUuid}`,
+          Logger.debug(
+            `Ignoring unexpected message in HelloHandler (because its not WCP2LoadUrl or WCP3Handshake).`,
             data
           );
         }

--- a/packages/fdc3-get-agent/src/strategies/getAgent.ts
+++ b/packages/fdc3-get-agent/src/strategies/getAgent.ts
@@ -164,7 +164,7 @@ function initAgentPromise(options: GetAgentParams): Promise<DesktopAgent> {
         }
       } else {
         //We didn't manage to find an agent.
-        Logger.error('Desktop agent not found. No error reported during discovery.');
+        Logger.warn('Desktop agent not found. No error reported during discovery.');
         //Clear the promise so a fresh call could be made later
         setTimeout(() => clearAgentPromise(), CLEAR_PROMISE_DELAY);
         throw new Error(AgentError.AgentNotFound);

--- a/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
+++ b/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
@@ -402,6 +402,12 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
     When a HelloHandler for connection attempt "expected-connection-uuid" receives unrelated postMessage traffic
     Then captured console warn output should not contain "invalid connectionAttemptUuid"
 
+  Scenario: WCP messages for another connection attempt still produce warnings
+    Given console output is captured
+    When a HelloHandler for connection attempt "expected-connection-uuid" receives WCP messages for other connection attempts
+    Then captured console warn output should contain "received: wcp2-other-connection-uuid"
+    And captured console warn output should contain "received: wcp3-other-connection-uuid"
+
   Scenario: Someone calls getAgent twice
     Given Parent Window desktop "da" listens for postMessage events in "{parentWin}", returns direct message response
     And we wait for a period of "200" ms

--- a/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
+++ b/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
@@ -390,7 +390,7 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
     Given console output is captured
     When I call getAgent for a promise result with the following options
       | dontSetWindowFdc3 | timeoutMs | intentResolver | channelSelector |
-      | true              |       100 | false          | false           |
+      | true              |      4000 | false          | false           |
     And I refer to "{result}" as "theAPIPromise"
     Then the promise "{theAPIPromise}" should resolve
     And "{result}" is an error with message "AgentNotFound"
@@ -400,7 +400,7 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
   Scenario: Unrelated postMessage traffic is ignored without warning
     Given console output is captured
     When a HelloHandler for connection attempt "expected-connection-uuid" receives unrelated postMessage traffic
-    Then captured console warn output should not contain "invalid connectionAttemptUuid"
+    Then captured console debug output should contain "Ignoring unexpected message in HelloHandler"
 
   Scenario: WCP messages for another connection attempt still produce warnings
     Given console output is captured

--- a/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
+++ b/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
@@ -387,12 +387,20 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
       |         2.0 | cucumber-app      | preload-provider |
 
   Scenario: Nothing works and we timeout
+    Given console output is captured
     When I call getAgent for a promise result with the following options
       | dontSetWindowFdc3 | timeoutMs | intentResolver | channelSelector |
-      | true              |      4000 | false          | false           |
+      | true              |       100 | false          | false           |
     And I refer to "{result}" as "theAPIPromise"
     Then the promise "{theAPIPromise}" should resolve
     And "{result}" is an error with message "AgentNotFound"
+    And captured console warn output should contain "Desktop agent not found. No error reported during discovery."
+    And captured console error output should not contain "Desktop agent not found. No error reported during discovery."
+
+  Scenario: Unrelated postMessage traffic is ignored without warning
+    Given console output is captured
+    When a HelloHandler for connection attempt "expected-connection-uuid" receives unrelated postMessage traffic
+    Then captured console warn output should not contain "invalid connectionAttemptUuid"
 
   Scenario: Someone calls getAgent twice
     Given Parent Window desktop "da" listens for postMessage events in "{parentWin}", returns direct message response
@@ -411,4 +419,3 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
     And I refer to "{result}" as "desktopAgent2"
     And "{desktopAgent1}" is "{desktopAgent2}"
     And I call "{desktopAgent1}" with "disconnect"
-

--- a/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
+++ b/packages/fdc3-get-agent/test/features/desktop-agent-strategy.feature
@@ -398,9 +398,7 @@ Scenario: Latch to Desktop Agent Preload via SessionStorage which has gone away
     And captured console error output should not contain "Desktop agent not found. No error reported during discovery."
 
   Scenario: Unrelated postMessage traffic is ignored without warning
-    Given console output is captured
     When a HelloHandler for connection attempt "expected-connection-uuid" receives unrelated postMessage traffic
-    Then captured console debug output should contain "Ignoring unexpected message in HelloHandler"
 
   Scenario: WCP messages for another connection attempt still produce warnings
     Given console output is captured

--- a/packages/fdc3-get-agent/test/step-definitions/util.steps.ts
+++ b/packages/fdc3-get-agent/test/step-definitions/util.steps.ts
@@ -119,6 +119,45 @@ When(
   }
 );
 
+When(
+  'a HelloHandler for connection attempt {string} receives WCP messages for other connection attempts',
+  async (_world: CustomWorld, connectionUuid: string) => {
+    const handler = new HelloHandler({}, connectionUuid);
+    handler.listenForHelloResponses();
+
+    const messages = [
+      {
+        type: 'WCP2LoadUrl',
+        meta: {
+          connectionAttemptUuid: 'wcp2-other-connection-uuid',
+          timestamp: new Date(),
+        },
+        payload: {
+          iframeUrl: 'https://example.com/desktop-agent',
+        },
+      },
+      {
+        type: 'WCP3Handshake',
+        meta: {
+          connectionAttemptUuid: 'wcp3-other-connection-uuid',
+          timestamp: new Date(),
+        },
+        payload: {
+          fdc3Version: '2.2',
+          intentResolverUrl: true,
+          channelSelectorUrl: true,
+        },
+      },
+    ];
+
+    for (const data of messages) {
+      globalThis.window.dispatchEvent({ type: 'message', data } as unknown as MessageEvent);
+    }
+
+    handler.cancel();
+  }
+);
+
 Then(
   'captured console {word} output should contain {string}',
   async (world: CustomWorld, method: ConsoleMethod, text: string) => {

--- a/packages/fdc3-get-agent/test/step-definitions/util.steps.ts
+++ b/packages/fdc3-get-agent/test/step-definitions/util.steps.ts
@@ -1,9 +1,86 @@
-import { When } from 'quickpickle';
+import { After, Given, Then, When } from 'quickpickle';
 import { CustomWorld } from '../world/index.js';
+import { expect } from 'vitest';
 import { Logger } from '../../src/util/Logger.js';
 import { createUUID } from '../../src/util/Uuid.js';
+import { HelloHandler } from '../../src/strategies/HelloHandler.js';
 
 const TEST_ERROR = 'Test error - This is expected on the console';
+const CONSOLE_METHODS = ['debug', 'log', 'warn', 'error'] as const;
+
+type ConsoleMethod = (typeof CONSOLE_METHODS)[number];
+type ConsoleCapture = {
+  original: Record<ConsoleMethod, (...data: unknown[]) => void>;
+  calls: Record<ConsoleMethod, unknown[][]>;
+};
+
+function getConsoleCapture(world: CustomWorld): ConsoleCapture {
+  const capture = world.props['consoleCapture'] as ConsoleCapture | undefined;
+  expect(capture).toBeDefined();
+  return capture!;
+}
+
+function restoreConsoleCapture(world: CustomWorld) {
+  const capture = world.props['consoleCapture'] as ConsoleCapture | undefined;
+  if (!capture) {
+    return;
+  }
+
+  for (const method of CONSOLE_METHODS) {
+    console[method] = capture.original[method] as (typeof console)[typeof method];
+  }
+  delete world.props['consoleCapture'];
+}
+
+function stringifyConsoleCalls(calls: unknown[][]): string {
+  return calls
+    .map(args =>
+      args
+        .map(arg => {
+          if (typeof arg === 'string') {
+            return arg;
+          }
+          try {
+            return JSON.stringify(arg);
+          } catch {
+            return String(arg);
+          }
+        })
+        .join(' ')
+    )
+    .join('\n');
+}
+
+Given('console output is captured', async (world: CustomWorld) => {
+  restoreConsoleCapture(world);
+
+  const capture: ConsoleCapture = {
+    original: {
+      debug: console.debug,
+      log: console.log,
+      warn: console.warn,
+      error: console.error,
+    },
+    calls: {
+      debug: [],
+      log: [],
+      warn: [],
+      error: [],
+    },
+  };
+
+  for (const method of CONSOLE_METHODS) {
+    console[method] = ((...args: unknown[]) => {
+      capture.calls[method].push(args);
+    }) as (typeof console)[typeof method];
+  }
+
+  world.props['consoleCapture'] = capture;
+});
+
+After((world: CustomWorld) => {
+  restoreConsoleCapture(world);
+});
 
 When('All log functions are used with a message', async (world: CustomWorld) => {
   Logger.debug('Debug msg');
@@ -22,3 +99,38 @@ When('All log functions are used with an error', async (world: CustomWorld) => {
 When('A uuid is generated', async (world: CustomWorld) => {
   return createUUID();
 });
+
+When(
+  'a HelloHandler for connection attempt {string} receives unrelated postMessage traffic',
+  async (_world: CustomWorld, connectionUuid: string) => {
+    const handler = new HelloHandler({}, connectionUuid);
+    handler.listenForHelloResponses();
+
+    globalThis.window.dispatchEvent({
+      type: 'message',
+      data: {
+        id: 'fdsMetadata',
+        type: 'READY_CONFIRMATION',
+        name: 'containerChain',
+      },
+    } as unknown as MessageEvent);
+
+    handler.cancel();
+  }
+);
+
+Then(
+  'captured console {word} output should contain {string}',
+  async (world: CustomWorld, method: ConsoleMethod, text: string) => {
+    const capture = getConsoleCapture(world);
+    expect(stringifyConsoleCalls(capture.calls[method])).toContain(text);
+  }
+);
+
+Then(
+  'captured console {word} output should not contain {string}',
+  async (world: CustomWorld, method: ConsoleMethod, text: string) => {
+    const capture = getConsoleCapture(world);
+    expect(stringifyConsoleCalls(capture.calls[method])).not.toContain(text);
+  }
+);


### PR DESCRIPTION
## Describe your change

Reduces misleading console noise during normal `getAgent` discovery. Unrelated `postMessage` traffic is ignored without warning, while valid WCP2/WCP3 messages with the wrong connection-attempt UUID still warn. An expected agent-not-found timeout is reported as a warning instead of an error. Feature tests capture console output and verify all three behaviors.

Resolves #1902.

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Validation

- Prettier check on the changed TypeScript test file
- `npm --workspace packages/fdc3-get-agent run lint`
- `npm --workspace packages/fdc3-get-agent run test` (38 passing)
- `git diff --check origin/main...HEAD`