### PR TITLE
fix(web-impl): gate channel changed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Prevented the FDC3 for Web reference implementation from sending channel-changed events to applications that have not registered a matching listener. ([#1806](https://github.com/finos/FDC3/issues/1806))
 * Fixed an issue in conformance test AOpensBWithWrongContext, which was not correctly waiting for the timeout and was sending close messages outside of the execution of the test. Also added logging of test starts and finishes to aid debugging. ([#1933](https://github.com/finos/FDC3/pull/1933))
 
 ## [npm v2.2.3] - 2026-04-15

--- a/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/src/handlers/BroadcastHandler.ts
@@ -134,6 +134,15 @@ export class BroadcastHandler implements MessageHandler {
   }
 
   fireChannelChangedEvent(channelId: string | null, sc: ServerContext<AppRegistration>, instanceId: string) {
+    const hasChannelChangedListener = this.desktopAgentEventListeners.some(
+      listener =>
+        listener.instanceId === instanceId &&
+        (listener.eventType === null || listener.eventType === 'USER_CHANNEL_CHANGED')
+    );
+    if (!hasChannelChangedListener) {
+      return;
+    }
+
     const event: ChannelChangedEvent = {
       meta: {
         eventUuid: sc.createUUID(),

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/event-listeners.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/event-listeners.feature
@@ -25,6 +25,15 @@ Feature: Client can add an event Listener
       | addEventListenerResponse         | a1            | App1     | uuid2                    |
       | eventListenerUnsubscribeResponse | a1            | App1     | {null}                   |
 
+  Scenario: App Receives User Channel Changed Events After Registering
+    When "App1/a1" adds an event listener for "USER_CHANNEL_CHANGED"
+    And "App1/a1" joins user channel "one"
+    Then messaging will have outgoing posts
+      | msg.matches_type         | to.instanceId | to.appId | msg.payload.listenerUUID | msg.payload.newChannelId |
+      | addEventListenerResponse | a1            | App1     | uuid2                    | {null}                   |
+      | channelChangedEvent      | a1            | App1     | {null}                   | one                      |
+      | joinUserChannelResponse  | a1            | App1     | {null}                   | {null}                   |
+
   Scenario: Unsubscribe a non-existent Event Listener
     When "App1/a1" removes event listener with id "uuid-na"
     Then messaging will have outgoing posts

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/event-listeners.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/event-listeners.feature
@@ -33,6 +33,24 @@ Feature: Client can add an event Listener
       | addEventListenerResponse | a1            | App1     | uuid2                    | {null}                   |
       | channelChangedEvent      | a1            | App1     | {null}                   | one                      |
       | joinUserChannelResponse  | a1            | App1     | {null}                   | {null}                   |
+    And messaging will have 3 posts
+
+  Scenario: App Receives User Channel Changed Events With An Untyped Listener
+    When "App1/a1" adds an event listener for "{null}"
+    And "App1/a1" joins user channel "one"
+    Then messaging will have outgoing posts
+      | msg.matches_type         | to.instanceId | to.appId | msg.payload.listenerUUID | msg.payload.newChannelId |
+      | addEventListenerResponse | a1            | App1     | uuid2                    | {null}                   |
+      | channelChangedEvent      | a1            | App1     | {null}                   | one                      |
+      | joinUserChannelResponse  | a1            | App1     | {null}                   | {null}                   |
+    And messaging will have 3 posts
+
+  Scenario: App Does Not Receive User Channel Changed Events Without A Listener
+    When "App1/a1" joins user channel "one"
+    Then messaging will have outgoing posts
+      | msg.matches_type        | to.instanceId | to.appId |
+      | joinUserChannelResponse | a1            | App1     |
+    And messaging will have 1 posts
 
   Scenario: Unsubscribe a non-existent Event Listener
     When "App1/a1" removes event listener with id "uuid-na"

--- a/toolbox/fdc3-for-web/fdc3-web-impl/test/features/user-channels.feature
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/test/features/user-channels.feature
@@ -29,7 +29,6 @@ Feature: Relaying Private Channel Broadcast messages
     And "App1/a1" gets the current user channel
     Then messaging will have outgoing posts
       | msg.payload.channel.id | to.instanceId | msg.matches_type          |
-      | {null}                 | a1            | channelChangedEvent       |
       | {null}                 | a1            | joinUserChannelResponse   |
       | one                    | a1            | getCurrentChannelResponse |
 
@@ -57,7 +56,6 @@ Feature: Relaying Private Channel Broadcast messages
     And "App2/a2" broadcasts "fdc3.instrument" on "two"
     Then messaging will have outgoing posts
       | msg.matches_type           | to.instanceId |
-      | channelChangedEvent        | a1            |
       | joinUserChannelResponse    | a1            |
       | addContextListenerResponse | a1            |
       | broadcastResponse          | a2            |
@@ -69,11 +67,9 @@ Feature: Relaying Private Channel Broadcast messages
     And "App2/a2" broadcasts "fdc3.instrument" on "one"
     Then messaging will have outgoing posts
       | msg.matches_type                   | msg.payload.listenerUUID |
-      | channelChangedEvent                | {null}                   |
       | joinUserChannelResponse            | {null}                   |
-      | addContextListenerResponse         | uuid6                    |
+      | addContextListenerResponse         | uuid5                    |
       | contextListenerUnsubscribeResponse | {null}                   |
-      | broadcastEvent                     | {null}                   |
       | broadcastResponse                  | {null}                   |
 
   Scenario: I should be able to leave a user channel, and not receive messages on it
@@ -83,10 +79,8 @@ Feature: Relaying Private Channel Broadcast messages
     And "App2/a2" broadcasts "fdc3.instrument" on "one"
     Then messaging will have outgoing posts
       | msg.matches_type            |
-      | channelChangedEvent         |
       | joinUserChannelResponse     |
       | addContextListenerResponse  |
-      | channelChangedEvent         |
       | leaveCurrentChannelResponse |
       | broadcastResponse           |
 


### PR DESCRIPTION
## Describe your change

Prevents the FDC3 for Web reference implementation from sending `channelChangedEvent` messages to an application unless that application registered a matching `USER_CHANNEL_CHANGED` or all-events listener.

Feature coverage now verifies:

- no event is sent when no listener exists, using an exact outgoing-message count;
- typed `USER_CHANNEL_CHANGED` listeners receive the event;
- untyped all-events listeners receive the event.

Resolves #1806.

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Validation

- `npm --workspace toolbox/fdc3-for-web/fdc3-web-impl test` (109 passing)
- `npm --workspace toolbox/fdc3-for-web/fdc3-web-impl run lint`
- staged-file formatting hook
- `git diff --check`
