### PR TITLE
chore: migrate CVE scanning to auditjs guide

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,20 +25,20 @@ jobs:
 
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Analyze
-        uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
     - name: Harden runner
-      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
       with:
         egress-policy: audit
 
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Node.js
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24.0.2
 

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -30,15 +30,15 @@ jobs:
         node-version: [24.0.2]
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -50,9 +50,11 @@ jobs:
       - run: npm install
         working-directory: website
 
-      - run: npx --yes auditjs ossi --whitelist allow-list.json -u ${{ secrets.OSS_INDEX_USERNAME }} -p ${{ secrets.OSS_INDEX_TOKEN }}
+      - name: Audit root dependencies
+        run: npx --yes auditjs@latest guide --allowlist allow-list.json --token ${{ secrets.SONATYPE_GUIDE_TOKEN }}
         if: success() || failure()
-        
-      - run: npx --yes auditjs ossi --whitelist ../allow-list.json -u ${{ secrets.OSS_INDEX_USERNAME }} -p ${{ secrets.OSS_INDEX_TOKEN }}
+
+      - name: Audit website dependencies
+        run: npx --yes auditjs@latest guide --allowlist ../allow-list.json --token ${{ secrets.SONATYPE_GUIDE_TOKEN }}
         working-directory: website
         if: success() || failure()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
       publish_tag: ${{ steps.version.outputs.publish_tag }}
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.0.2
 
@@ -98,12 +98,12 @@ jobs:
     needs: build_and_pack
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: Checkout repo (required for npm provenance)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download packed artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -112,7 +112,7 @@ jobs:
           path: ./dist-tarballs
 
       - name: Configure Node for npmjs.org
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.0.2
           registry-url: https://registry.npmjs.org
@@ -137,7 +137,7 @@ jobs:
     needs: build_and_pack
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
@@ -148,7 +148,7 @@ jobs:
           path: ./dist-tarballs
 
       - name: Configure Node for GitHub Packages
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.0.2
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
       - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -74,6 +74,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Describe your change

We've been seeing frequent (but weirdly intermittent — consistent with an expired token) failures in the CVE scanning workflow on PRs, where `auditjs ossi` errors out with `Error: Unauthorized` from Sonatype OSS Index. This PR resolves that by migrating to the replacement `auditjs guide` command.

### CVE Scanning Migration

The `auditjs ossi` subcommand is deprecated and will be removed in v6. This PR migrates to `auditjs guide`, which uses the newer Sonatype Guide API. Key changes:

- `auditjs ossi` → `auditjs guide`
- `--whitelist` → `--allowlist` (flag renamed in auditjs v5)
- Authentication now uses a single API token (`--token`) instead of username/password
- New secret required: `SONATYPE_GUIDE_TOKEN`

> **@TheJuanAndOnly99 @finos-admin** — This PR requires a new repository secret `SONATYPE_GUIDE_TOKEN` to be created before the CVE scanning workflow will pass. You can get a free API token from https://guide.sonatype.com under Settings → API Tokens. Once added, the old `OSS_INDEX_USERNAME` and `OSS_INDEX_TOKEN` secrets can be removed.

### Related Issue

N/A — resolves ongoing intermittent CVE scan failures and routine dependency maintenance.

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
  - N/A — no standard changes.
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
  - Not required for CI-only changes.
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - No.
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - No.
- [ ] **Intents**: Were new Intents created in this PR?
  - No.
