### PR TITLE
chore: fix website build, resolve CVEs,

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,19 @@ updates:
       default-days: 7
       semver-major-days: 10
     groups:
+      # Docusaurus and its rendering stack must move together — they share
+      # peer dependencies on react/react-dom and layout-elk, so upgrading
+      # any one in isolation risks peer dep conflicts.
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@mermaid-js/layout-elk"
+          - "prism-react-renderer"
+      # react and react-dom must always be the same version.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
       minor-and-patch:
         update-types:
           - "minor"

--- a/.npmrc
+++ b/.npmrc
@@ -8,7 +8,8 @@ omit-lockfile-registry-resolved = true
 # Ensuring optional deps stay in the install graph fixes that without Linux-only devDependencies.
 include = optional
 
-# Require packages to have been published for at least 7 days before resolving them.
+# Require packages to have been published for at least 3 days before resolving them.
 # This mitigates supply-chain attacks from newly published malicious versions.
+# Dependabot cooldown (7 days) provides an additional layer of protection for PRs.
 # Requires npm >= 11.10.
-min-release-age = 7
+min-release-age = 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -9023,8 +9023,8 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "vitest": "^3.2.6"
   },
   "overrides": {
-    "fast-uri": "3.1.3",
     "serialize-javascript": "^7.0.5",
     "@cucumber/messages": "^27.2.0"
   },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,7 +21,6 @@ module.exports = {
     "repoUrl": "https://github.com/finos/FDC3"
   },
   "onBrokenLinks": "log",
-  "onBrokenMarkdownLinks": "log",
   "presets": [
     [
       "@docusaurus/preset-classic",
@@ -44,6 +43,9 @@ module.exports = {
   ],
   markdown: {
     mermaid: true,
+    hooks: {
+      onBrokenMarkdownLinks: "log",
+    },
   },
   themes: ['@docusaurus/theme-mermaid'],
   "plugins": [],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4,11 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "website",
       "devDependencies": {
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
         "@docusaurus/theme-mermaid": "^3.10.2",
+        "@mermaid-js/layout-elk": "^0.1.9",
         "clsx": "^1.2.1",
         "cpy-cli": "4.2.0",
         "cross-env": "^7.0.3",
@@ -4821,6 +4821,19 @@
         "react": ">=16"
       }
     },
+    "node_modules/@mermaid-js/layout-elk": {
+      "version": "0.1.9",
+      "integrity": "sha512-HuvaqFZBr6yT9PpWYockvKAZPJVd89yn/UjOYPxhzbZxlybL2v+2BjVCg7MVH6vRs1irUohb/s42HEdec1CCZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "elkjs": "^0.9.3"
+      },
+      "peerDependencies": {
+        "mermaid": "^11.0.2"
+      }
+    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.1.1",
       "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
@@ -9496,6 +9509,12 @@
       "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.3",
+      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
+      "dev": true,
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4,11 +4,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "website",
       "devDependencies": {
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
         "@docusaurus/theme-mermaid": "^3.10.2",
-        "@mermaid-js/layout-elk": "^0.2.2",
         "clsx": "^1.2.1",
         "cpy-cli": "4.2.0",
         "cross-env": "^7.0.3",
@@ -4821,19 +4821,6 @@
         "react": ">=16"
       }
     },
-    "node_modules/@mermaid-js/layout-elk": {
-      "version": "0.2.2",
-      "integrity": "sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d3": "^7.9.0",
-        "elkjs": "^0.9.3"
-      },
-      "peerDependencies": {
-        "mermaid": "^11.0.2"
-      }
-    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.1.1",
       "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
@@ -6322,8 +6309,8 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6365,22 +6352,6 @@
       "peerDependencies": {
         "ajv": "^8.8.2"
       }
-    },
-    "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.3",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/algoliasearch": {
       "version": "5.56.0",
@@ -6767,8 +6738,8 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6865,8 +6836,8 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9154,8 +9125,8 @@
       }
     },
     "node_modules/del/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9525,12 +9496,6 @@
       "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elkjs": {
-      "version": "0.9.3",
-      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
-      "dev": true,
-      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -10082,6 +10047,22 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -11204,8 +11185,8 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11874,8 +11855,8 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -18683,8 +18664,8 @@
       }
     },
     "node_modules/serve-handler/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -30,7 +30,6 @@
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@docusaurus/theme-mermaid": "^3.10.2",
-    "@mermaid-js/layout-elk": "^0.2.2",
     "clsx": "^1.2.1",
     "cpy-cli": "4.2.0",
     "cross-env": "^7.0.3",
@@ -45,7 +44,6 @@
     "rimraf": "5.0.0"
   },
   "overrides": {
-    "fast-uri": "3.1.3",
     "serialize-javascript": "^7.0.5",
     "webpack": "~5.105.0"
   }

--- a/website/package.json
+++ b/website/package.json
@@ -30,6 +30,7 @@
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@docusaurus/theme-mermaid": "^3.10.2",
+    "@mermaid-js/layout-elk": "^0.1.9",
     "clsx": "^1.2.1",
     "cpy-cli": "4.2.0",
     "cross-env": "^7.0.3",
@@ -46,5 +47,6 @@
   "overrides": {
     "serialize-javascript": "^7.0.5",
     "webpack": "~5.105.0"
-  }
+  },
+  "allowScripts": {}
 }


### PR DESCRIPTION
## Describe your change

Fixes CI failures in the website build and CVE scanning job, resolves several npm audit vulnerabilities, upgrades Node.js across all CI environments, and makes dependabot configuration improvements to prevent similar issues recurring.

### Website `npm install` failure — `@mermaid-js/layout-elk` peer conflict

Dependabot had upgraded `@mermaid-js/layout-elk` from `^0.1.9` to `^0.2.2` in isolation. This caused the CVE scanning job (which runs `npm install` in the website folder) to fail with an `ERESOLVE` error because `@docusaurus/theme-mermaid@3.10.2` declares a peer dependency of `^0.1.9` — a range that excludes `0.2.x`.

The dependency has been pinned back to `^0.1.9`. Although the peer dep is marked optional, `@docusaurus/theme-mermaid` contains a static `import('@mermaid-js/layout-elk')` in its client bundle (guarded by a compile-time flag), meaning webpack requires the module to be resolvable regardless of whether ELK layout is actually used. The package must remain as a direct dependency.

### Website build failure — deprecated `onBrokenMarkdownLinks` config

The top-level `siteConfig.onBrokenMarkdownLinks` option is deprecated in Docusaurus v4. Migrated it to `siteConfig.markdown.hooks.onBrokenMarkdownLinks`.

### `fast-uri` CVE (GHSA-v2hh-gcrm-f6hx)

`fast-uri@3.1.4` fixes a high-severity host confusion vulnerability. The fix was initially blocked by `min-release-age = 7` in `.npmrc` as the patched version was published fewer than 7 days ago. The `min-release-age` threshold has been reduced to 3 days — still providing meaningful supply-chain protection while allowing timely security fixes to land. The dependabot cooldown remains at 7 days, providing the outer safety net for automated dependency PRs.

### Additional audit fixes (`npm audit fix`)

| CVE | Package | Severity |
|-----|---------|----------|
| GHSA-v422-hmwv-36x6 | `body-parser` < 1.20.6 | moderate |
| GHSA-3jxr-9vmj-r5cp | `brace-expansion` | high |
| GHSA-64mm-vxmg-q3vj | `http-proxy-middleware` < 2.0.10 | moderate |
| GHSA-52cp-r559-cp3m | `js-yaml` 4.0.0–4.2.0 | high |
| GHSA-v2hh-gcrm-f6hx | `fast-uri` 3.0.0–3.1.3 | high |

**Remaining unfixed:** `uuid` < 11.1.1 (moderate, GHSA-w5hq-g745-h8pq) in `sockjs → webpack-dev-server → @docusaurus/core` — no fix available upstream; affects dev server only, not production builds.

### Node.js upgrade to 24.18.0

All CI environments and version manager configs updated from `24.0.2` to `24.18.0`. The bundled npm (11.16.0) now natively supports `min-release-age`, so the `.npmrc` supply-chain protection is enforced on Netlify builds.

### Dependabot improvements

Added an npm ecosystem entry for `/website` so its dependencies receive properly cooldown-gated update PRs (missing previously, which is why the `@mermaid-js/layout-elk` upgrade went unreviewed as a grouped change).

Added dependency groups to the `/website` entry to prevent future peer conflict PRs:

- **`docusaurus`** — groups `@docusaurus/*`, `@mermaid-js/layout-elk`, and `prism-react-renderer` so they always upgrade atomically. All share peer dependencies on `react`/`react-dom`, and `@docusaurus/theme-mermaid` controls the peer constraint on `layout-elk`.
- **`react`** — groups `react` and `react-dom`, which must always be the same version.

---

**Files changed:**
- `.npmrc` — `min-release-age` 7 → 3; updated comment
- `.nvmrc` / `.node-version` — `24` → `24.18.0`
- `netlify.toml` — `NODE_VERSION=24.18.0`, `NPM_VERSION=11.16.0`
- `.github/workflows/coverage.yml`, `cve-scanning.yml`, `release.yml` — `node-version: 24.18.0`
- `.github/dependabot.yml` — added `/website` npm entry with `docusaurus` and `react` dependency groups
- `website/package.json` — pinned `@mermaid-js/layout-elk` to `^0.1.9`; removed temporary `fast-uri` override
- `website/package-lock.json` — regenerated (audit fixes, `fast-uri` → 3.1.4, `@mermaid-js/layout-elk` → 0.1.9)
- `website/docusaurus.config.js` — migrated `onBrokenMarkdownLinks` to `markdown.hooks`
- `package.json` — removed temporary `fast-uri` override
- `package-lock.json` — regenerated (`fast-uri` → 3.1.4)

### Related Issue

N/A — fixes CI failures and resolves audit vulnerabilities.

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
  - N/A — infrastructure/CI change only, no standard changes.
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs?
  - No.
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - No.
- [ ] **Intents**: Were new Intents created in this PR?
  - No.