### PR TITLE
Document Vitest UI reporter usage

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -24,7 +24,7 @@ ignores:
   - "@types/node"
   # Loaded by Vitest when workspace coverage scripts use `--coverage`.
   - "@vitest/coverage-v8"
-  # No current `--ui` invocation was found; likely valid to remove.
+  # Loaded as `@vitest/ui/reporter` by the fdc3-web-impl Vitest configuration.
   - "@vitest/ui"
   # Invoked by workspace `lint` scripts and imported by ESLint configurations.
   - eslint


### PR DESCRIPTION
## What changed

Updates the root depcheck baseline to document the concrete use of `@vitest/ui`: `toolbox/fdc3-for-web/fdc3-web-impl` loads `@vitest/ui/reporter` as a custom Vitest reporter.

## Investigation

I removed `@vitest/ui` from the root manifest and lockfile and ran the repository build and tests. The build passed, but the full test suite failed when `fdc3-web-impl` could not load `@vitest/ui/reporter`. I restored the dependency and lockfile, then updated the depcheck explanation instead.

## Validation

- `npm run build` — passes
- `npm test` — passes
- `npm test --workspace toolbox/fdc3-for-web/fdc3-web-impl` — 109 tests pass
- root plus all 15 workspace depcheck invocations — pass

## Impact

No dependency is removed. The baseline now prevents `@vitest/ui` from being incorrectly selected for a future removal PR.
