### PR TITLE
Remove unused FDC3 security dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19021,7 +19021,6 @@
         "@finos/fdc3-context": "3.0.0-alpha.2",
         "@finos/fdc3-get-agent": "3.0.0-alpha.2",
         "@finos/fdc3-schema": "3.0.0-alpha.2",
-        "@finos/fdc3-security": "3.0.0-alpha.2",
         "@finos/fdc3-standard": "3.0.0-alpha.2"
       },
       "engines": {

--- a/packages/fdc3/.depcheckrc.yml
+++ b/packages/fdc3/.depcheckrc.yml
@@ -1,2 +1,0 @@
-# depcheck currently reports no unused dependencies for this workspace.
-ignores: []

--- a/packages/fdc3/.depcheckrc.yml
+++ b/packages/fdc3/.depcheckrc.yml
@@ -1,3 +1,2 @@
-ignores:
-  # The roll-up entry point does not currently export this package; likely valid to remove.
-  - "@finos/fdc3-security"
+# depcheck currently reports no unused dependencies for this workspace.
+ignores: []

--- a/packages/fdc3/package.json
+++ b/packages/fdc3/package.json
@@ -25,8 +25,7 @@
     "@finos/fdc3-context": "3.0.0-alpha.2",
     "@finos/fdc3-get-agent": "3.0.0-alpha.2",
     "@finos/fdc3-schema": "3.0.0-alpha.2",
-    "@finos/fdc3-standard": "3.0.0-alpha.2",
-    "@finos/fdc3-security": "3.0.0-alpha.2"
+    "@finos/fdc3-standard": "3.0.0-alpha.2"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## What changed

- removes the unused `@finos/fdc3-security` dependency from `packages/fdc3`
- removes its depcheck baseline entry
- updates the lockfile

## Why

The `@finos/fdc3` roll-up entry point does not import or export `@finos/fdc3-security`, so consumers were installing it without receiving any API from it.

## Validation

- `npm run build` — passes for all workspaces
- `npm test` — passes for all workspaces
- root plus all 15 workspace depcheck invocations — pass
