### PR TITLE
Remove unused agent proxy dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19039,10 +19039,6 @@
         "@cucumber/cucumber": "^13.1.1",
         "@finos/testing": "3.0.0-alpha.2",
         "@types/uuid": "^10.0.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-prettier": "3.3.1",
-        "is-ci": "4.1.0",
-        "jsonpath-plus": "^10.1.0",
         "quickpickle": "^1.6.1",
         "uuid": "^14.0.1"
       },

--- a/packages/fdc3-agent-proxy/.depcheckrc.yml
+++ b/packages/fdc3-agent-proxy/.depcheckrc.yml
@@ -1,9 +1,2 @@
-ignores:
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-import
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-prettier
-  # No source or script reference was found; likely valid to remove.
-  - is-ci
-  # Matching helpers come from @finos/testing; likely valid to remove here.
-  - jsonpath-plus
+# depcheck currently reports no unused dependencies for this workspace.
+ignores: []

--- a/packages/fdc3-agent-proxy/.depcheckrc.yml
+++ b/packages/fdc3-agent-proxy/.depcheckrc.yml
@@ -1,2 +1,0 @@
-# depcheck currently reports no unused dependencies for this workspace.
-ignores: []

--- a/packages/fdc3-agent-proxy/package.json
+++ b/packages/fdc3-agent-proxy/package.json
@@ -32,10 +32,6 @@
     "@cucumber/cucumber": "^13.1.1",
     "@finos/testing": "3.0.0-alpha.2",
     "@types/uuid": "^10.0.0",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-prettier": "3.3.1",
-    "is-ci": "4.1.0",
-    "jsonpath-plus": "^10.1.0",
     "quickpickle": "^1.6.1",
     "uuid": "^14.0.1"
   },


### PR DESCRIPTION
## Summary

- remove four dependencies that are not referenced by the agent proxy source, scripts, or configuration
- clear the workspace depcheck ignore list now that depcheck reports no unused declarations

Removed: `eslint-plugin-import`, `eslint-plugin-prettier`, `is-ci`, and `jsonpath-plus`.

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
