### PR TITLE
Remove unused CommonJS build dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4651,53 +4651,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/@rollup/plugin-typescript": {
-      "version": "12.3.0",
-      "integrity": "sha512-7DP0/p7y3t67+NabT9f8oTBFE6gGkto4SA6Np2oudYmZE/m1dt8RB0SjL1msMxFpLo631qjRCcBlAbq1ml/Big==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.1.0",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.14.0||^3.0.0||^4.0.0",
-        "tslib": "*",
-        "typescript": ">=3.7.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        },
-        "tslib": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-typescript/node_modules/resolve": {
-      "version": "1.22.12",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
       "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
@@ -19061,7 +19014,6 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.3.0",
-        "@rollup/plugin-typescript": "^12.1.1",
         "rollup": "^4.62.2",
         "rollup-plugin-dts": "^6.3.0"
       },

--- a/packages/fdc3-commonjs/.depcheckrc.yml
+++ b/packages/fdc3-commonjs/.depcheckrc.yml
@@ -1,5 +1,3 @@
 ignores:
-  # No matching plugin invocation exists in rollup.config.mjs; likely valid to remove.
-  - "@rollup/plugin-typescript"
   # Invoked by the `build` package script.
   - rollup

--- a/packages/fdc3-commonjs/package.json
+++ b/packages/fdc3-commonjs/package.json
@@ -30,7 +30,6 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.3.0",
-    "@rollup/plugin-typescript": "^12.1.1",
     "rollup": "^4.62.2",
     "rollup-plugin-dts": "^6.3.0"
   },


### PR DESCRIPTION
## Summary

- remove `@rollup/plugin-typescript`, which is not loaded by `rollup.config.mjs`
- retain and document `rollup`, which is invoked by the workspace build script

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
