### PR TITLE
Remove unused context tslib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19485,8 +19485,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "mkdirp": "^3.0.1",
-        "quicktype": "23.0.78",
-        "tslib": "^2.7.0"
+        "quicktype": "23.0.78"
       },
       "engines": {
         "node": ">=22"

--- a/packages/fdc3-context/.depcheckrc.yml
+++ b/packages/fdc3-context/.depcheckrc.yml
@@ -3,5 +3,3 @@ ignores:
   - mkdirp
   # Invoked directly by s2tQuicktypeUtil.cjs during schema generation.
   - quicktype
-  # No tslib helpers are imported by the emitted code; likely valid to remove.
-  - tslib

--- a/packages/fdc3-context/package.json
+++ b/packages/fdc3-context/package.json
@@ -38,8 +38,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "mkdirp": "^3.0.1",
-    "quicktype": "23.0.78",
-    "tslib": "^2.7.0"
+    "quicktype": "23.0.78"
   },
   "overrides": {
     "ajv-formats": {


### PR DESCRIPTION
## Summary

- remove `tslib`, which is not referenced by source, compiler settings, or emitted code
- retain the documented ignores for `mkdirp` and `quicktype`, which schema-generation scripts invoke

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
