### PR TITLE
Remove unused get-agent dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19531,37 +19531,12 @@
         "@finos/fdc3-web-impl": "3.0.0-alpha.2",
         "@finos/testing": "3.0.0-alpha.2",
         "@types/wtfnode": "^0.7.3",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "jsonpath-plus": "^10.1.0",
         "quickpickle": "^1.6.1",
         "wtfnode": "^0.10.1"
       },
       "engines": {
         "node": ">=22"
       }
-    },
-    "packages/fdc3-get-agent/node_modules/ajv": {
-      "version": "8.20.0",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "packages/fdc3-get-agent/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/fdc3-schema": {
       "name": "@finos/fdc3-schema",

--- a/packages/fdc3-get-agent/.depcheckrc.yml
+++ b/packages/fdc3-get-agent/.depcheckrc.yml
@@ -1,2 +1,0 @@
-# depcheck currently reports no unused dependencies for this workspace.
-ignores: []

--- a/packages/fdc3-get-agent/.depcheckrc.yml
+++ b/packages/fdc3-get-agent/.depcheckrc.yml
@@ -1,7 +1,2 @@
-ignores:
-  # No source or test import was found; likely valid to remove.
-  - ajv
-  # No source or test import was found; likely valid to remove.
-  - ajv-formats
-  # Matching helpers come from @finos/testing; likely valid to remove here.
-  - jsonpath-plus
+# depcheck currently reports no unused dependencies for this workspace.
+ignores: []

--- a/packages/fdc3-get-agent/package.json
+++ b/packages/fdc3-get-agent/package.json
@@ -37,9 +37,6 @@
     "@finos/fdc3-web-impl": "3.0.0-alpha.2",
     "@finos/testing": "3.0.0-alpha.2",
     "@types/wtfnode": "^0.7.3",
-    "ajv": "^8.17.1",
-    "ajv-formats": "^3.0.1",
-    "jsonpath-plus": "^10.1.0",
     "quickpickle": "^1.6.1",
     "wtfnode": "^0.10.1"
   },


### PR DESCRIPTION
## Summary

- remove `ajv` and `ajv-formats`, which have no source, test, script, or configuration use in this workspace
- remove `jsonpath-plus`; matching helpers are supplied through `@finos/testing`
- clear the workspace depcheck ignore list

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
