### PR TITLE
Remove unused schema tslib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19572,7 +19572,6 @@
         "mkdirp": "^3.0.1",
         "quicktype": "23.0.78",
         "ts-morph": "^24.0.0",
-        "tslib": "^2.7.0",
         "typescript": "^5.6.3"
       },
       "engines": {

--- a/packages/fdc3-schema/.depcheckrc.yml
+++ b/packages/fdc3-schema/.depcheckrc.yml
@@ -5,5 +5,3 @@ ignores:
   - mkdirp
   # Invoked directly by s2tQuicktypeUtil.cjs during schema generation.
   - quicktype
-  # No tslib helpers are imported by the emitted code; likely valid to remove.
-  - tslib

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -32,7 +32,6 @@
     "mkdirp": "^3.0.1",
     "quicktype": "23.0.78",
     "ts-morph": "^24.0.0",
-    "tslib": "^2.7.0",
     "typescript": "^5.6.3"
   },
   "type": "module",


### PR DESCRIPTION
## Summary

- remove `tslib`, which is not referenced by source, compiler settings, or emitted code
- retain documented generator dependencies used through scripts or `createRequire()`

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
