### PR TITLE
Clean up security dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19590,24 +19590,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
-        "@types/expect": "24.3.0",
         "@types/jest": "^29.5.12",
-        "@types/lodash": "4.17.24",
         "@types/node": "^20.16.11",
         "@types/uuid": "^10.0.0",
-        "@typescript-eslint/eslint-plugin": "^8.18.2",
-        "@typescript-eslint/parser": "^8.18.2",
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-prettier": "3.3.1",
-        "expect": "^29.7.0",
         "globals": "^15.14.0",
-        "is-ci": "4.1.0",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "jsonpath-plus": "^10.1.0",
-        "prettier": "3.9.5",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.1.2",
         "tsx": "^4.23.1",
@@ -19624,12 +19614,6 @@
         "@finos/fdc3-schema": "3.0.0-alpha.2",
         "@finos/fdc3-standard": "3.0.0-alpha.2"
       }
-    },
-    "packages/fdc3-security/node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/fdc3-standard": {
       "name": "@finos/fdc3-standard",

--- a/packages/fdc3-security/.depcheckrc.yml
+++ b/packages/fdc3-security/.depcheckrc.yml
@@ -3,35 +3,15 @@ ignores:
   - eslint
   # Invoked by the build and test package scripts.
   - typescript
-  # No direct type reference was found; likely valid to remove.
-  - "@types/expect"
   # Supplies Jest globals to the TypeScript test build.
   - "@types/jest"
-  # No direct type reference was found; likely valid to remove.
-  - "@types/lodash"
-  # Superseded by the package's typescript-eslint flat-config dependency; likely valid to remove.
-  - "@typescript-eslint/eslint-plugin"
-  # Superseded by the package's typescript-eslint flat-config dependency; likely valid to remove.
-  - "@typescript-eslint/parser"
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-import
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-prettier
-  # Tests use Jest's global expect; likely valid to remove.
-  - expect
-  # No source or script reference was found; likely valid to remove.
-  - is-ci
   # Invoked by the `test-jest` package script.
   - jest
   # Configured as a reporter in jest.config.mjs.
   - jest-junit
-  # No source or configuration reference was found; likely valid to remove.
-  - jsonpath-plus
   # Configured as the ESM TypeScript transform in jest.config.mjs.
   - ts-jest
-  # No package script invokes Prettier directly; likely valid to remove.
-  - prettier
   # Invoked by the `clean` package script.
   - rimraf
-  # No source or package script reference was found; likely valid to remove.
+  # Used to execute the standalone TypeScript examples documented in samples/README.md.
   - tsx

--- a/packages/fdc3-security/package.json
+++ b/packages/fdc3-security/package.json
@@ -37,31 +37,21 @@
     "ws": "^8.21.1"
   },
   "peerDependencies": {
+    "@finos/fdc3-agent-proxy": "3.0.0-alpha.2",
     "@finos/fdc3-context": "3.0.0-alpha.2",
     "@finos/fdc3-schema": "3.0.0-alpha.2",
-    "@finos/fdc3-standard": "3.0.0-alpha.2",
-    "@finos/fdc3-agent-proxy": "3.0.0-alpha.2"
+    "@finos/fdc3-standard": "3.0.0-alpha.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
-    "@types/expect": "24.3.0",
     "@types/jest": "^29.5.12",
-    "@types/lodash": "4.17.24",
     "@types/node": "^20.16.11",
     "@types/uuid": "^10.0.0",
-    "@typescript-eslint/eslint-plugin": "^8.18.2",
-    "@typescript-eslint/parser": "^8.18.2",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-prettier": "3.3.1",
-    "expect": "^29.7.0",
     "globals": "^15.14.0",
-    "is-ci": "4.1.0",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "jsonpath-plus": "^10.1.0",
-    "prettier": "3.9.5",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.1.2",
     "tsx": "^4.23.1",


### PR DESCRIPTION
## Summary

- remove ten unused type, lint, formatting, test, CI, and JSONPath declarations
- retain `tsx` and document its use for the standalone TypeScript examples in `samples/README.md`

## Validation

- `npm run lint --workspace packages/fdc3-security`
- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
