### PR TITLE
Remove unused standard dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17110,20 +17110,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-essentials": {
-      "version": "10.2.1",
-      "integrity": "sha512-+Id1fRkuir+CsgK2x04/icS2b4V1hQmq7ObzIrDjhN0ozfRYivnP7aaKMVJfLApQm0trjR39A6NIMVchiB9Erw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=4.5.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/ts-jest": {
       "version": "29.4.11",
       "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
@@ -18388,19 +18374,6 @@
         }
       }
     },
-    "node_modules/vitest-mock-extended": {
-      "version": "3.1.1",
-      "integrity": "sha512-IQBKkEYB5BW4eJ+8JHZRzrLkKIJu5zkLJsU6u8vB+skSXbES+Di86nrUIbXwEQivDXcR4APMZFSvt398+iqKYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ts-essentials": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "3.x || 4.x || 5.x || 6.x",
-        "vitest": ">=3.0.0"
-      }
-    },
     "node_modules/vitest/node_modules/@types/chai": {
       "version": "5.2.3",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
@@ -19636,16 +19609,12 @@
       "version": "3.0.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-context": "3.0.0-alpha.2",
-        "@finos/fdc3-schema": "3.0.0-alpha.2"
+        "@finos/fdc3-context": "3.0.0-alpha.2"
       },
       "devDependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
         "jsdom": "^28.1.0",
-        "jsonschema": "^1.4.0",
-        "quicktype": "23.0.78",
-        "tslib": "^2.7.0",
-        "vitest-mock-extended": "^3.0.0"
+        "jsonschema": "^1.4.0"
       },
       "engines": {
         "node": ">=22"

--- a/packages/fdc3-standard/.depcheckrc.yml
+++ b/packages/fdc3-standard/.depcheckrc.yml
@@ -1,11 +1,3 @@
 ignores:
-  # No source import or package export was found; likely valid to remove.
-  - "@finos/fdc3-schema"
   # Selected as the Vitest DOM environment in vitest.config.ts.
   - jsdom
-  # No schema-generation command exists in this package; likely valid to remove.
-  - quicktype
-  # No tslib helpers are imported by the emitted code; likely valid to remove.
-  - tslib
-  # No source or test import was found; likely valid to remove.
-  - vitest-mock-extended

--- a/packages/fdc3-standard/package.json
+++ b/packages/fdc3-standard/package.json
@@ -32,16 +32,12 @@
     "printWidth": 120
   },
   "dependencies": {
-    "@finos/fdc3-context": "3.0.0-alpha.2",
-    "@finos/fdc3-schema": "3.0.0-alpha.2"
+    "@finos/fdc3-context": "3.0.0-alpha.2"
   },
   "devDependencies": {
     "@apidevtools/swagger-parser": "^10.1.1",
     "jsdom": "^28.1.0",
-    "jsonschema": "^1.4.0",
-    "quicktype": "23.0.78",
-    "tslib": "^2.7.0",
-    "vitest-mock-extended": "^3.0.0"
+    "jsonschema": "^1.4.0"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- remove four declarations with no source, test, script, generator, or emitted-helper use
- retain and document `jsdom`, which Vitest selects as this workspace's test environment

Removed: `@finos/fdc3-schema`, `quicktype`, `tslib`, and `vitest-mock-extended`.

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
