### PR TITLE
Remove unused example app dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7068,14 +7068,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/canonicalize": {
-      "version": "2.1.0",
-      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "canonicalize": "bin/canonicalize.js"
-      }
-    },
     "node_modules/chai": {
       "version": "4.5.0",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
@@ -20338,9 +20330,7 @@
         "@azure/msal-browser": "^4.12.0",
         "@finos/fdc3": "3.0.0-alpha.2",
         "@finos/fdc3-security": "3.0.0-alpha.2",
-        "@jridgewell/trace-mapping": "^0.3.28",
         "@vitejs/plugin-react": "^4.7.0",
-        "canonicalize": "^2.1.0",
         "dotenv": "^16.4.0",
         "express": "^4.21.1",
         "express-rate-limit": "^7.5.0",
@@ -20349,7 +20339,6 @@
         "react-dom": "^18.3.1",
         "tsx": "^4.23.1",
         "typescript": "^5.6.3",
-        "uuid": "^14.0.1",
         "vite": "^7.3.5",
         "ws": "^8.21.1"
       },

--- a/toolbox/fdc3-example-apps/.depcheckrc.yml
+++ b/toolbox/fdc3-example-apps/.depcheckrc.yml
@@ -1,11 +1,5 @@
 ignores:
   # Invoked by the `build` package script and used by tsx/Vite compilation.
   - typescript
-  # No source or configuration reference was found; likely valid to remove.
-  - "@jridgewell/trace-mapping"
-  # No source import was found; likely valid to remove.
-  - canonicalize
-  # No source import was found; likely valid to remove.
-  - uuid
   # Invoked by the `clean` package script.
   - rimraf

--- a/toolbox/fdc3-example-apps/package.json
+++ b/toolbox/fdc3-example-apps/package.json
@@ -41,9 +41,7 @@
     "@azure/msal-browser": "^4.12.0",
     "@finos/fdc3": "3.0.0-alpha.2",
     "@finos/fdc3-security": "3.0.0-alpha.2",
-    "@jridgewell/trace-mapping": "^0.3.28",
     "@vitejs/plugin-react": "^4.7.0",
-    "canonicalize": "^2.1.0",
     "dotenv": "^16.4.0",
     "express": "^4.21.1",
     "express-rate-limit": "^7.5.0",
@@ -52,15 +50,14 @@
     "react-dom": "^18.3.1",
     "tsx": "^4.23.1",
     "typescript": "^5.6.3",
-    "uuid": "^14.0.1",
     "vite": "^7.3.5",
     "ws": "^8.21.1"
   },
   "devDependencies": {
-    "rimraf": "^6.0.1",
     "@types/express": "^4.17.21",
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.12",
-    "@types/react-dom": "^18.3.1"
+    "@types/react-dom": "^18.3.1",
+    "rimraf": "^6.0.1"
   }
 }


### PR DESCRIPTION
## Summary

- remove `@jridgewell/trace-mapping`, `canonicalize`, and `uuid`, which have no source, configuration, or script use in this workspace
- retain and document `typescript` and `rimraf`, which are invoked by package scripts

## Validation

- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
