### PR TITLE
Remove unused web demo dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10037,12 +10037,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/image-crop-or-pad": {
       "version": "1.0.1",
       "integrity": "sha512-0Gu+rHoFyKLZ14oaj+CJCElQz/5EOlMHvO9WwsANukerPSGG4MFpC81oDbvsN1wMbSzAhsgTPvgbBICl7ecazg==",
@@ -13243,91 +13237,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/nodemon": {
-      "version": "3.1.14",
-      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^10.2.1",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/nodemon/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/minimatch": {
-      "version": "10.2.5",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "8.0.0",
       "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
@@ -14454,12 +14363,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -15923,18 +15826,6 @@
         "is-arrayish": "^0.3.1"
       }
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
@@ -17062,15 +16953,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
@@ -17483,12 +17365,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.29.0",
@@ -20374,7 +20250,6 @@
       "dependencies": {
         "@finos/fdc3": "3.0.0-alpha.2",
         "@types/uuid": "^10.0.0",
-        "@types/ws": "^8.5.12",
         "express": "^4.22.2",
         "socket.io": "^4.8.0",
         "socket.io-client": "^4.8.0",
@@ -20392,8 +20267,6 @@
         "eslint": "^9.32.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.14.0",
-        "nodemon": "^3.1.7",
-        "rimraf": "^6.0.1",
         "typescript-eslint": "^8.64.0",
         "vite": "^6.4.2"
       },

--- a/toolbox/fdc3-for-web/demo/.depcheckrc.yml
+++ b/toolbox/fdc3-for-web/demo/.depcheckrc.yml
@@ -7,11 +7,5 @@ ignores:
   - typescript
   # Supplies Node.js types to the server-side TypeScript source.
   - "@types/node"
-  # No direct ws import exists and ws ships its own types; likely valid to remove.
-  - "@types/ws"
-  # No package script invokes nodemon; likely valid to remove.
-  - nodemon
   # Used by vite-express at runtime rather than imported directly by this package.
   - vite
-  # No package script invokes rimraf; likely valid to remove.
-  - rimraf

--- a/toolbox/fdc3-for-web/demo/package.json
+++ b/toolbox/fdc3-for-web/demo/package.json
@@ -16,15 +16,12 @@
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.14.0",
-    "nodemon": "^3.1.7",
-    "rimraf": "^6.0.1",
     "typescript-eslint": "^8.64.0",
     "vite": "^6.4.2"
   },
   "dependencies": {
     "@finos/fdc3": "3.0.0-alpha.2",
     "@types/uuid": "^10.0.0",
-    "@types/ws": "^8.5.12",
     "express": "^4.22.2",
     "socket.io": "^4.8.0",
     "socket.io-client": "^4.8.0",


### PR DESCRIPTION
## Summary

- remove `@types/ws`; the demo has no direct `ws` import and `ws` supplies its own types
- remove `nodemon` and `rimraf`, which are not invoked by package scripts or configuration
- retain documented indirect build/runtime dependencies such as Vite

## Validation

- `npm run lint --workspace toolbox/fdc3-for-web/demo`
- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
