### PR TITLE
Clean up web implementation dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20966,9 +20966,7 @@
       "version": "3.0.0-alpha.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3-standard": "3.0.0-alpha.2",
-        "@types/uuid": "^10.0.0",
-        "uuid": "^14.0.1"
+        "@finos/fdc3-standard": "3.0.0-alpha.2"
       },
       "devDependencies": {
         "@cucumber/cucumber": "13.1.1",
@@ -20976,28 +20974,38 @@
         "@cucumber/messages": "^28.1.0",
         "@cucumber/pretty-formatter": "4.0.0",
         "@finos/testing": "3.0.0-alpha.2",
-        "@types/expect": "24.3.0",
-        "@types/lodash": "4.17.24",
-        "@types/uuid": "^10.0.0",
         "cucumber-console-formatter": "1.0.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-prettier": "3.3.1",
-        "is-ci": "4.1.0",
-        "jsonpath-plus": "^10.1.0",
         "openapi-typescript": "^7.13.0",
-        "quickpickle": "^1.6.1",
-        "ts-node": "^10.9.2",
-        "uuid": "^14.0.1"
+        "quickpickle": "^1.6.1"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "toolbox/fdc3-for-web/fdc3-web-impl/node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+    "toolbox/fdc3-for-web/fdc3-web-impl/node_modules/@cucumber/messages": {
+      "version": "28.1.0",
+      "integrity": "sha512-2LzZtOwYKNlCuNf31ajkrekoy2M4z0Z1QGiPH40n4gf5t8VOUFb7m1ojtR4LmGvZxBGvJZP8voOmRqDWzBzYKA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.1.0"
+      }
+    },
+    "toolbox/fdc3-for-web/fdc3-web-impl/node_modules/uuid": {
+      "version": "11.1.0",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "toolbox/fdc3-for-web/reference-ui": {
       "name": "fdc3-for-web-reference-ui",

--- a/toolbox/fdc3-for-web/fdc3-web-impl/.depcheckrc.yml
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/.depcheckrc.yml
@@ -1,29 +1,11 @@
 ignores:
-  # Installed for Cucumber report formatting; likely removable if no external runner relies on it.
+  # Available to Cucumber runs that request the HTML formatter.
   - "@cucumber/html-formatter"
   # Used by Cucumber formatters through their plugin API rather than a source import.
   - "@cucumber/messages"
-  # Installed for Cucumber report formatting; likely removable if no external runner relies on it.
+  # Available to Cucumber runs that request the pretty formatter.
   - "@cucumber/pretty-formatter"
-  # No direct type reference was found; likely valid to remove.
-  - "@types/expect"
-  # No direct type reference was found; likely valid to remove.
-  - "@types/lodash"
-  # uuid now ships its own types; likely valid to remove from both dependency sections.
-  - "@types/uuid"
   # Loaded by Cucumber as a formatter plugin rather than imported by source.
   - cucumber-console-formatter
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-import
-  # Not referenced by this package's current ESLint configuration; likely valid to remove.
-  - eslint-plugin-prettier
-  # No source or script reference was found; likely valid to remove.
-  - is-ci
-  # Matching helpers come from @finos/testing; likely valid to remove here.
-  - jsonpath-plus
   # Invoked by the `directory-openapi` package script.
   - openapi-typescript
-  # TypeScript is compiled with tsc rather than ts-node; likely valid to remove.
-  - ts-node
-  # No source import was found; likely valid to remove from both dependency sections.
-  - uuid

--- a/toolbox/fdc3-for-web/fdc3-web-impl/package.json
+++ b/toolbox/fdc3-for-web/fdc3-web-impl/package.json
@@ -27,9 +27,7 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@finos/fdc3-standard": "3.0.0-alpha.2",
-    "@types/uuid": "^10.0.0",
-    "uuid": "^14.0.1"
+    "@finos/fdc3-standard": "3.0.0-alpha.2"
   },
   "devDependencies": {
     "@cucumber/cucumber": "13.1.1",
@@ -37,18 +35,9 @@
     "@cucumber/messages": "^28.1.0",
     "@cucumber/pretty-formatter": "4.0.0",
     "@finos/testing": "3.0.0-alpha.2",
-    "@types/expect": "24.3.0",
-    "@types/lodash": "4.17.24",
-    "@types/uuid": "^10.0.0",
     "cucumber-console-formatter": "1.0.0",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-prettier": "3.3.1",
-    "is-ci": "4.1.0",
-    "jsonpath-plus": "^10.1.0",
     "openapi-typescript": "^7.13.0",
-    "quickpickle": "^1.6.1",
-    "ts-node": "^10.9.2",
-    "uuid": "^14.0.1"
+    "quickpickle": "^1.6.1"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

- remove nine unused type, lint, CI, JSONPath, TypeScript-runner, and UUID declarations
- retain both Cucumber formatter packages and document their plugin-driven use
- retain other documented formatter and OpenAPI generator dependencies

## Validation

- `npm run lint --workspace toolbox/fdc3-for-web/fdc3-web-impl`
- `npm run build`
- `npm test`
- `npx depcheck --skip-missing --quiet` at the repository root and in every workspace
