### PR TITLE
Run Sonatype CVE audit nightly

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -1,22 +1,11 @@
 name: Node.js CVE Scanning
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'allow-list.json'
-      - 'package.json'
-      - 'toolbox/fdc3-workbench/package.json'
-      - '.github/workflows/cve-scanning.yml'
-  # push:
-  #   paths:
-  #     - 'package.json'
-  #     - 'toolbox/fdc3-workbench/package.json'
-  #     - '.github/workflows/cve-scanning.yml'
-  #     - 'website/package.json'
+  # Sonatype Guide audits consume a shared credit allowance. Run once nightly
+  # to retain vulnerability visibility without exhausting credits on PR activity.
+  # See https://github.com/finos/FDC3/issues/2087.
   schedule:
-    # Run every day at 5am and 5pm
-    - cron: '0 5,17 * * *'
+    - cron: '0 5 * * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- remove the Sonatype Guide audit from pull request events
- reduce the scheduled audit from twice daily to once nightly at 05:00 UTC
- document why the credit-consuming audit is intentionally schedule-only

## Why

The Sonatype Guide integration was introduced on July 22, 2026, and began returning HTTP 402 credit failures on August 3. Running it for qualifying PR activity exhausted the shared allowance in roughly 10 days.

A nightly scan preserves useful vulnerability visibility for maintainers while avoiding repeated, non-actionable red checks on pull requests after the quota is exhausted.

Closes #2087.

## Validation

- `npx prettier --check .github/workflows/cve-scanning.yml`
- `git diff --check`
