### PR TITLE
Bump quicktype to 23.0.176

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1781,6 +1781,7 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1792,6 +1793,7 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2122,19 +2124,9 @@
         "@cucumber/messages": "*"
       }
     },
-    "node_modules/@cucumber/pretty-formatter/node_modules/@cucumber/query": {
-      "version": "16.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@teppeis/multimaps": "3.0.0",
-        "lodash.sortby": "^4.7.0"
-      },
-      "peerDependencies": {
-        "@cucumber/messages": "*"
-      }
-    },
     "node_modules/@cucumber/query": {
-      "version": "16.1.0",
+      "version": "16.0.0",
+      "integrity": "sha512-CtGBHLc92y1RNogXGOFVF7so+XdLR5rVuJGsS6nH7yLeayyYhdV8lYW/LG8R05cm4irG/RO6Wn5I2CAgxMhmwQ==",
       "license": "MIT",
       "dependencies": {
         "@teppeis/multimaps": "3.0.0",
@@ -2940,7 +2932,8 @@
       }
     },
     "node_modules/@glideapps/ts-necessities": {
-      "version": "2.4.0",
+      "version": "2.2.3",
+      "integrity": "sha512-gXi0awOZLHk3TbW55GZLCPP6O+y/b5X1pBXKBVckFONSwF1z1E5ND2BGJsghQFah+pW7pkkyFb2VhUQI2qhL5w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3186,20 +3179,6 @@
     "node_modules/@jest/core/node_modules/ansi-regex": {
       "version": "5.0.1",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/ci-info": {
-      "version": "3.9.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3548,6 +3527,7 @@
     },
     "node_modules/@mark.probst/typescript-json-schema": {
       "version": "0.55.0",
+      "integrity": "sha512-jI48mSnRgFQxXiE/UTUCVCpX8lK3wCFKLF1Ss2aEreboKNuLQGt3e0/YFqWVHe/WENxOaqiJvwOz+L/SrN2+qQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3566,11 +3546,14 @@
     },
     "node_modules/@mark.probst/typescript-json-schema/node_modules/@types/node": {
       "version": "16.18.126",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@mark.probst/typescript-json-schema/node_modules/glob": {
       "version": "7.2.3",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3590,6 +3573,7 @@
     },
     "node_modules/@mark.probst/typescript-json-schema/node_modules/typescript": {
       "version": "4.9.4",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4405,21 +4389,25 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4684,11 +4672,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
+      "version": "18.3.1",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
       "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^18.0.0"
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -4705,10 +4694,12 @@
       "license": "MIT"
     },
     "node_modules/@types/send": {
-      "version": "1.2.1",
+      "version": "0.17.6",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/mime": "^1",
         "@types/node": "*"
       }
     },
@@ -4722,22 +4713,8 @@
         "@types/send": "<1"
       }
     },
-    "node_modules/@types/serve-static/node_modules/@types/send": {
-      "version": "0.17.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/urijs": {
-      "version": "1.19.26",
       "dev": true,
       "license": "MIT"
     },
@@ -5533,6 +5510,7 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5579,6 +5557,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5695,6 +5674,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6220,7 +6200,8 @@
       }
     },
     "node_modules/browser-or-node": {
-      "version": "2.1.1",
+      "version": "3.0.0",
+      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6513,6 +6494,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "dev": true,
@@ -6707,6 +6703,7 @@
     },
     "node_modules/collection-utils": {
       "version": "1.0.1",
+      "integrity": "sha512-LA2YTIlR7biSpXkKYwwuzGjwL5rjWEZVOSnvdUc7gObvWe4WkjxOpfrdhoP7Hs09YWDVfg0Mal9BpAqLfVEzQg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -6979,11 +6976,13 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "4.1.0",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8039,6 +8038,7 @@
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8052,6 +8052,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8772,6 +8773,8 @@
     },
     "node_modules/graphql": {
       "version": "0.11.7",
+      "integrity": "sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9617,6 +9620,7 @@
     },
     "node_modules/is-url": {
       "version": "1.2.4",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "dev": true,
       "license": "MIT"
     },
@@ -9744,6 +9748,7 @@
     },
     "node_modules/iterall": {
       "version": "1.1.3",
+      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -10008,20 +10013,6 @@
         "ts-node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-config/node_modules/ci-info": {
-      "version": "3.9.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-config/node_modules/glob": {
@@ -10425,20 +10416,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-util/node_modules/ci-info": {
-      "version": "3.9.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "dev": true,
@@ -10529,6 +10506,7 @@
     },
     "node_modules/js-base64": {
       "version": "3.9.2",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -11799,6 +11777,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11818,16 +11797,19 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12210,6 +12192,7 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
     },
@@ -12266,6 +12249,7 @@
     },
     "node_modules/path-equal": {
       "version": "1.2.5",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
       "dev": true,
       "license": "MIT"
     },
@@ -12735,16 +12719,18 @@
       }
     },
     "node_modules/quicktype": {
-      "version": "23.0.78",
+      "version": "23.0.176",
+      "integrity": "sha512-Vz+hGWtfJiHMw1WwWTpIWEAHTrCkvPh0wiheJ8MHmo5s1rHth4hbRYWrTTlYCtnbcPmTS2KMohlqaS0DFfKbrA==",
       "dev": true,
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/quicktype-core",
         "./packages/quicktype-graphql-input",
-        "./packages/quicktype-typescript-input"
+        "./packages/quicktype-typescript-input",
+        "./packages/quicktype-vscode"
       ],
       "dependencies": {
-        "@glideapps/ts-necessities": "^2.1.3",
+        "@glideapps/ts-necessities": "^2.2.3",
         "chalk": "^4.1.2",
         "collection-utils": "^1.0.1",
         "command-line-args": "^5.2.1",
@@ -12752,11 +12738,11 @@
         "cross-fetch": "^4.0.0",
         "graphql": "^0.11.7",
         "lodash": "^4.17.21",
-        "moment": "^2.29.4",
-        "quicktype-core": "23.0.78",
-        "quicktype-graphql-input": "23.0.78",
-        "quicktype-typescript-input": "23.0.78",
-        "readable-stream": "^4.4.2",
+        "moment": "^2.30.1",
+        "quicktype-core": "23.0.176",
+        "quicktype-graphql-input": "23.0.176",
+        "quicktype-typescript-input": "23.0.176",
+        "readable-stream": "^4.5.2",
         "stream-json": "1.8.0",
         "string-to-stream": "^3.0.1",
         "typescript": "4.9.5"
@@ -12769,34 +12755,30 @@
       }
     },
     "node_modules/quicktype-core": {
-      "version": "23.0.78",
+      "version": "23.0.176",
+      "integrity": "sha512-zKgd25bZtPgJ3SQorT6EpRsdW6kAlOh3hXj/RH6fyUuFRkN5Qx61j4F/iRMRm+EyxpvyI6jxZAh/MJ50ZMAjDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@glideapps/ts-necessities": "2.1.3",
-        "@types/urijs": "^1.19.19",
-        "browser-or-node": "^2.1.1",
+        "@glideapps/ts-necessities": "2.2.3",
+        "browser-or-node": "^3.0.0",
         "collection-utils": "^1.0.1",
         "cross-fetch": "^4.0.0",
         "is-url": "^1.2.4",
-        "js-base64": "^3.7.5",
+        "js-base64": "^3.7.7",
         "lodash": "^4.17.21",
         "pako": "^1.0.6",
         "pluralize": "^8.0.0",
-        "readable-stream": "4.4.2",
+        "readable-stream": "4.5.2",
         "unicode-properties": "^1.4.1",
         "urijs": "^1.19.1",
         "wordwrap": "^1.0.0",
-        "yaml": "^2.3.1"
+        "yaml": "^2.4.1"
       }
     },
-    "node_modules/quicktype-core/node_modules/@glideapps/ts-necessities": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/quicktype-core/node_modules/readable-stream": {
-      "version": "4.4.2",
+      "version": "4.5.2",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12811,27 +12793,30 @@
       }
     },
     "node_modules/quicktype-graphql-input": {
-      "version": "23.0.78",
+      "version": "23.0.176",
+      "integrity": "sha512-W0IMVdHxuMa6w/WvfB9/eoGbI/iK17emMBSfLdNjrcrsKkrkK6Y2Gs0z9hrIPJ6yy6bxY4skmgRSbSIaLPf6DQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "collection-utils": "^1.0.1",
         "graphql": "^0.11.7",
-        "quicktype-core": "23.0.78"
+        "quicktype-core": "23.0.176"
       }
     },
     "node_modules/quicktype-typescript-input": {
-      "version": "23.0.78",
+      "version": "23.0.176",
+      "integrity": "sha512-ySOkQXcvs6NXz+tdGk0C5MBSAijbn7P3mvw8/zOB90iz+xDHatu3tpJf9HwCj/rsAYkvlhZgHcmgZiYgqjzeEg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mark.probst/typescript-json-schema": "0.55.0",
-        "quicktype-core": "23.0.78",
+        "quicktype-core": "23.0.176",
         "typescript": "4.9.5"
       }
     },
     "node_modules/quicktype-typescript-input/node_modules/typescript": {
       "version": "4.9.5",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -12844,6 +12829,7 @@
     },
     "node_modules/quicktype/node_modules/readable-stream": {
       "version": "4.7.0",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12859,6 +12845,7 @@
     },
     "node_modules/quicktype/node_modules/typescript": {
       "version": "4.9.5",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13493,6 +13480,7 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14124,11 +14112,13 @@
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
       "version": "1.8.0",
+      "integrity": "sha512-HZfXngYHUAr1exT4fxlbc1IOce1RYxp2ldeaf97LYCOPSoOqY/1Psp7iGvpb+6JIOgkra9zDYnPX01hGAHzEPw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14636,6 +14626,7 @@
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14856,6 +14847,7 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14898,6 +14890,7 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.4",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -15181,6 +15174,7 @@
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15198,6 +15192,7 @@
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15207,6 +15202,7 @@
     },
     "node_modules/unicode-trie/node_modules/pako": {
       "version": "0.2.9",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
       "license": "MIT"
     },
@@ -15281,6 +15277,7 @@
     },
     "node_modules/urijs": {
       "version": "1.19.11",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -15328,6 +15325,7 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -15991,6 +15989,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16088,7 +16087,7 @@
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "mkdirp": "^3.0.1",
-        "quicktype": "23.0.78"
+        "quicktype": "23.0.176"
       },
       "engines": {
         "node": ">=22"
@@ -16125,7 +16124,7 @@
       "devDependencies": {
         "message-await": "^1.1.0",
         "mkdirp": "^3.0.1",
-        "quicktype": "23.0.78",
+        "quicktype": "23.0.176",
         "ts-morph": "^24.0.0",
         "typescript": "^7.0.2"
       },
@@ -16602,14 +16601,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "toolbox/fdc3-workbench/node_modules/@types/react-dom": {
-      "version": "18.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "toolbox/fdc3-workbench/node_modules/react": {

--- a/packages/fdc3-context/package.json
+++ b/packages/fdc3-context/package.json
@@ -38,7 +38,7 @@
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "mkdirp": "^3.0.1",
-    "quicktype": "23.0.78"
+    "quicktype": "23.0.176"
   },
   "overrides": {
     "ajv-formats": {

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "message-await": "^1.1.0",
     "mkdirp": "^3.0.1",
-    "quicktype": "23.0.78",
+    "quicktype": "23.0.176",
     "ts-morph": "^24.0.0",
     "typescript": "^7.0.2"
   },


### PR DESCRIPTION
## Summary

- bump quicktype from 23.0.78 to 23.0.176 in fdc3-context and fdc3-schema
- update the shared npm lockfile
- remain on the compatible 23.0 release line because quicktype 23.3+ and 26 currently break FDC3 schema generation

## Validation

- npm run build
- npm test --workspace packages/fdc3-context
- npm test --workspace packages/fdc3-schema

The complete workspace test command was also exercised; affected-package tests pass, while the unconstrained Windows run encountered the repository's existing Vitest worker resource failure outside these packages.