### PR TITLE
Bump @apidevtools dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,19 +60,50 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.7.2",
+      "version": "15.5.1",
+      "integrity": "sha512-69KDKWQvk5jfDQfSTzAUHkI731X7CaJLwQxlS87AXyFHoJzsd/Pufrqsz7PqXMgrtAA99D9Y6NujkEkzli6kVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
+        "js-yaml": "^5.2.2",
+        "undici": "^6.28.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=20"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "5.2.3",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/undici": {
+      "version": "6.28.0",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -89,20 +120,36 @@
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.1.1",
+      "version": "12.1.0",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
-        "@jsdevtools/ono": "^7.1.3",
         "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -3520,11 +3567,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
@@ -16211,7 +16253,7 @@
         "@finos/fdc3-context": "3.0.0-alpha.2"
       },
       "devDependencies": {
-        "@apidevtools/swagger-parser": "^10.1.1",
+        "@apidevtools/swagger-parser": "^12.1.0",
         "jsdom": "^30.0.1",
         "jsonschema": "^1.4.0"
       },
@@ -16539,7 +16581,7 @@
       "version": "3.0.0-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@apidevtools/json-schema-ref-parser": "11.7.2",
+        "@apidevtools/json-schema-ref-parser": "^15.5.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@eslint/compat": "^1.2.5",

--- a/packages/fdc3-standard/package.json
+++ b/packages/fdc3-standard/package.json
@@ -35,7 +35,7 @@
     "@finos/fdc3-context": "3.0.0-alpha.2"
   },
   "devDependencies": {
-    "@apidevtools/swagger-parser": "^10.1.1",
+    "@apidevtools/swagger-parser": "^12.1.0",
     "jsdom": "^30.0.1",
     "jsonschema": "^1.4.0"
   },

--- a/toolbox/fdc3-workbench/package.json
+++ b/toolbox/fdc3-workbench/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "devDependencies": {
-    "@apidevtools/json-schema-ref-parser": "11.7.2",
+    "@apidevtools/json-schema-ref-parser": "^15.5.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@eslint/compat": "^1.2.5",


### PR DESCRIPTION
## Summary

- bump @apidevtools/swagger-parser to 12.1.0
- bump @apidevtools/json-schema-ref-parser to 15.5.1
- update the shared lockfile

## Validation

- npm run build
- npm test --workspace packages/fdc3-standard
- npm run build --workspace toolbox/fdc3-workbench

## Supersedes

Closes #2107.
Closes #2106.