### PR TITLE
Bump Vite to 8.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3826,6 +3826,7 @@
     },
     "node_modules/@oxc-project/types": {
       "version": "0.142.0",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -3936,6 +3937,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3950,6 +3952,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3965,6 +3968,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3980,6 +3984,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3995,6 +4000,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4010,6 +4016,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4025,6 +4032,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4040,6 +4048,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4055,6 +4064,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4070,6 +4080,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4085,6 +4096,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4100,6 +4112,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4115,6 +4128,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4130,6 +4144,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7241,6 +7256,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8297,6 +8313,7 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10788,6 +10805,7 @@
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -10819,6 +10837,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10837,6 +10856,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10856,6 +10876,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10875,6 +10896,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10894,6 +10916,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10913,6 +10936,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10932,6 +10956,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10951,6 +10976,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10970,6 +10996,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10989,6 +11016,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11008,6 +11036,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11736,6 +11765,7 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.17",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12479,6 +12509,7 @@
     },
     "node_modules/postcss": {
       "version": "8.5.25",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13284,6 +13315,7 @@
     },
     "node_modules/rolldown": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.142.0",
@@ -14016,6 +14048,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -14654,6 +14687,7 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -14668,6 +14702,7 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15368,13 +15403,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.2.0",
+      "version": "8.2.1",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.23",
-        "rolldown": "~1.2.0",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -15460,6 +15497,7 @@
     },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -16258,7 +16296,7 @@
         "http-server": "^14.1.1",
         "shx": "^0.4.0",
         "typescript": "^7.0.2",
-        "vite": "^8.2.0",
+        "vite": "^8.2.1",
         "vite-plugin-css-injected-by-js": "^5.0.2"
       },
       "engines": {
@@ -16344,7 +16382,6 @@
         "react-dom": "^18.3.1",
         "tsx": "^4.23.7",
         "typescript": "^7.0.2",
-        "vite": "^8.2.0",
         "ws": "^8.21.1"
       },
       "bin": {
@@ -16355,7 +16392,8 @@
         "@types/node": "^20.16.11",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
-        "rimraf": "^6.0.1"
+        "rimraf": "^6.0.1",
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=22"
@@ -16419,7 +16457,7 @@
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.14.0",
         "typescript-eslint": "^8.64.0",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=22"
@@ -16495,7 +16533,7 @@
         "globals": "^15.14.0",
         "typescript": "^7.0.2",
         "typescript-eslint": "^8.64.0",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=22"
@@ -16572,7 +16610,7 @@
         "typescript": "^7.0.2",
         "typescript-eslint": "^8.64.0",
         "uuid": "^14.0.1",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
       },
       "engines": {
         "node": ">=22"

--- a/toolbox/fdc3-conformance/package.json
+++ b/toolbox/fdc3-conformance/package.json
@@ -33,7 +33,7 @@
     "http-server": "^14.1.1",
     "shx": "^0.4.0",
     "typescript": "^7.0.2",
-    "vite": "^8.2.0",
+    "vite": "^8.2.1",
     "vite-plugin-css-injected-by-js": "^5.0.2"
   },
   "engines": {

--- a/toolbox/fdc3-example-apps/package.json
+++ b/toolbox/fdc3-example-apps/package.json
@@ -50,7 +50,6 @@
     "react-dom": "^18.3.1",
     "tsx": "^4.23.7",
     "typescript": "^7.0.2",
-    "vite": "^8.2.0",
     "ws": "^8.21.1"
   },
   "devDependencies": {
@@ -58,6 +57,7 @@
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "vite": "^8.2.1"
   }
 }

--- a/toolbox/fdc3-for-web/demo/package.json
+++ b/toolbox/fdc3-for-web/demo/package.json
@@ -17,7 +17,7 @@
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.14.0",
     "typescript-eslint": "^8.64.0",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   },
   "dependencies": {
     "@finos/fdc3": "3.0.0-alpha.2",

--- a/toolbox/fdc3-for-web/reference-ui/package.json
+++ b/toolbox/fdc3-for-web/reference-ui/package.json
@@ -20,7 +20,7 @@
     "globals": "^15.14.0",
     "typescript": "^7.0.2",
     "typescript-eslint": "^8.64.0",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   },
   "dependencies": {
     "@finos/fdc3": "3.0.0-alpha.2"

--- a/toolbox/fdc3-workbench/package.json
+++ b/toolbox/fdc3-workbench/package.json
@@ -67,7 +67,7 @@
     "typescript": "^7.0.2",
     "typescript-eslint": "^8.64.0",
     "uuid": "^14.0.1",
-    "vite": "^8.2.0"
+    "vite": "^8.2.1"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Bump Vite to 8.2.1 across all five workspaces that directly depend on it and update the shared lockfile.

## Validation

- npm run build
- tests for every directly affected workspace with a test script