### PR TITLE
Update remaining @finos/fdc3-schema dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4356,32 +4356,47 @@
       }
     },
     "node_modules/@ts-morph/common": {
-      "version": "0.25.0",
+      "version": "0.29.0",
+      "integrity": "sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minimatch": "^9.0.4",
+        "minimatch": "^10.0.1",
         "path-browserify": "^1.0.1",
-        "tinyglobby": "^0.2.9"
+        "tinyglobby": "^0.2.14"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.1.4",
+      "version": "5.0.9",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "9.0.9",
+      "version": "10.2.6",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -11318,65 +11333,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/message-await": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cli-cursor": "^3.1.0",
-        "log-symbols": "^4.1.0"
-      }
-    },
-    "node_modules/message-await/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/message-await/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/message-await/node_modules/onetime": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/message-await/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/message-await/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/methods": {
       "version": "1.1.2",
       "license": "MIT",
@@ -14837,11 +14793,12 @@
       }
     },
     "node_modules/ts-morph": {
-      "version": "24.0.0",
+      "version": "28.0.0",
+      "integrity": "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ts-morph/common": "~0.25.0",
+        "@ts-morph/common": "~0.29.0",
         "code-block-writer": "^13.0.3"
       }
     },
@@ -16122,10 +16079,9 @@
       "version": "3.0.0-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "message-await": "^1.1.0",
         "mkdirp": "^3.0.1",
         "quicktype": "23.0.176",
-        "ts-morph": "^24.0.0",
+        "ts-morph": "^28.0.0",
         "typescript": "^7.0.2"
       },
       "engines": {

--- a/packages/fdc3-schema/code-generation/generate-type-predicates.ts
+++ b/packages/fdc3-schema/code-generation/generate-type-predicates.ts
@@ -1,17 +1,18 @@
 import type { InterfaceDeclaration, KindToNodeMappings, MethodDeclaration, TypeAliasDeclaration } from 'ts-morph';
-import { createRequire } from 'node:module';
 import { Project, SyntaxKind } from 'ts-morph';
 
-// CJS default export (message-await) via require so emitted ESM runs under plain node (no tsx/esbuild)
-const requireModule = createRequire(import.meta.url);
-const messageAwaitMod = requireModule('message-await') as { default?: (...args: unknown[]) => unknown };
-const print = (messageAwaitMod.default ?? messageAwaitMod) as (
-  message: string,
-  options?: { spinner?: boolean }
-) => {
-  updateMessage: (message: string, force?: boolean) => void;
-  complete: (success: boolean, message: string) => void;
-};
+function print(message: string, _options?: { spinner?: boolean }) {
+  process.stdout.write(`${message}\r`);
+
+  return {
+    updateMessage(updatedMessage: string, _force?: boolean) {
+      process.stdout.write(`${updatedMessage}\r`);
+    },
+    complete(success: boolean, completedMessage: string) {
+      console.log(`${completedMessage}... ${success ? '√' : '×'}`);
+    },
+  };
+}
 
 // open a new project with just BrowserTypes as the only source file
 const project = new Project();

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -28,10 +28,9 @@
     "typegen-bridging": "cd schemas && node ../s2tQuicktypeUtil.cjs api/api.schema.json api/common.schema.json api/broadcastRequest.schema.json api/findInstancesRequest.schema.json api/findInstancesResponse.schema.json api/findIntentRequest.schema.json api/findIntentResponse.schema.json api/findIntentsByContextRequest.schema.json api/findIntentsByContextResponse.schema.json api/getAppMetadataRequest.schema.json api/getAppMetadataResponse.schema.json api/openRequest.schema.json api/openResponse.schema.json api/raiseIntentRequest.schema.json api/raiseIntentResponse.schema.json api/raiseIntentResultResponse.schema.json ../../fdc3-context/schemas/context/context.schema.json bridging ../generated/bridging/BridgingTypes.ts"
   },
   "devDependencies": {
-    "message-await": "^1.1.0",
     "mkdirp": "^3.0.1",
     "quicktype": "23.0.176",
-    "ts-morph": "^24.0.0",
+    "ts-morph": "^28.0.0",
     "typescript": "^7.0.2"
   },
   "type": "module",


### PR DESCRIPTION
## Summary

- bump ts-morph from 24.0.0 to 28.0.0
- remove message-await and replace its progress-only usage with a small local reporter
- update the shared npm lockfile

message-await 2.0.0 cannot be consumed because its published package declares dist/src/index.js as its entry point but does not include a dist directory. Removing it eliminates the remaining outdated dependency without changing generated output.

## Validation

- npm test --workspace packages/fdc3-schema
- npm run build

## Supersedes

Closes #2104. The Dependabot update cannot be used because message-await 2.0.0 was published without its declared entry-point files; this PR removes the dependency instead.