### PR TITLE
Fix intermittent failures in fdc3.destructuredMethods conformance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Prevented the FDC3 for Web reference implementation from sending channel-changed events to applications that have not registered a matching listener. ([#1806](https://github.com/finos/FDC3/issues/1806))
 * Fixed an issue in conformance test AOpensBWithWrongContext, which was not correctly waiting for the timeout and was sending close messages outside of the execution of the test. Also added logging of test starts and finishes to aid debugging. ([#1933](https://github.com/finos/FDC3/pull/1933))
 * Fixed the `BasicJC1` conformance test to skip user channel membership checks when `getInfo().optionalFeatures.UserChannelMembershipAPIs` is not advertised, while still validating `joinUserChannel`, `getCurrentChannel`, and `leaveCurrentChannel` when the feature is enabled. ([#1777](https://github.com/finos/FDC3/issues/1777))
+* Fixed intermittent failures in the `fdc3.destructuredMethods` conformance tests caused by mock apps not yet being ready when opened, and by too short a timeout when awaiting their close confirmation. ([#2114](https://github.com/finos/FDC3/issues/2114))
 
 ## [npm v2.2.3] - 2026-04-15
 

--- a/toolbox/fdc3-conformance/src/test/advanced/fdc3.destructured-methods.ts
+++ b/toolbox/fdc3-conformance/src/test/advanced/fdc3.destructured-methods.ts
@@ -1,6 +1,7 @@
 import { AppIdentifier, DesktopAgent, getAgent, IntentResolution, PrivateChannel } from '@finos/fdc3';
 import { expect } from 'chai';
-import { handleFail } from '../../utils';
+import constants from '../../constants';
+import { handleFail, wait } from '../../utils';
 import { closeMockAppWindow } from '../fdc3-conformance-utils';
 import { APIDocumentation } from '../support/apiDocuments';
 import { ContextType, Intent, IntentApp } from '../support/intent-support';
@@ -53,6 +54,9 @@ export default async () =>
         const appIdentifier = await open({ appId: IntentApp.IntentAppA });
         openedWindows = 1;
 
+        // open() may resolve before the mock app has registered its close listener.
+        await wait(constants.ShortWait);
+
         validateAppIdentifier(appIdentifier);
       } catch (ex) {
         handleFail(documentation + '\r\n' + APIDocumentation.open, ex);
@@ -65,6 +69,9 @@ export default async () =>
         const appIdentifier1 = await open({ appId: IntentApp.IntentAppA });
         const appIdentifier2 = await open({ appId: IntentApp.IntentAppA });
         openedWindows = 2;
+
+        // Ensure both mock apps are ready before querying and later closing them.
+        await wait(constants.ShortWait);
 
         const instances = await findInstances({ appId: IntentApp.IntentAppA });
 
@@ -84,7 +91,7 @@ export default async () =>
     it('(DestructuredGetAppMetadata) getAppMetadata should remain callable when destructured', async () => {
       try {
         const { getAppMetadata } = fdc3;
-        const metadata = await getAppMetadata();
+        const metadata = await getAppMetadata({ appId: IntentApp.IntentAppA });
 
         expect(metadata, documentation).to.have.property('appId');
       } catch (ex) {

--- a/toolbox/fdc3-conformance/src/test/fdc3-conformance-utils.ts
+++ b/toolbox/fdc3-conformance/src/test/fdc3-conformance-utils.ts
@@ -24,7 +24,7 @@ export async function closeMockAppWindow(testId: string, count: number = 1) {
 
 const broadcastCloseWindow = async (currentTest: string) => {
   const appControlChannel = await fdc3.getOrCreateChannel(constants.ControlChannel);
-  appControlChannel.broadcast({
+  await appControlChannel.broadcast({
     type: 'closeWindow',
     testId: currentTest,
   } as AppControlContext);
@@ -34,7 +34,8 @@ export const waitForContext = async (
   contextType: string,
   testId: string,
   channel: Channel,
-  count = 1
+  count = 1,
+  timeoutMs = constants.WaitTime
 ): Promise<AppControlContextListener & { listener: Listener }> => {
   let promiseResolve: (c: Context) => void;
   let promiseReject: (x: unknown) => void;
@@ -46,9 +47,9 @@ export const waitForContext = async (
 
   setTimeout(() => {
     if (count > 0) {
-      promiseReject(new Error("App didn't return close context within 1 sec"));
+      promiseReject(new Error(`App didn't return ${contextType} context within ${timeoutMs} ms`));
     }
-  }, 1000);
+  }, timeoutMs);
 
   const listener = await channel.addContextListener(contextType, ctx => {
     if (ctx['testId'] == testId) {


### PR DESCRIPTION
Mock apps opened via the destructured open() method could have their close listener registered after the test had already completed, and the cleanup step only allowed a 1 second window to receive the close confirmation. Wait for mock app initialization before proceeding, await the close broadcast, and use the existing mock-processing timeout instead of the hardcoded 1 second window.

Fixes #2114

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- 
If you've changed docs or schemas make sure you run code and documentation tasks before raising your PR.
To do so, run: 
    - Code generation and build: `npm run build`
    - Docs generation and preview `cd website; npm run start`
Once run, any modified files can be committed and added to your PR for review.
--->
<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.