### PR TITLE
Fix fdc3-context typegen to resolve AppIdentifier ref locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+* Fixed `fdc3-context`'s `typegen` script so that it resolves the `AppIdentifier` type referenced from `action.schema.json` via a local path to `fdc3-schema`'s `api.schema.json`, instead of relying on `quicktype` fetching it over the network from the (as yet unpublished) `$id` URL. Previously, after running `npm run clean`, `npm run build` would fail across the whole monorepo because the `fdc3-context` build silently produced an empty `generated/context` directory (the underlying `quicktype` failure was swallowed) and downstream packages could not resolve `@finos/fdc3-context`.
 * Fixed the basic conformance version check to use the exported FDC3 version and accept newer compatible Desktop Agents. ([#1966](https://github.com/finos/FDC3/pull/1966))
 * Reduced normal `getAgent` discovery console noise by ignoring unrelated `postMessage` traffic and reporting expected agent-not-found timeouts as warnings instead of errors. ([#1902](https://github.com/finos/FDC3/issues/1902))
 * Prevented the FDC3 for Web reference implementation from sending channel-changed events to applications that have not registered a matching listener. ([#1806](https://github.com/finos/FDC3/issues/1806))

--- a/packages/fdc3-context/generated/context/ContextTypes.ts
+++ b/packages/fdc3-context/generated/context/ContextTypes.ts
@@ -1870,8 +1870,8 @@ export interface EncryptedContextWrapperID {
  * **Note:** This context type MUST be signed to be effective. The key owner uses the
  * signature's public key URL to encrypt the symmetric key in the response, ensuring only
  * the requesting application can decrypt it. See the [Security & Identity
- * documentation](../../api/security) for details on signing context objects and encrypted
- * communications.
+ * documentation](/docs/next/api/security) for details on signing context objects and
+ * encrypted communications.
  */
 export interface SymmetricKeyRequest {
   /**
@@ -1949,8 +1949,8 @@ export interface User {
  *
  * **Note:** This context type MUST be signed to be effective. The identity provider app
  * uses the signature's public key URL to verify the requesting application's identity and
- * to encrypt the response. See the [Security & Identity documentation](../../api/security)
- * for details on signing context objects.
+ * to encrypt the response. See the [Security & Identity
+ * documentation](/docs/next/api/security) for details on signing context objects.
  */
 export interface UserRequest {
   /**

--- a/packages/fdc3-context/package.json
+++ b/packages/fdc3-context/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint generated/ --fix && npx prettier generated/ --write",
     "test": "npm run generate && tsc && vitest run",
     "test:watch": "vitest",
-    "typegen": "cd schemas && node ../s2tQuicktypeUtil.cjs context ../generated/context/ContextTypes.ts"
+    "typegen": "cd schemas && node ../s2tQuicktypeUtil.cjs ../../fdc3-schema/schemas/api/api.schema.json context ../generated/context/ContextTypes.ts"
   },
   "devDependencies": {
     "ajv": "^8.18.0",


### PR DESCRIPTION
Previously, npm run clean followed by npm run build failed across the whole monorepo. The fdc3-context typegen script did not pass fdc3-schema's api.schema.json as a local schema source, so quicktype fell back to fetching the cross-package $ref for AppIdentifier over the network from an unpublished $id URL. That fetch failure was silently swallowed by s2tQuicktypeUtil.cjs's use of exec(), leaving generated/context empty and breaking every downstream package that depends on @finos/fdc3-context.

- Pass ../../fdc3-schema/schemas/api/api.schema.json as an additional local schema source in fdc3-context's typegen script, mirroring the pattern fdc3-schema already uses in the opposite direction.
- Regenerate ContextTypes.ts, picking up the Security & Identity documentation link path fix (/docs/next/api/security) that had not been reflected in the previously committed generated file.
- Add CHANGELOG entries.

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- 
If you've changed docs or schemas make sure you run code and documentation tasks before raising your PR.
To do so, run: 
    - Code generation and build: `npm run build`
    - Docs generation and preview `cd website; npm run start`
Once run, any modified files can be committed and added to your PR for review.
--->
<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [ ] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [x] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [ ] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [ ] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
