### PR TITLE
chore(deps): separate CVE and evergreening updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,98 @@
 version: 2
 
+# ---------------------------------------------------------------------------
+# CVE resolutions vs. routine evergreening
+# ---------------------------------------------------------------------------
+# Dependabot distinguishes two kinds of update via a group's `applies-to`:
+#
+#   * security-updates — raised to resolve a known CVE/advisory. These take
+#     priority. Security updates are NEVER subject to `cooldown` (Dependabot
+#     applies no cooldown to security updates), so they are raised as soon as a
+#     fixed version exists — effectively same/next-day. They are also exempt
+#     from `open-pull-requests-limit`. Each of these is grouped under a group
+#     named "security", and that group identifier appears in the PR title and
+#     branch name (e.g. "…/security-…" / "Bump the security group"), which is
+#     how CVE PRs are differentiated from evergreening PRs. Dependabot also
+#     applies its automatic "dependencies" label plus any SemVer labels.
+#
+#   * version-updates — routine evergreening. These carry a longer `cooldown`
+#     to let newly published versions bake (supply-chain mitigation) and are
+#     grouped aggressively (by tooling domain) to reduce PR noise and merge
+#     conflicts. Their group names (cucumber, linting, vitest, types, …) mark
+#     them as routine in the PR title/branch.
+#
+# NOTES / limitations:
+#   * `labels` and `commit-message` are ecosystem-wide in dependabot.yml — they
+#     cannot differ per group — so CVE-vs-evergreen differentiation is carried
+#     by the GROUP NAME (surfaced in the title/branch), not by a bespoke label.
+#   * `cooldown` only applies to version updates, so the "1 day" target for CVE
+#     work is achieved by security updates bypassing cooldown entirely.
+#   * The "let new releases bake" supply-chain protection lives HERE (this
+#     cooldown), not in .npmrc. `min-release-age` was removed from .npmrc
+#     because it re-validates the lockfile on every install and would fail CI
+#     on same-day releases — see the note in .npmrc for details.
+#   * This relies on Dependabot security updates (+ dependency graph + alerts)
+#     being enabled for the repository.
+# ---------------------------------------------------------------------------
+
 updates:
-  # npm dependencies
+  # ---- npm dependencies (workspaces root) --------------------------------
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "daily"
-    # Use cooldown to align with min-release-age in .npmrc — skip versions
-    # published fewer than 7 days ago, giving time for malicious packages to
-    # be detected and removed before they reach this repo.
     cooldown:
+      # Applies to evergreening (version) updates only. Security updates are
+      # never delayed by cooldown.
       default-days: 7
       semver-major-days: 10
-    # Group minor and patch updates into a single PR to reduce noise.
     groups:
+      # CVE resolutions — grouped and prioritised; the "security" group name
+      # surfaces in the PR title/branch to differentiate from evergreening.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      # Evergreening — recurring cross-package dev tooling grouped together so
+      # a single PR updates them in lockstep and avoids conflicting PRs.
+      cucumber:
+        applies-to: version-updates
+        patterns:
+          - "@cucumber/*"
+          - "quickpickle"
+      linting:
+        applies-to: version-updates
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "eslint-config-prettier"
+          - "eslint-plugin-*"
+          - "globals"
+          - "prettier"
+          - "lint-staged"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      types:
+        applies-to: version-updates
+        patterns:
+          - "@types/*"
       minor-and-patch:
+        applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
 
-  # npm dependencies — website (separate lock file, not in workspaces)
+  # ---- npm dependencies — website (separate lock file, not in workspaces)
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
@@ -32,42 +101,62 @@ updates:
       default-days: 7
       semver-major-days: 10
     groups:
+      # CVE resolutions — prioritised; differentiated by the "security" group
+      # name in the PR title/branch.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
       # Docusaurus and its rendering stack must move together — they share
       # peer dependencies on react/react-dom and layout-elk, so upgrading
       # any one in isolation risks peer dep conflicts.
       docusaurus:
+        applies-to: version-updates
         patterns:
           - "@docusaurus/*"
           - "@mermaid-js/layout-elk"
           - "prism-react-renderer"
       # react and react-dom must always be the same version.
       react:
+        applies-to: version-updates
         patterns:
           - "react"
           - "react-dom"
       minor-and-patch:
+        applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
 
-  # GitHub Actions
+  # ---- GitHub Actions -----------------------------------------------------
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     cooldown:
       default-days: 7
-    # Group all actions updates into a single PR.
     groups:
+      # CVE resolutions — prioritised; differentiated by the "security" group
+      # name in the PR title/branch.
+      security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      # Evergreening — all actions in a single PR.
       actions-minor-and-patch:
+        applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
     open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
     commit-message:
       prefix: "ci(deps)"
       include: "scope"

--- a/.npmrc
+++ b/.npmrc
@@ -8,11 +8,27 @@ omit-lockfile-registry-resolved = true
 # Ensuring optional deps stay in the install graph fixes that without Linux-only devDependencies.
 include = optional
 
-# Require packages to have been published for at least 3 days before resolving them.
-# This mitigates supply-chain attacks from newly published malicious versions.
-# Dependabot cooldown (7 days) provides an additional layer of protection for PRs.
-# Requires npm >= 11.10.
-min-release-age = 3
+# NOTE: `min-release-age` (npm >= 11.10) is intentionally NOT set here.
+#
+# It refuses to resolve ANY dependency version — direct or transitive — that
+# was published more recently than the threshold, and it re-validates the
+# lockfile on every install. In CI that breaks two ways:
+#   1. A Dependabot PR that bumps to a version released the same day would fail
+#      `npm ci`, even though Dependabot was allowed to open the PR (the npm
+#      floor and Dependabot's cooldown are enforced at different moments).
+#   2. Any routine `npm ci` could start failing whenever a transitive dep
+#      publishes a new version inside the window.
+#
+# Supply-chain "let new releases bake" protection is instead handled by
+# Dependabot's `cooldown` in .github/dependabot.yml, which gates the versions
+# we actually adopt at PR-open time without breaking CI. Security (CVE) updates
+# deliberately bypass cooldown so fixes land fast. Because the lockfile is
+# committed, `npm ci` installs exactly what is pinned, so we are not silently
+# pulling brand-new transitive versions between Dependabot bumps.
+#
+# If per-install quarantine is ever required again, re-introduce it here and
+# raise (or drop) the Dependabot cooldown accordingly to avoid same-day CI
+# resolution failures.
 
 # Required for correct dependency nesting: workspace packages have conflicting
 # peer requirements, including toolchains whose ranges do not yet support TypeScript 7.


### PR DESCRIPTION
## Describe your change

Reworks Dependabot configuration so that CVE-resolving PRs are clearly separated from routine dependency evergreening, and prioritised.

**`.github/dependabot.yml`**
- Adds a `security` group (`applies-to: security-updates`, `patterns: ["*"]`) to every ecosystem (npm root, npm website, github-actions). Security updates bypass cooldown and the open-PR limit, so CVE fixes are raised as soon as a fix is disclosed. The `security` group name surfaces in the PR title/branch, which is how CVE PRs are distinguished from evergreening PRs (labels/commit-message are ecosystem-wide in `dependabot.yml` and can't differ per group).
- Scopes all existing groups to `applies-to: version-updates` and keeps the longer `cooldown` (7 days, 10 for majors) on that routine work.
- Adds tooling groups to the `/` workspace config — `cucumber`, `linting`, `vitest`, `types` — so recurring cross-package dev dependencies update in a single PR instead of many conflicting ones.

**`.npmrc`**
- Removes `min-release-age`. It re-validates the committed lockfile on every install, so it would fail `npm ci` in CI whenever a resolved version (including a Dependabot PR's own bump, or any transitive dependency) was published within the window. The "let new releases bake" supply-chain protection now lives solely in the Dependabot `cooldown`, which gates adopted versions at PR-open time without breaking CI. A note explaining the decision (and how to reintroduce it safely) is left in the file.

### Related Issue
<!-- Please link an issue here if one exists, e.g. "resolves #1234" -->

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above? — N/A, no Standard change (CI/tooling config only).
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included? — Not included; this is repo tooling config, not a published/API change. Happy to add one if preferred.
- [x] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)? — No.
- [x] **Context types**: Were new Context type schemas created or modified in this PR? — No.
- [x] **Intents**: Were new Intents created in this PR? — No.
