### PR TITLE
Update MAINTAINERS.md to remove Yannick Malins

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ This file lists the maintainers of this repository.
 | GitHub Username | Name | Organization | Email |
 |----------------|------|--------------|-------|
 | @Roaders | Giles Roadnight | Morgan Stanley | Giles.Roadnight@morganstanley.com |
-| @Yannick-Malins | Yannick | @SymphonyOSF | yannick.malins@symphony.com |
 | @bingenito | Brian Ingenito | Morgan Stanley  | Brian.Ingenito@morganstanley.com |
 | @hughtroeger | Hugh Troeger | FactSet Research Systems | htroeger@factset.com |
 | @julianna-ciq | Julianna Mealin | interop.io | julianna.mealin@interop.io |


### PR DESCRIPTION
FDC3 Identity and Security has completed - Removed Yannick Malins from the maintainers list.
