### PR TITLE
fix(example-apps): add trace ID to fallback metadata

### DIFF
--- a/toolbox/fdc3-example-apps/common/src/security-demo/fdc3.ts
+++ b/toolbox/fdc3-example-apps/common/src/security-demo/fdc3.ts
@@ -9,6 +9,7 @@ export function ensureContextMetadata(metadata?: ContextMetadata): ContextMetada
   return {
     timestamp: new Date(),
     source: { appId: 'fdc3-example-apps', instanceId: 'local' },
+    traceId: crypto.randomUUID(),
   };
 }
 


### PR DESCRIPTION
## Describe your change

Adds a generated `traceId` to the security demo's fallback `ContextMetadata`. #2198 makes `ContextMetadata.traceId` required, so the existing fallback caused the Netlify TypeScript build to fail with TS2741.

This PR is stacked on #2198 and targets `2163-appprovidable-metadata-optional`.

## Testing

- `npm run build`

## Contributor License Agreement

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

- [x] **Issue**: Addresses the build regression in #2198.
- [ ] **CHANGELOG**: Not applicable; this is a build fix for the parent PR.
- [ ] **API changes**: No.
- [ ] **Context types**: No.
- [ ] **Intents**: No.
