### PR TITLE
Validate retained context response invariants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8770,7 +8770,6 @@
     "node_modules/events": {
       "version": "3.3.0",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -12240,7 +12239,6 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-equal": {
@@ -15953,6 +15951,8 @@
       "version": "3.0.0-alpha.2",
       "license": "Apache-2.0",
       "devDependencies": {
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "message-await": "^1.1.0",
         "mkdirp": "^3.0.1",
         "quicktype": "23.0.176",
@@ -16117,7 +16117,9 @@
         "@finos/fdc3": "3.0.0-alpha.2",
         "buffer": "^6.0.3",
         "chai": "^6.2.2",
+        "events": "^3.3.0",
         "mocha": "^11.8.0",
+        "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "source-map-support": "^0.5.21",
         "stream-browserify": "^3.0.0",

--- a/packages/fdc3-agent-proxy/src/channels/DefaultChannel.ts
+++ b/packages/fdc3-agent-proxy/src/channels/DefaultChannel.ts
@@ -1,7 +1,6 @@
 import {
   ContextHandler,
   ContextWithMetadata,
-  ContextMetadata,
   DisplayMetadata,
   Listener,
   Channel,
@@ -23,7 +22,23 @@ import {
 } from '@finos/fdc3-schema/generated/api/BrowserTypes.js';
 import { RegisterableListener } from '../listeners/RegisterableListener.js';
 import { EventListener } from '../listeners/EventListener.js';
-import { throwIfUndefined } from '../util/throwIfUndefined.js';
+
+function parseCurrentContextResponse(response: GetCurrentContextResponse): ContextWithMetadata | null {
+  const { context, metadata } = response.payload;
+
+  if (context === null) {
+    if (metadata !== null) {
+      throw new Error(ChannelError.MalformedContext);
+    }
+    return null;
+  }
+
+  if (context === undefined || metadata == null) {
+    throw new Error(ChannelError.MalformedContext);
+  }
+
+  return { context, metadata };
+}
 
 export class DefaultChannel implements Channel {
   protected readonly messaging: Messaging;
@@ -85,7 +100,7 @@ export class DefaultChannel implements Channel {
       this.messageExchangeTimeout
     );
 
-    return response.payload.context ?? null;
+    return parseCurrentContextResponse(response)?.context ?? null;
   }
 
   /**
@@ -108,29 +123,7 @@ export class DefaultChannel implements Channel {
       this.messageExchangeTimeout
     );
 
-    const context = response.payload.context;
-    if (context) {
-      // Per the getCurrentContextResponse invariant, a non-null context MUST be accompanied by
-      // its complete ContextMetadata, so we use it directly and preserve the actual provenance
-      // rather than fabricating fallback values.
-      throwIfUndefined(
-        response.payload.metadata ?? undefined,
-        'Invalid response from Desktop Agent to getCurrentContext: metadata must be provided alongside a non-null context!',
-        response,
-        ChannelError.MalformedContext
-      );
-      const responseMetadata = response.payload.metadata!;
-      const metadata: ContextMetadata = {
-        source: responseMetadata.source,
-        timestamp: responseMetadata.timestamp,
-        traceId: responseMetadata.traceId,
-        signature: responseMetadata.signature,
-        custom: responseMetadata.custom,
-        antiReplay: responseMetadata.antiReplay,
-      };
-      return { context, metadata };
-    }
-    return null;
+    return parseCurrentContextResponse(response);
   }
 
   async addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener> {

--- a/packages/fdc3-agent-proxy/test/features/broadcast.feature
+++ b/packages/fdc3-agent-proxy/test/features/broadcast.feature
@@ -60,11 +60,30 @@ Feature: Broadcasting
     And I call "{channel1}" with "broadcast" with parameter "{instrumentContext}"
     And I call "{channel1}" with "getCurrentContextWithMetadata" with parameter "fdc3.instrument"
     Then "{result}" is an object with the following contents
-      | context.type    | context.name | metadata.source.appId | metadata.source.instanceId | metadata.traceId | metadata.signature.signature      | metadata.signature.protected      | metadata.custom.key |
-      | fdc3.instrument | Apple        | test-app              | test-instance              | test-trace-id    | test-signature (signature part) | test-signature (protected part) | value               |
+      | context.type    | context.name | metadata.source.appId | metadata.source.instanceId | metadata.traceId | metadata.signature.signature      | metadata.signature.protected      | metadata.custom.key | metadata.antiReplay.iat | metadata.antiReplay.exp | metadata.antiReplay.jti |
+      | fdc3.instrument | Apple        | test-app              | test-instance              | test-trace-id    | test-signature (signature part)   | test-signature (protected part)   | value               | {1234}                  | {2345}                  | test-jti                |
 
   Scenario: getCurrentContextWithMetadata returns null for empty channel
     When I call "{api}" with "getOrCreateChannel" with parameter "channel-name"
     And I refer to "{result}" as "channel1"
     And I call "{channel1}" with "getCurrentContextWithMetadata" with parameter "fdc3.instrument"
     Then "{result}" is null
+
+  Scenario: Current context APIs reject malformed context and metadata pairs
+    When I call "{api}" with "getOrCreateChannel" with parameter "channel-name"
+    And I refer to "{result}" as "channel1"
+    Given the next getCurrentContext response has payload "null-without-metadata"
+    When I call "{channel1}" with "getCurrentContext"
+    Then "{result}" is an error with message "MalformedContext"
+    Given the next getCurrentContext response has payload "null-with-metadata"
+    When I call "{channel1}" with "getCurrentContextWithMetadata"
+    Then "{result}" is an error with message "MalformedContext"
+    Given the next getCurrentContext response has payload "context-with-null-metadata"
+    When I call "{channel1}" with "getCurrentContextWithMetadata"
+    Then "{result}" is an error with message "MalformedContext"
+    Given the next getCurrentContext response has payload "context-without-metadata"
+    When I call "{channel1}" with "getCurrentContextWithMetadata"
+    Then "{result}" is an error with message "MalformedContext"
+    Given the next getCurrentContext response has payload "missing-context"
+    When I call "{channel1}" with "getCurrentContextWithMetadata"
+    Then "{result}" is an error with message "MalformedContext"

--- a/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
+++ b/packages/fdc3-agent-proxy/test/step-definitions/channels.steps.ts
@@ -9,10 +9,13 @@ import {
   BroadcastEvent,
   ChannelChangedEvent,
   ContextClearedEvent,
+  GetCurrentContextRequest,
+  GetCurrentContextResponse,
   PrivateChannelOnAddContextListenerEvent,
   PrivateChannelOnDisconnectEvent,
   PrivateChannelOnUnsubscribeEvent,
 } from '@finos/fdc3-schema/dist/generated/api/BrowserTypes.js';
+import { createResponseMeta } from '../support/responses/support.js';
 
 const contextMap: Record<string, Context> = {
   'fdc3.instrument': {
@@ -38,6 +41,40 @@ const contextMap: Record<string, Context> = {
     type: 'fdc3.cancel-me',
   },
 };
+
+Given('the next getCurrentContext response has payload {string}', (world: CustomWorld, shape: string) => {
+  const context = contextMap['fdc3.instrument'];
+  const metadata: ContextMetadata = {
+    source: { appId: 'test-app', instanceId: 'test-instance' },
+    timestamp: new Date(),
+    traceId: 'test-trace-id',
+  };
+  const payloads: Record<string, object> = {
+    'null-without-metadata': { context: null },
+    'null-with-metadata': { context: null, metadata },
+    'context-with-null-metadata': { context, metadata: null },
+    'context-without-metadata': { context },
+    'missing-context': { metadata },
+  };
+  const payload = payloads[shape];
+  if (!payload) {
+    throw new Error(`Unknown getCurrentContext response shape: ${shape}`);
+  }
+
+  world.messaging!.automaticResponses.unshift({
+    filter: type => type === 'getCurrentContextRequest',
+    action: (input, messaging) => {
+      const request = input as GetCurrentContextRequest;
+      const response = {
+        meta: createResponseMeta(request.meta),
+        payload,
+        type: 'getCurrentContextResponse',
+      } as GetCurrentContextResponse;
+      setTimeout(() => messaging.receive(response), 0);
+      return Promise.resolve();
+    },
+  });
+});
 
 Given('{string} is a {string} context', (world: CustomWorld, field: string, type: string) => {
   world.props[field] = contextMap[type];

--- a/packages/fdc3-agent-proxy/test/support/responses/ChannelState.ts
+++ b/packages/fdc3-agent-proxy/test/support/responses/ChannelState.ts
@@ -138,6 +138,11 @@ export class ChannelState implements AutomaticResponse {
                 signature: 'test-signature (signature part)',
               },
               custom: { key: 'value' },
+              antiReplay: {
+                iat: 1234,
+                exp: 2345,
+                jti: 'test-jti',
+              },
             }
           : null,
       },

--- a/packages/fdc3-schema/package.json
+++ b/packages/fdc3-schema/package.json
@@ -23,11 +23,13 @@
     "generate": "npm run mkdirs && npm run typegen-browser && npm run typegen-bridging && npm run generate-type-predicates && npm run lint",
     "build": "npm run generate && tsc",
     "lint": "eslint generated/ --fix && npx prettier generated/ --write",
-    "test": "npm run generate && tsc",
+    "test": "npm run generate && tsc && vitest run",
     "typegen-browser": "cd schemas && node ../s2tQuicktypeUtil.cjs api/api.schema.json api/common.schema.json ../../fdc3-context/schemas/context/context.schema.json api ../generated/api/BrowserTypes.ts",
     "typegen-bridging": "cd schemas && node ../s2tQuicktypeUtil.cjs api/api.schema.json api/common.schema.json api/broadcastRequest.schema.json api/findInstancesRequest.schema.json api/findInstancesResponse.schema.json api/findIntentRequest.schema.json api/findIntentResponse.schema.json api/findIntentsByContextRequest.schema.json api/findIntentsByContextResponse.schema.json api/getAppMetadataRequest.schema.json api/getAppMetadataResponse.schema.json api/openRequest.schema.json api/openResponse.schema.json api/raiseIntentRequest.schema.json api/raiseIntentResponse.schema.json api/raiseIntentResultResponse.schema.json ../../fdc3-context/schemas/context/context.schema.json bridging ../generated/bridging/BridgingTypes.ts"
   },
   "devDependencies": {
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "message-await": "^1.1.0",
     "mkdirp": "^3.0.1",
     "quicktype": "23.0.176",

--- a/packages/fdc3-schema/test/getCurrentContextResponse.schema.test.ts
+++ b/packages/fdc3-schema/test/getCurrentContextResponse.schema.test.ts
@@ -1,0 +1,50 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright FINOS FDC3 contributors - see NOTICE file
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { describe, expect, test } from 'vitest';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function addSchemasFrom(ajv: Ajv, directory: string): void {
+  for (const filename of fs.readdirSync(directory).filter(file => file.endsWith('.schema.json'))) {
+    const schema = JSON.parse(fs.readFileSync(path.join(directory, filename), 'utf8'));
+    ajv.addSchema(schema, schema.$id ?? filename);
+  }
+}
+
+describe('getCurrentContextResponse success payload', () => {
+  const ajv = new Ajv({ strict: false, allErrors: true });
+  addFormats(ajv);
+  addSchemasFrom(ajv, path.resolve(dirname, '../schemas/api'));
+  addSchemasFrom(ajv, path.resolve(dirname, '../../fdc3-context/schemas/context'));
+
+  const validate = ajv.getSchema(
+    'https://fdc3.finos.org/schemas/next/api/getCurrentContextResponse.schema.json#/$defs/GetCurrentContextSuccessResponsePayload'
+  );
+  const context = { type: 'fdc3.instrument', name: 'Apple', id: { ticker: 'AAPL' } };
+  const metadata = {
+    source: { appId: 'test-app', instanceId: 'test-instance' },
+    timestamp: new Date().toISOString(),
+    traceId: 'test-trace-id',
+  };
+
+  test.each([
+    ['context with complete metadata', { context, metadata }, true],
+    ['null context with null metadata', { context: null, metadata: null }, true],
+    ['context with null metadata', { context, metadata: null }, false],
+    ['context with omitted metadata', { context }, false],
+    ['null context with object metadata', { context: null, metadata }, false],
+    ['null context with omitted metadata', { context: null }, false],
+    ['omitted context', { metadata }, false],
+  ])('%s is %s', (_name, payload, expected) => {
+    expect(validate, 'schema validator should be registered').toBeDefined();
+    expect(validate!(payload), JSON.stringify(validate!.errors)).toBe(expected);
+  });
+});

--- a/toolbox/fdc3-conformance/.depcheckrc.yml
+++ b/toolbox/fdc3-conformance/.depcheckrc.yml
@@ -9,6 +9,10 @@ ignores:
   - stream-browserify
   # Injected as a browser polyfill by vite.config.ts.
   - util
+  # Injected as a browser polyfill by vite.config.ts (node:events alias).
+  - events
+  # Injected as a browser polyfill by vite.config.ts (node:path alias).
+  - path-browserify
   # Invoked by the `serve` package script.
   - http-server
   # Invoked by the `copy` package script.


### PR DESCRIPTION
Addresses the review feedback on #2197 and hardens the retained-context response contract.

- Enforces the context/metadata coupling in the proxy implementation.
- Adds schema and proxy regression coverage for valid and invalid response shapes.
- Reuses the same depcheck alias exclusions as the #2193 follow-up to reduce future merge conflicts.

This PR is intentionally stacked on #2197.