### PR TITLE
Test omitted metadata in proxy requests

### DIFF
--- a/packages/fdc3-agent-proxy/test/features/open.feature
+++ b/packages/fdc3-agent-proxy/test/features/open.feature
@@ -13,8 +13,8 @@ Feature: Desktop Agent Information
       | appId    | instanceId |
       | chipShop | abc123     |
     And messaging will have posts
-      | payload.app.appId | payload.context.type | payload.context.id.ticker | matches_type |
-      | chipShop          | fdc3.instrument      | AAPL                      | openRequest  |
+      | payload.app.appId | payload.context.type | payload.context.id.ticker | payload.metadata | matches_type |
+      | chipShop          | fdc3.instrument      | AAPL                      | {undefined}      | openRequest  |
 
   Scenario: Opening a non-existent App
     When I call "{api}" with "open" with parameters "{nonExistent}" and "{instrumentContext}"

--- a/packages/fdc3-agent-proxy/test/features/raise-intents.feature
+++ b/packages/fdc3-agent-proxy/test/features/raise-intents.feature
@@ -80,9 +80,9 @@ Feature: Basic Intents Support
       | source.appId | source.instanceId |
       | chipShop     | c1                |
     And messaging will have posts
-      | payload.context.type | payload.context.id.ticker | payload.app.instanceId | matches_type                 |
-      | fdc3.instrument      | AAPL                      | {null}                 | raiseIntentForContextRequest |
-      | fdc3.instrument      | AAPL                      | c1                     | raiseIntentRequest           |
+      | payload.context.type | payload.context.id.ticker | payload.app.instanceId | payload.metadata | matches_type                 |
+      | fdc3.instrument      | AAPL                      | {null}                 | {undefined}      | raiseIntentForContextRequest |
+      | fdc3.instrument      | AAPL                      | c1                     | {undefined}      | raiseIntentRequest           |
 
   Scenario: Raising Intent By Context exactly right, so the resolver isn't required
     When I call "{api}" with "raiseIntentForContext" with parameters "{countryContext}" and "{t1}"


### PR DESCRIPTION
Adds regression coverage ensuring open and raise-intent proxy requests omit optional metadata when none is supplied.

This PR is intentionally stacked on #2198. The separate Netlify fallback-metadata fix was merged as #2202.